### PR TITLE
Add uuid to ast dir generation in context retrieval to prevent race condition

### DIFF
--- a/data_prep/project_context/context_retriever.py
+++ b/data_prep/project_context/context_retriever.py
@@ -1,11 +1,11 @@
 import json
 import os
 import re
+import shutil
 import subprocess
+import uuid
 from collections import defaultdict
 from typing import List, Tuple
-import uuid
-import shutil
 
 
 class ContextRetriever:
@@ -264,7 +264,7 @@ class ContextRetriever:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-  
+
   def cleanup_asts(self):
     """Removes ASTs for the given project."""
     shutil.rmtree(self._ast_path)

--- a/data_prep/project_context/context_retriever.py
+++ b/data_prep/project_context/context_retriever.py
@@ -5,6 +5,7 @@ import subprocess
 from collections import defaultdict
 from typing import List, Tuple
 import uuid
+import shutil
 
 
 class ContextRetriever:
@@ -266,10 +267,7 @@ class ContextRetriever:
   
   def cleanup_asts(self):
     """Removes ASTs for the given project."""
-    for ast_file in os.listdir(self._ast_path):
-      os.remove(f'{self._ast_path}/{ast_file}')
-  
-    os.rmdir(self._ast_path)
+      shutil.rmtree(self._ast_path)
 
   def generate_lookups(self):
     """Goes through all AST files downloaded.

--- a/data_prep/project_context/context_retriever.py
+++ b/data_prep/project_context/context_retriever.py
@@ -267,7 +267,7 @@ class ContextRetriever:
   
   def cleanup_asts(self):
     """Removes ASTs for the given project."""
-      shutil.rmtree(self._ast_path)
+    shutil.rmtree(self._ast_path)
 
   def generate_lookups(self):
     """Goes through all AST files downloaded.

--- a/data_prep/project_context/context_retriever.py
+++ b/data_prep/project_context/context_retriever.py
@@ -27,10 +27,10 @@ class ContextRetriever:
     self._function_signature = function_signature
     self._download_from_path = f'{self.AST_BASE_PATH}/{self._project_name}/*'
     self._uuid = uuid.uuid4()
-    self._ast_path = f'{self.DOWNLOAD_TO_PATH}/{self._project_name}{self._uuid}'
+    self._ast_path = f'{self.DOWNLOAD_TO_PATH}/{self._project_name}-{self._uuid}'
 
   def _get_function_name(self, target_function_signature: str) -> str:
-    """Retrieve the function name from the target function signature."""
+    """Retrieves the function name from the target function signature."""
     # Grabs the function name by getting anything before '(' and then remove the type by grabbing any character after space.
     target_function = target_function_signature.split('(')[0].split(' ')[-1]
     # Removes possible pointer.

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -242,6 +242,7 @@ def run(benchmark: Benchmark,
       print(context_header)
       context_types = '\n'.join(retriever.get_type_info())
       context_info = (context_header, context_types)
+      retriever.cleanup_asts()
 
     model.prompt_path = model.prepare_generate_prompt(
         work_dirs.prompt,


### PR DESCRIPTION
Add uuid to AST directory generation to prevent race condition when multiple experiments are run with the same project, causing a potential race when one experiment is downloading and copying the ast files to the project ast directory and when the other experiment is iterating over the files within that ast directory.

Fixes #20 