### PR TITLE
Add missing benchmarks

### DIFF
--- a/benchmark-sets/all/brpc.yaml
+++ b/benchmark-sets/all/brpc.yaml
@@ -1,0 +1,14 @@
+Retrieving human-written fuzz targets of brpc from local Docker build.
+functions:
+- int brpc::policy::ConsulNamingService::RunNamingService(brpc::policy::ConsulNamingService
+  * , char * , brpc::ProgressiveReader * )
+- char * brpc::GlobalUpdate(char * )
+- int brpc::policy::ConsulNamingService::GetServers(brpc::policy::ConsulNamingService
+  * , char * , std::vector * )
+- int brpc::policy::DiscoveryClient::Register(brpc::policy::DiscoveryClient * , struct
+  brpc::policy::DiscoveryRegisterParam * )
+- char * brpc::policy::DiscoveryClient::PeriodicRenew(char * )
+project: brpc
+target_name: fuzz_butil
+target_path: /src/brpc/test/fuzzing/fuzz_butil.cpp
+

--- a/benchmark-sets/all/expat.yaml
+++ b/benchmark-sets/all/expat.yaml
@@ -1,0 +1,13 @@
+Retrieving human-written fuzz targets of expat from local Docker build.
+functions:
+- struct encoding * XmlInitUnknownEncodingNS(char * mem, int * table, func_type *
+  convert, char * userData)
+- struct encoding * XmlInitUnknownEncoding(char * mem, int * table, func_type * convert,
+  char * userData)
+- int sip24_valid()
+- int XML_SetBase(struct XML_ParserStruct * parser, char * p)
+- int initScanContentNS(struct encoding * enc, char * ptr, char * end, char ** nextTokPtr)
+project: expat
+target_name: xml_parsebuffer_fuzzer_UTF-16LE
+target_path: /src/expat/expat/fuzz/xml_parsebuffer_fuzzer.c
+

--- a/benchmark-sets/all/libavif.yaml
+++ b/benchmark-sets/all/libavif.yaml
@@ -1,0 +1,14 @@
+Retrieving human-written fuzz targets of libavif from local Docker build.
+functions:
+- int aom_decode_frame_from_obus(struct AV1Decoder * , char * , char * , char ** )
+- int read_and_decode_one_tile_list(struct AV1Decoder * , struct aom_read_bit_buffer
+  * , char * , char * , char ** , int * )
+- int read_one_tile_group_obu(struct AV1Decoder * , struct aom_read_bit_buffer * ,
+  int , char * , char * , char ** , int * , int )
+- int avifDecoderReadFile(struct avifDecoder * , struct avifImage * , char * )
+- int avifDecoderReadMemory(struct avifDecoder * , struct avifImage * , char * , size_t
+  )
+project: libavif
+target_name: repro_fuzz
+target_path: /src/libavif/tests/oss-fuzz/repro_fuzz.cc
+

--- a/benchmark-sets/all/libpng.yaml
+++ b/benchmark-sets/all/libpng.yaml
@@ -1,0 +1,14 @@
+Retrieving human-written fuzz targets of libpng from local Docker build.
+functions:
+- void OSS_FUZZ_png_read_png(struct png_struct_def * png_ptr, struct png_info_def
+  * info_ptr, int transforms, char * params)
+- int OSS_FUZZ_png_image_finish_read(struct png_image * image, struct png_color_struct
+  * background, char * buffer, int row_stride, char * colormap)
+- int png_image_read_direct(char * argument)
+- int OSS_FUZZ_png_image_begin_read_from_memory(struct png_image * image, char * memory,
+  size_t size)
+- int png_image_read_colormapped(char * argument)
+project: libpng
+target_name: libpng_read_fuzzer
+target_path: /src/libpng/contrib/oss-fuzz/libpng_read_fuzzer.cc
+

--- a/benchmark-sets/all/libyal.yaml
+++ b/benchmark-sets/all/libyal.yaml
@@ -1,0 +1,16 @@
+Retrieving human-written fuzz targets of libyal from local Docker build.
+functions:
+- int libewf_handle_open(size_t * handle, char ** filenames, int number_of_filenames,
+  int access_flags, size_t ** error)
+- int libevtx_file_open(size_t * file, char * filename, int access_flags, size_t **
+  error)
+- int libscca_file_open(size_t * file, char * filename, int access_flags, size_t **
+  error)
+- int libesedb_index_get_record(size_t * index, int record_entry, size_t ** record,
+  size_t ** error)
+- int libevtx_record_get_data(size_t * record, char * data, size_t data_size, size_t
+  ** error)
+project: libyal
+target_name: libmdmp_file_fuzzer
+target_path: /src/libmdmp/ossfuzz/file_fuzzer.cc
+

--- a/benchmark-sets/all/lua.yaml
+++ b/benchmark-sets/all/lua.yaml
@@ -1,0 +1,7 @@
+Retrieving human-written fuzz targets of lua from local Docker build.
+functions:
+- void _GLOBAL__sub_I_serializer.cc()
+project: lua
+target_name: fuzz_lua
+target_path: /src/fuzz_lua.c
+

--- a/benchmark-sets/all/lzo.yaml
+++ b/benchmark-sets/all/lzo.yaml
@@ -1,0 +1,14 @@
+Retrieving human-written fuzz targets of lzo from local Docker build.
+functions:
+- int lzo1z_999_compress_dict(char * in, size_t in_len, char * out, size_t * out_len,
+  char * wrkmem, char * dict, size_t dict_len)
+- int lzo1x_999_compress_dict(char * in, size_t in_len, char * out, size_t * out_len,
+  char * wrkmem, char * dict, size_t dict_len)
+- int lzo1y_999_compress_dict(char * in, size_t in_len, char * out, size_t * out_len,
+  char * wrkmem, char * dict, size_t dict_len)
+- void swd_insertdict(struct lzo2a_999_swd_t * s, size_t node, size_t len)
+- size_t lzo1_info(int * rbits, int * clevel)
+project: lzo
+target_name: all_lzo_compress
+target_path: /src/all_lzo_compress.cc
+

--- a/benchmark-sets/all/nestegg.yaml
+++ b/benchmark-sets/all/nestegg.yaml
@@ -1,0 +1,12 @@
+Retrieving human-written fuzz targets of nestegg from local Docker build.
+functions:
+- int nestegg_track_seek(struct nestegg * ctx, int track, size_t tstamp)
+- int nestegg_get_cue_point(struct nestegg * ctx, int cluster_num, size_t max_offset,
+  size_t * start_pos, size_t * end_pos, size_t * tstamp)
+- int nestegg_sniff(char * buffer, size_t length)
+- int ne_init_cue_points(struct nestegg * ctx, size_t max_offset)
+- int ne_match_webm(struct nestegg_io * io, size_t max_offset)
+project: nestegg
+target_name: fuzz
+target_path: /src/nestegg/test/fuzz.cc
+

--- a/benchmark-sets/all/nokogiri.yaml
+++ b/benchmark-sets/all/nokogiri.yaml
@@ -1,0 +1,14 @@
+Retrieving human-written fuzz targets of nokogiri from local Docker build.
+functions:
+- struct GumboInternalOutput * gumbo_parse(char * buffer)
+- void gumbo_print_caret_diagnostic(struct GumboInternalError * error, char * source_text,
+  size_t source_length)
+- size_t gumbo_caret_diagnostic_to_string(struct GumboInternalError * error, char
+  * source_text, size_t source_length, char ** output)
+- void caret_diagnostic_to_string(struct GumboInternalError * error, char * source_text,
+  size_t source_length, struct GumboStringBuffer * output)
+- char * gumbo_error_code(struct GumboInternalError * error)
+project: nokogiri
+target_name: parse_fuzzer
+target_path: /src/nokogiri/gumbo-parser/fuzzer/parse_fuzzer.cc
+

--- a/benchmark-sets/all/piex.yaml
+++ b/benchmark-sets/all/piex.yaml
@@ -1,0 +1,11 @@
+Retrieving human-written fuzz targets of piex from local Docker build.
+functions:
+- bool piex::GetDngInformation(std::exception * , int * , int * , std::vector * )
+- bool piex::(std::map * , std::exception * , int * , int * , std::vector * )
+- bool piex::GetOrientation(std::exception * , int * )
+- bool piex::(std::exception * , int * )
+- bool piex::GetExifOrientation(std::exception * , int , int * )
+project: piex
+target_name: fuzzer-tiff_parser
+target_path: /src/piex/fuzzers/tiff_parser.cpp
+

--- a/benchmark-sets/all/relic.yaml
+++ b/benchmark-sets/all/relic.yaml
@@ -1,0 +1,16 @@
+Retrieving human-written fuzz targets of relic from local Docker build.
+functions:
+- size_t LLVMFuzzerCustomMutator(char * , size_t , size_t , int )
+- void cryptofuzz::module::Botan::OpECDSA_Sign(std::optional * , cryptofuzz::module::relic
+  * , cryptofuzz::operation::ECDSA_Sign * )
+- void cryptofuzz::module::Botan::OpECGDSA_Sign(std::optional * , cryptofuzz::module::relic
+  * , cryptofuzz::operation::ECDSA_Sign * )
+- void std::__1::optional<cryptofuzz::component::ECDSA_Signature> cryptofuzz::module::Botan_detail::ECxDSA_Sign<Botan::ECGDSA_PrivateKey,
+  cryptofuzz::operation::ECGDSA_Sign, false>(std::optional * , cryptofuzz::operation::ECDSA_Sign
+  * )
+- void cryptofuzz::module::Botan::OpECC_GenerateKeyPair(std::optional * , cryptofuzz::module::relic
+  * , cryptofuzz::operation::Misc * )
+project: relic
+target_name: cryptofuzz-relic
+target_path: /src/cryptofuzz/entry.cpp
+

--- a/benchmark-sets/all/zydis.yaml
+++ b/benchmark-sets/all/zydis.yaml
@@ -1,0 +1,13 @@
+Retrieving human-written fuzz targets of zydis from local Docker build.
+functions:
+- int ZydisCalcAbsoluteAddressEx(struct ZydisDecodedInstruction_ * , struct ZydisDecodedOperand_
+  * , size_t , struct ZydisRegisterContext_ * , size_t * )
+- int ZydisFormatterBufferGetString(struct ZydisFormatterBuffer_ * , struct ZyanString_
+  ** )
+- int ZydisFormatterSetHook(struct ZydisFormatter_ * , int , char ** )
+- int ZydisEncoderNopFill(char * , size_t )
+- size_t ZydisStdinRead(char * ctx, char * buf, size_t max_len)
+project: zydis
+target_name: ZydisFuzzReEncoding
+target_path: /src/zydis/tools/ZydisFuzzShared.c
+


### PR DESCRIPTION
@thuanpv noticed that we did not have any benchmark from `libpng`.
So I re-generated the benchmarks of all projects missing in `benchmark-sets/all/`, and found these new ones.