### PR TITLE
Fix Github action to push to gcloud

### DIFF
--- a/.github/workflows/push-to-gcloud.yml
+++ b/.github/workflows/push-to-gcloud.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag gcr.io/oss-fuzz-base/oss-fuzz-gen:daily
+      run: docker build . --file Dockerfile --tag us-central1-docker.pkg.dev/oss-fuzz-base/testing/oss-fuzz-gen:daily
     - name: Authenticate to gcloud
       uses: google-github-actions/auth@v2
       with:


### PR DESCRIPTION
The docker build tag wasn't updated to the new artifact registry URL