### PR TITLE
Use sub-directories to categorize reports

### DIFF
--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -29,6 +29,7 @@
 BENCHMARK_SET=$1
 FREQUENCY_LABEL=$2
 RUN_TIMEOUT=$3
+SUB_DIR=$4
 # Uses python3 by default and /venv/bin/python3 for Docker containers.
 PYTHON="$( [[ -x "/venv/bin/python3" ]] && echo "/venv/bin/python3" || echo "python3" )"
 export PYTHON
@@ -59,6 +60,13 @@ then
   echo "Run timeout was not specified as the third argument. Defaulting to ${RUN_TIMEOUT:?}."
 fi
 
+# The subdirectory for the generated report in GCS.
+if [[ $SUB_DIR = '' ]]
+then
+  SUB_DIR='others'
+  echo "Sub-directory was not specified as the fourth argument. Defaulting to ${SUB_DIR:?}. Please consider using sub-directory to classify your experiment."
+fi
+
 DATE=$(date '+%Y-%m-%d')
 LOCAL_RESULTS_DIR='results'
 # Experiment name is used to label the Cloud Builds and as part of the
@@ -66,10 +74,9 @@ LOCAL_RESULTS_DIR='results'
 #
 # Example directory: 2023-12-02-daily-comparison
 EXPERIMENT_NAME="${DATE:?}-${FREQUENCY_LABEL:?}-${BENCHMARK_SET:?}"
-# The subdirectory for the generated report in GCS. Use the same name as
-# experiment.
+# Report directory uses the same name as experiment.
 # See upload_report.sh on how this is used.
-GCS_REPORT_DIR=${EXPERIMENT_NAME:?}
+GCS_REPORT_DIR="${SUB_DIR:?}/${EXPERIMENT_NAME:?}"
 
 # Generate a report and upload it to GCS
 bash report/upload_report.sh "${LOCAL_RESULTS_DIR:?}" "${GCS_REPORT_DIR:?}" &

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -63,7 +63,7 @@ fi
 # The subdirectory for the generated report in GCS.
 if [[ $SUB_DIR = '' ]]
 then
-  SUB_DIR='others'
+  SUB_DIR='default'
   echo "Sub-directory was not specified as the fourth argument. Defaulting to ${SUB_DIR:?}. Please consider using sub-directory to classify your experiment."
 fi
 


### PR DESCRIPTION
As we start to have many reports (from daily, one-off, pr), I wanted to use sub-directory as an easy way to visually categorize reports to keep the directory more organized.

@erfanio also proposed using tags in the report, which will provide more dimensionality in classification later.
