### PR TITLE
Enable linting and building images for all PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,11 +15,7 @@
 name: lint
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/push-pr-to-gcloud.yml
+++ b/.github/workflows/push-pr-to-gcloud.yml
@@ -2,8 +2,6 @@ name: Build Docker image for PR
 
 on:
   pull_request:
-    branches:
-    - main
 
 env:
   PR_ID: ${{ github.event.number }}


### PR DESCRIPTION
The current setting does not lint PRs like https://github.com/google/oss-fuzz-gen/pull/82 and https://github.com/google/oss-fuzz-gen/pull/81, nor build images for them for testing purposes.
This PR fixes that.