### PR TITLE
two minor changes for running all experiments

### DIFF
--- a/benchmark-sets/all/brpc.yaml
+++ b/benchmark-sets/all/brpc.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of brpc from local Docker build.
 functions:
 - int brpc::policy::ConsulNamingService::RunNamingService(brpc::policy::ConsulNamingService
   * , char * , brpc::ProgressiveReader * )
@@ -10,5 +9,8 @@ functions:
 - char * brpc::policy::DiscoveryClient::PeriodicRenew(char * )
 project: brpc
 target_name: fuzz_butil
+target_path: /src/brpc/test/fuzzing/fuzz_butil.cpp
+
+t_name: fuzz_butil
 target_path: /src/brpc/test/fuzzing/fuzz_butil.cpp
 

--- a/benchmark-sets/all/expat.yaml
+++ b/benchmark-sets/all/expat.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of expat from local Docker build.
 functions:
 - struct encoding * XmlInitUnknownEncodingNS(char * mem, int * table, func_type *
   convert, char * userData)
@@ -9,5 +8,8 @@ functions:
 - int initScanContentNS(struct encoding * enc, char * ptr, char * end, char ** nextTokPtr)
 project: expat
 target_name: xml_parsebuffer_fuzzer_UTF-16LE
+target_path: /src/expat/expat/fuzz/xml_parsebuffer_fuzzer.c
+
+r_UTF-16LE
 target_path: /src/expat/expat/fuzz/xml_parsebuffer_fuzzer.c
 

--- a/benchmark-sets/all/libavif.yaml
+++ b/benchmark-sets/all/libavif.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of libavif from local Docker build.
 functions:
 - int aom_decode_frame_from_obus(struct AV1Decoder * , char * , char * , char ** )
 - int read_and_decode_one_tile_list(struct AV1Decoder * , struct aom_read_bit_buffer
@@ -10,5 +9,8 @@ functions:
   )
 project: libavif
 target_name: repro_fuzz
+target_path: /src/libavif/tests/oss-fuzz/repro_fuzz.cc
+
+_name: repro_fuzz
 target_path: /src/libavif/tests/oss-fuzz/repro_fuzz.cc
 

--- a/benchmark-sets/all/libpng.yaml
+++ b/benchmark-sets/all/libpng.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of libpng from local Docker build.
 functions:
 - void OSS_FUZZ_png_read_png(struct png_struct_def * png_ptr, struct png_info_def
   * info_ptr, int transforms, char * params)
@@ -10,5 +9,8 @@ functions:
 - int png_image_read_colormapped(char * argument)
 project: libpng
 target_name: libpng_read_fuzzer
+target_path: /src/libpng/contrib/oss-fuzz/libpng_read_fuzzer.cc
+
+_fuzzer
 target_path: /src/libpng/contrib/oss-fuzz/libpng_read_fuzzer.cc
 

--- a/benchmark-sets/all/libyal.yaml
+++ b/benchmark-sets/all/libyal.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of libyal from local Docker build.
 functions:
 - int libewf_handle_open(size_t * handle, char ** filenames, int number_of_filenames,
   int access_flags, size_t ** error)
@@ -12,5 +11,8 @@ functions:
   ** error)
 project: libyal
 target_name: libmdmp_file_fuzzer
+target_path: /src/libmdmp/ossfuzz/file_fuzzer.cc
+
+e: libmdmp_file_fuzzer
 target_path: /src/libmdmp/ossfuzz/file_fuzzer.cc
 

--- a/benchmark-sets/all/lua.yaml
+++ b/benchmark-sets/all/lua.yaml
@@ -1,6 +1,10 @@
-Retrieving human-written fuzz targets of lua from local Docker build.
 functions:
 - void _GLOBAL__sub_I_serializer.cc()
+project: lua
+target_name: fuzz_lua
+target_path: /src/fuzz_lua.c
+
+cc()
 project: lua
 target_name: fuzz_lua
 target_path: /src/fuzz_lua.c

--- a/benchmark-sets/all/lzo.yaml
+++ b/benchmark-sets/all/lzo.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of lzo from local Docker build.
 functions:
 - int lzo1z_999_compress_dict(char * in, size_t in_len, char * out, size_t * out_len,
   char * wrkmem, char * dict, size_t dict_len)
@@ -9,6 +8,10 @@ functions:
 - void swd_insertdict(struct lzo2a_999_swd_t * s, size_t node, size_t len)
 - size_t lzo1_info(int * rbits, int * clevel)
 project: lzo
+target_name: all_lzo_compress
+target_path: /src/all_lzo_compress.cc
+
+
 target_name: all_lzo_compress
 target_path: /src/all_lzo_compress.cc
 

--- a/benchmark-sets/all/nestegg.yaml
+++ b/benchmark-sets/all/nestegg.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of nestegg from local Docker build.
 functions:
 - int nestegg_track_seek(struct nestegg * ctx, int track, size_t tstamp)
 - int nestegg_get_cue_point(struct nestegg * ctx, int cluster_num, size_t max_offset,
@@ -7,6 +6,10 @@ functions:
 - int ne_init_cue_points(struct nestegg * ctx, size_t max_offset)
 - int ne_match_webm(struct nestegg_io * io, size_t max_offset)
 project: nestegg
+target_name: fuzz
+target_path: /src/nestegg/test/fuzz.cc
+
+roject: nestegg
 target_name: fuzz
 target_path: /src/nestegg/test/fuzz.cc
 

--- a/benchmark-sets/all/nokogiri.yaml
+++ b/benchmark-sets/all/nokogiri.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of nokogiri from local Docker build.
 functions:
 - struct GumboInternalOutput * gumbo_parse(char * buffer)
 - void gumbo_print_caret_diagnostic(struct GumboInternalError * error, char * source_text,
@@ -10,5 +9,8 @@ functions:
 - char * gumbo_error_code(struct GumboInternalError * error)
 project: nokogiri
 target_name: parse_fuzzer
+target_path: /src/nokogiri/gumbo-parser/fuzzer/parse_fuzzer.cc
+
+rse_fuzzer
 target_path: /src/nokogiri/gumbo-parser/fuzzer/parse_fuzzer.cc
 

--- a/benchmark-sets/all/piex.yaml
+++ b/benchmark-sets/all/piex.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of piex from local Docker build.
 functions:
 - bool piex::GetDngInformation(std::exception * , int * , int * , std::vector * )
 - bool piex::(std::map * , std::exception * , int * , int * , std::vector * )
@@ -7,5 +6,8 @@ functions:
 - bool piex::GetExifOrientation(std::exception * , int , int * )
 project: piex
 target_name: fuzzer-tiff_parser
+target_path: /src/piex/fuzzers/tiff_parser.cpp
+
+me: fuzzer-tiff_parser
 target_path: /src/piex/fuzzers/tiff_parser.cpp
 

--- a/benchmark-sets/all/relic.yaml
+++ b/benchmark-sets/all/relic.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of relic from local Docker build.
 functions:
 - size_t LLVMFuzzerCustomMutator(char * , size_t , size_t , int )
 - void cryptofuzz::module::Botan::OpECDSA_Sign(std::optional * , cryptofuzz::module::relic
@@ -11,6 +10,10 @@ functions:
 - void cryptofuzz::module::Botan::OpECC_GenerateKeyPair(std::optional * , cryptofuzz::module::relic
   * , cryptofuzz::operation::Misc * )
 project: relic
+target_name: cryptofuzz-relic
+target_path: /src/cryptofuzz/entry.cpp
+
+c
 target_name: cryptofuzz-relic
 target_path: /src/cryptofuzz/entry.cpp
 

--- a/benchmark-sets/all/zydis.yaml
+++ b/benchmark-sets/all/zydis.yaml
@@ -1,4 +1,3 @@
-Retrieving human-written fuzz targets of zydis from local Docker build.
 functions:
 - int ZydisCalcAbsoluteAddressEx(struct ZydisDecodedInstruction_ * , struct ZydisDecodedOperand_
   * , size_t , struct ZydisRegisterContext_ * , size_t * )
@@ -9,5 +8,8 @@ functions:
 - size_t ZydisStdinRead(char * ctx, char * buf, size_t max_len)
 project: zydis
 target_name: ZydisFuzzReEncoding
+target_path: /src/zydis/tools/ZydisFuzzShared.c
+
+e: ZydisFuzzReEncoding
 target_path: /src/zydis/tools/ZydisFuzzShared.c
 

--- a/clean.py
+++ b/clean.py
@@ -1,0 +1,23 @@
+import os
+import yaml
+
+def searchStringInYaml(filename):
+    with open(filename) as file:
+        contents = file.read()
+    with open(filename, 'r+') as f:       
+        lines = f.readlines()
+        f.seek(0)
+        if "Retrieving human-written fuzz targets of" in contents: 
+                f.writelines(lines[1:])
+
+def clean(dir):
+        directory = os.fsencode(dir)  
+        for file in os.listdir(directory):
+                filename = os.fsdecode(file)
+                if filename.endswith(".yaml"):
+                        print(filename)
+                        searchStringInYaml(dir+"/"+filename)
+
+
+if __name__ == '__main__':
+        clean("./benchmark-sets/all")

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -44,7 +44,7 @@ RESULTS_DIR: str = run_one_experiment.RESULTS_DIR
 
 class Result:
   benchmark: benchmarklib.Benchmark
-  result: run_one_experiment.AggregatedResult | str
+  result: run_one_experiment.AggregatedResult
 
   def __init__(self, benchmark, result):
     self.benchmark = benchmark


### PR DESCRIPTION
Hi,

PR for two minor changes: 

- removing `| str` at line 47 in run_all_experiments.py, because of the compilation error below: 
<img width="675" alt="Screen Shot 2024-02-09 at 2 39 24 PM" src="https://github.com/google/oss-fuzz-gen/assets/60257613/fd4c1e3f-8c3b-49c3-b969-2f1112788386">

-cleaning the benchmark yaml file by removing the first string, because of the error below:
<img width="722" alt="Screen Shot 2024-02-09 at 2 47 10 PM" src="https://github.com/google/oss-fuzz-gen/assets/60257613/9f768da5-d212-40c5-84f6-4790002471fd">

 
Users can run the added file: `python clean.py` at the root of the repository and retrieve all experiments without the issue above. 

Happy to refactor any of the submitted code if/when needed. 