### PR TITLE
Hide the error message when deleting temp OSS-Fuzz dir

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -41,7 +41,7 @@ def _remove_temp_oss_fuzz_repo():
   try:
     shutil.rmtree(OSS_FUZZ_DIR)
   except PermissionError as e:
-    logging.warning('No permission to remove %s: %s', OSS_FUZZ_DIR, e)
+    logging.warning('No permission to remove %s', OSS_FUZZ_DIR)
   except FileNotFoundError as e:
     logging.warning('No OSS-Fuzz directory %s: %s', OSS_FUZZ_DIR, e)
 

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -43,7 +43,7 @@ def _remove_temp_oss_fuzz_repo():
   except PermissionError as e:
     logging.warning('No permission to remove %s', OSS_FUZZ_DIR)
   except FileNotFoundError as e:
-    logging.warning('No OSS-Fuzz directory %s: %s', OSS_FUZZ_DIR, e)
+    logging.warning('No OSS-Fuzz directory %s', OSS_FUZZ_DIR)
 
 
 def _set_temp_oss_fuzz_repo():


### PR DESCRIPTION
Hiding the error message details because:
1. The error is expected in all local experiments: OSS-Fuzz dir (`/tmp/<tmp_dir>/build/work`) contains the files copied from the docker container, which requires root privilege to delete.
2. The error is benign: Temp dir is in `/tmp` and will be automatically deleted by OS.
3. The error is hard to fix: Fixing this requires using `sudo` or docker, which adds too much unnecessary effort.

We did not have this problem before because we used `pass`:
https://github.com/google/oss-fuzz-gen/commit/9885ae16b9f12686b504eecd94b35641f27c608a#diff-c265089165acff162907dbef5c22b1f966e638b1e750bee28c5a548262464fc3L40

Now, we also log a warning in case this happens elsewhere.
