### PR TITLE
Use function signature in report

### DIFF
--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -79,7 +79,7 @@ EXPERIMENT_NAME="${DATE:?}-${FREQUENCY_LABEL:?}-${BENCHMARK_SET:?}"
 GCS_REPORT_DIR="${SUB_DIR:?}/${EXPERIMENT_NAME:?}"
 
 # Generate a report and upload it to GCS
-bash report/upload_report.sh "${LOCAL_RESULTS_DIR:?}" "${GCS_REPORT_DIR:?}" &
+bash report/upload_report.sh "${LOCAL_RESULTS_DIR:?}" "${GCS_REPORT_DIR:?}" "${BENCHMARK_SET:?}" &
 pid_report=$!
 
 # Run the experiment

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -28,7 +28,7 @@
     </tr>
 {% for benchmark in benchmarks %}
     <tr>
-        <td><a href="benchmark/{{ benchmark.id|urlencode }}">{{ benchmark.id }}</a></li></td>
+        <td><a href="benchmark/{{ benchmark.id|urlencode }}">{{ benchmark.signature }}</a></li></td>
         <td>{{ benchmark.status }}</td>
         <td>{{ benchmark.result.build_success_rate|percent}}</td>
         <td>{{ benchmark.result.crash_rate|percent }} </td>

--- a/report/templates/index.json
+++ b/report/templates/index.json
@@ -2,7 +2,7 @@
     "benchmarks": [
 {% for benchmark in benchmarks %}
     {
-        "benchmark": "{{ benchmark.id }}",
+        "benchmark": "{{ benchmark.signature }}",
         "status": "{{ benchmark.status }}",
         "build_success_rate": "{{ benchmark.result.build_success_rate|percent }}",
         "crash_rate": "{{ benchmark.result.crash_rate|percent }}",

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -23,6 +23,7 @@
 
 RESULTS_DIR=$1
 GCS_DIR=$2
+BENCHMARK_SET=$3
 WEB_PORT=8080
 DATE=$(date '+%Y-%m-%d')
 
@@ -45,7 +46,7 @@ mkdir results-report
 
 while true; do
   # Spin up the web server generating the report (and bg the process).
-  $PYTHON -m report.web "${RESULTS_DIR:?}" "${WEB_PORT:?}" &
+  $PYTHON -m report.web "${RESULTS_DIR:?}" "${WEB_PORT:?}" "${BENCHMARK_SET:?}" &
   pid_web=$!
 
   cd results-report || exit 1

--- a/report/web.py
+++ b/report/web.py
@@ -58,11 +58,15 @@ class Benchmark:
       return ''
 
     for project_yaml in os.listdir(BENCHMARK_DIR):
+      yaml_project_name = project_yaml.removesuffix(".yaml")
       with open(os.path.join(BENCHMARK_DIR, project_yaml)) as project_yaml_file:
+        if yaml_project_name not in self.id:
+          continue
         functions = yaml.safe_load(project_yaml_file).get('functions', [])
         for function in functions:
-          if function.get('name', '').startswith(self.id):
-            return function.get('signature', '')
+          function_name = self.id.removeprefix(f'output-{yaml_project_name}-')
+          if function.get('name', '').lower().startswith(function_name):
+            return f'{yaml_project_name}-{function.get("signature", "")}'
 
     return ''
 

--- a/report/web.py
+++ b/report/web.py
@@ -141,7 +141,7 @@ def _is_valid_benchmark_dir(cur_dir: str) -> bool:
   if not cur_dir.startswith('output-'):
     return False
   # Check sub-directories.
-  expected_dirs = ['raw_targets', 'status', 'fixed_targets', 'logs', 'corpora']
+  expected_dirs = ['raw_targets', 'status', 'fixed_targets']
   return all(
       os.path.isdir(os.path.join(RESULTS_DIR, cur_dir, expected_dir))
       for expected_dir in expected_dirs)

--- a/report/web.py
+++ b/report/web.py
@@ -35,6 +35,7 @@ log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 
 RESULTS_DIR = ''
+BENCHMARK_SET_DIR = 'benchmark-sets'
 BENCHMARK_DIR = ''
 
 MAX_RUN_LOGS_LEN = 16 * 1024
@@ -323,7 +324,7 @@ def cov_report_link(link: str):
 def serve(directory: str, port: int, benchmark_set: str):
   global RESULTS_DIR, BENCHMARK_DIR
   RESULTS_DIR = directory
-  BENCHMARK_DIR = benchmark_set
+  BENCHMARK_DIR = os.path.join(BENCHMARK_SET_DIR, benchmark_set)
   app.run(host='localhost', port=port)
 
 

--- a/report/web.py
+++ b/report/web.py
@@ -23,6 +23,7 @@ import sys
 import urllib.parse
 from typing import List, Optional
 
+import yaml
 from flask import Flask, abort, render_template
 
 import run_one_experiment
@@ -34,15 +35,35 @@ log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 
 RESULTS_DIR = ''
+BENCHMARK_DIR = ''
 
 MAX_RUN_LOGS_LEN = 16 * 1024
 
 
 @dataclasses.dataclass
 class Benchmark:
+  """The class of a benchmark function and its experiment results."""
   id: str
   status: str
   result: run_one_experiment.AggregatedResult
+  signature: str = ''
+
+  def __post_init__(self):
+    self.signature = self._find_signature() or self.id
+
+  def _find_signature(self) -> str:
+    """Finds the function signature by searching for its id in BENCHMARK_DIR."""
+    if not BENCHMARK_DIR:
+      return ''
+
+    for project_yaml in os.listdir(BENCHMARK_DIR):
+      with open(os.path.join(BENCHMARK_DIR, project_yaml)) as project_yaml_file:
+        functions = yaml.safe_load(project_yaml_file).get('functions', [])
+        for function in functions:
+          if function.get('name', '').startswith(self.id):
+            return function.get('signature', '')
+
+    return ''
 
 
 @dataclasses.dataclass
@@ -299,14 +320,16 @@ def cov_report_link(link: str):
   return f'https://llm-exp.oss-fuzz.com/{path}/report/linux/report.html'
 
 
-def serve(directory: str, port: int):
-  global RESULTS_DIR
+def serve(directory: str, port: int, benchmark_set: str):
+  global RESULTS_DIR, BENCHMARK_DIR
   RESULTS_DIR = directory
+  BENCHMARK_DIR = benchmark_set
   app.run(host='localhost', port=port)
 
 
 if __name__ == '__main__':
   results_dir = sys.argv[1]
   server_port = int(sys.argv[2])
+  benchmark_dir = sys.argv[3] if len(sys.argv) > 2 else ''
 
-  serve(results_dir, server_port)
+  serve(results_dir, server_port, benchmark_dir)


### PR DESCRIPTION
The current report displays function by its `raw_function_name`, which is not human-readable.
This PR replaces that with the corresponding function signature found in the benchmark set used in the experiment.

Related: https://github.com/google/oss-fuzz-gen/pull/98#issuecomment-1938208683