### PR TITLE
Push image for weekly experiments

### DIFF
--- a/.github/workflows/push-weekly-image-to-gcloud.yml
+++ b/.github/workflows/push-weekly-image-to-gcloud.yml
@@ -1,0 +1,25 @@
+name: Build Docker image from main
+
+on:
+  schedule:
+    - cron: '0 1 * * 6'  # Saturday 1 AM.
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag us-central1-docker.pkg.dev/oss-fuzz-base/testing/oss-fuzz-gen:weekly
+    - name: Authenticate to gcloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCLOUD_CREDENTIAL }}'
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+    - name: Auth to Artifact Registry
+      run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+    - name: Push to Artifact Registry
+      run: docker push us-central1-docker.pkg.dev/oss-fuzz-base/testing/oss-fuzz-gen:weekly

--- a/.github/workflows/push-weekly-image-to-gcloud.yml
+++ b/.github/workflows/push-weekly-image-to-gcloud.yml
@@ -2,7 +2,7 @@ name: Build Docker image from main
 
 on:
   schedule:
-    - cron: '0 1 * * 6'  # Saturday 1 AM.
+    - cron: '0 15 * * 5'  # Sydney Saturday ~1 AM.
 
 jobs:
 


### PR DESCRIPTION
1. Add workflow to build a docker image with the latest code in `main`
2. Push the image to the artifact registry on Saturday at 1 AM.

I will also run some experiments here for testing purposes.