### PR TITLE
Fix docker tag pattern

### DIFF
--- a/.github/workflows/push-weekly-image-to-gcloud.yml
+++ b/.github/workflows/push-weekly-image-to-gcloud.yml
@@ -1,0 +1,25 @@
+name: Build Docker image from main
+
+on:
+  schedule:
+    - cron: '0 1 * * 6'  # Saturday 1 AM.
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag us-central1-docker.pkg.dev/oss-fuzz-base/testing/oss-fuzz-gen:weekly
+    - name: Authenticate to gcloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCLOUD_CREDENTIAL }}'
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+    - name: Auth to Artifact Registry
+      run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+    - name: Push to Artifact Registry
+      run: docker push us-central1-docker.pkg.dev/oss-fuzz-base/testing/oss-fuzz-gen:weekly

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -205,6 +205,8 @@ class Evaluator:
     # Replace "::" and any character not \w, _, or . with "-".
     valid_docker_tag_name = re.sub(r'::', '-', self.benchmark.id)
     valid_docker_tag_name = re.sub(r'[^\w_.]', '-', valid_docker_tag_name)
+    # Docker fails with tags containing -_ or _-.
+    valid_docker_tag_name = re.sub(r'[-_]{2,}', '-', valid_docker_tag_name)
     generated_oss_fuzz_project = f'{valid_docker_tag_name}-{sample_id}'
     self.create_ossfuzz_project(generated_oss_fuzz_project, target_path)
 


### PR DESCRIPTION
Docker appears to have an undocumented name rule that disallows dashes (`-`) followed by underscores (`_`) (and `-`s after `_`), which caused some of our projects to fail to build.

This PR fixes this issue by replacing these patterns (`[_-]{2, }`) with `-`.