### PR TITLE
Fix port

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -252,10 +252,10 @@ class BuilderRunner:
                stderr=sp.STDOUT,
                check=True)
       except sp.CalledProcessError:
-        print(f'Failed to build {generated_project} with {sanitizer}')
+        print(f'Failed to run {generated_project} with {sanitizer}')
         return False
 
-    print(f'Successfully built {generated_project} with {sanitizer}')
+    print(f'Successfully run {generated_project} with {sanitizer}')
     return True
 
   def get_coverage_local(

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -274,9 +274,17 @@ class BuilderRunner:
 
     corpus_dir = self.work_dirs.corpus(benchmark_target_name)
     command = [
-        'python3', 'infra/helper.py', 'coverage', '--corpus-dir', corpus_dir,
-        '--fuzz-target', self.benchmark.target_name, '--no-serve', '--port',
-        '0', generated_project
+        'python3',
+        'infra/helper.py',
+        'coverage',
+        '--corpus-dir',
+        corpus_dir,
+        '--fuzz-target',
+        self.benchmark.target_name,
+        '--no-serve',
+        '--port',
+        '',
+        generated_project,
     ]
 
     try:


### PR DESCRIPTION
Changing `'--port', '0'` to `'--port', ''` to avoid the following error message:
```
docker: Error response from daemon: driver failed programming external connectivity on endpoint upbeat_haslett (9eb48aa55a0c0d79a31616850c8fff6173fb088c6f6deb1213a8e9c0ffc90a04):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32807 -j DNAT --to-destination 172.17.0.2:0 ! -i docker0: iptables v1.8.7 (nf_tables): Port `0' not valid\n\nTry `iptables -h' or 'iptables --help' for more information.\n (exit status 2)).

INFO:__main__:Running: docker run --rm --privileged --shm-size=2g --platform linux/amd64 -e FUZZING_ENGINE=libfuzzer -e HELPER=True -e FUZZING_LANGUAGE=c++ -e PROJECT=<project> -e SANITIZER=coverage -e COVERAGE_EXTRA_ARGS= -e ARCHITECTURE=x86_64 -p 0:0 -v <host_dir>:/corpus/xmltest -v <host_dir>:/out -t gcr.io/oss-fuzz-base/base-runner coverage xmltest.
ERROR:__main__:Failed to generate clang code coverage report.
```