### PR TITLE
Fix and improve CI lint

### DIFF
--- a/.github/helper/presubmit
+++ b/.github/helper/presubmit
@@ -1,6 +1,9 @@
 #! /bin/bash -eu
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
+
+# Disable shellcheck false warning as it assumes incorrect path of `activate`.
+# shellcheck disable=SC1091
 source "$GIT_ROOT/.venv/bin/activate"
 
 # Always use the latest Pyright.

--- a/.github/helper/presubmit
+++ b/.github/helper/presubmit
@@ -17,6 +17,15 @@ for file in $CHANGED_PY; do
         yapf --diff "$file" || true
         yapf --parallel --in-place --print-modified "$file"
         isort "$file"
+
+        # Ensure Pylint continues after linting errors.
+        # Ignore long lines with URLs.
+        pylint "$file" \
+            --rcfile="$GIT_ROOT/.pylintrc" \
+            --ignore-long-lines='^\s*(# .*)?<?https?://\S+>?$' \
+            --score=no \
+            --jobs=0 \
+        || true
     fi
 done
 

--- a/.github/helper/presubmit
+++ b/.github/helper/presubmit
@@ -1,6 +1,7 @@
 #! /bin/bash -eu
 
-source "$(git rev-parse --show-toplevel)/.venv/bin/activate"
+GIT_ROOT=$(git rev-parse --show-toplevel)
+source "$GIT_ROOT/.venv/bin/activate"
 
 # Always use the latest Pyright.
 export PYRIGHT_PYTHON_FORCE_VERSION=latest
@@ -20,16 +21,10 @@ for file in $CHANGED_PY; do
 done
 
 # Type Check and lint all Python code.
-pyright "./" \
-    --project="./.pyrightconfig.json" \
-    --venvpath="./.venv"
+pyright "$GIT_ROOT" \
+    --project="$GIT_ROOT/.pyrightconfig.json" \
+    --venvpath="$GIT_ROOT/.venv"
 
-# Ignore long lines with URLs.
-pylint "./" \
-    --rcfile="./.pylintrc" \
-    --ignore-long-lines='^\s*(# .*)?<?https?://\S+>?$' \
-    --score=no \
-    --jobs=0
 
 
 # Check and remove trailing spaces.

--- a/.github/helper/presubmit
+++ b/.github/helper/presubmit
@@ -9,8 +9,8 @@ export PYRIGHT_PYTHON_FORCE_VERSION=latest
 # Ensure we have the latest code from the repository.
 git fetch origin > /dev/null
 
-# Reformat changed Python code.
-CHANGED_PY=$(git diff origin/main --name-only | grep "\.py$" || echo "")
+# Reformat changed Python code. No need to check uncommitted files.
+CHANGED_PY=$(git diff HEAD origin/main --name-only | grep "\.py$" || echo "")
 for file in $CHANGED_PY; do
     if [ -f "$file" ]; then
         # Ensure the script continues after yapf --diff


### PR DESCRIPTION
1. Apply `pylint` on each file explicitly. Some errors were not captured in #112, this should fix it.
2. Only check committed files. Unstaged files will not be pushed anyway, and leaving them can make local tests more flexible.
3. Use a more specific path to dot files to avoid any ambiguity.
4. Disable a false warning from `shellcheck`, because it cannot interpret path correctly.