### PR TITLE
Support specifying models in GKE experiment runs

### DIFF
--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -100,7 +100,7 @@ $PYTHON run_all_experiments.py \
   --template-directory 'prompts/template_xml' \
   --work-dir ${LOCAL_RESULTS_DIR:?} \
   --num-samples 10 \
-  --mode "$MODEL"
+  --model "$MODEL"
 
 export ret_val=$?
 

--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -22,5 +22,6 @@ table, th, td {
 }
 </style>
 <body>
+LLM: {{ model }}
  {% block content %}{% endblock %}
 </body>

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -21,9 +21,12 @@
 ##   gcs_dir is the name of the directory for the report in gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/.
 ##     Defaults to '$(whoami)-%YY-%MM-%DD'.
 
+# TODO(dongge): Re-write this script in Python as it gets more complex.
+
 RESULTS_DIR=$1
 GCS_DIR=$2
 BENCHMARK_SET=$3
+MODEL=$4
 WEB_PORT=8080
 DATE=$(date '+%Y-%m-%d')
 
@@ -38,15 +41,22 @@ fi
 
 if [[ $GCS_DIR = '' ]]
 then
-  GCS_DIR="$(whoami)-${DATE:?}"
-  echo "GCS directory was not specified as the second argument. Defaulting to ${GCS_DIR:?}."
+  echo "This script needs to take gcloud Bucket directory as the second argument. Consider using $(whoami)-${DATE:?}."
+  exit 1
+fi
+
+# The LLM used to generate and fix fuzz targets.
+if [[ $MODEL = '' ]]
+then
+  echo "This script needs to take LLM as the third argument."
+  exit 1
 fi
 
 mkdir results-report
 
 while true; do
   # Spin up the web server generating the report (and bg the process).
-  $PYTHON -m report.web "${RESULTS_DIR:?}" "${WEB_PORT:?}" "${BENCHMARK_SET:?}" &
+  $PYTHON -m report.web "${RESULTS_DIR:?}" "${WEB_PORT:?}" "${BENCHMARK_SET:?}" "$MODEL" &
   pid_web=$!
 
   cd results-report || exit 1

--- a/report/web.py
+++ b/report/web.py
@@ -266,18 +266,23 @@ def get_targets(benchmark: str, sample: str) -> list[Target]:
 
 @app.route('/')
 def index():
-  return render_template('index.html', benchmarks=list_benchmarks())
+  return render_template('index.html',
+                         benchmarks=list_benchmarks(),
+                         model=model)
 
 
 @app.route('/json')
 def index_json():
-  return render_template('index.json', benchmarks=list_benchmarks())
+  return render_template('index.json',
+                         benchmarks=list_benchmarks(),
+                         model=model)
 
 
 @app.route('/sort')
 def index_sort():
   return render_template('index.html',
-                         benchmarks=sort_benchmarks(list_benchmarks()))
+                         benchmarks=sort_benchmarks(list_benchmarks()),
+                         model=model)
 
 
 @app.route('/benchmark/<benchmark>')
@@ -334,8 +339,10 @@ def serve(directory: str, port: int, benchmark_set: str):
 
 
 if __name__ == '__main__':
+  # TODO(Dongge): Use argparser as this script gets more complex.
   results_dir = sys.argv[1]
   server_port = int(sys.argv[2])
   benchmark_dir = sys.argv[3] if len(sys.argv) > 3 else ''
+  model = sys.argv[4] if len(sys.argv) > 4 else ''
 
   serve(results_dir, server_port, benchmark_dir)


### PR DESCRIPTION
Support specifying models in GKE experiment runs

1. Add `model` argument to `docker_run.sh`, `upload_report.sh`, and `web.py`.
2. Display the model name in experiment reports
3. Some TODOs to rewrite code to adapt to increasing complexity.

Preview:
<img width="1425" alt="image" src="https://github.com/google/oss-fuzz-gen/assets/20501961/96b12bb2-d945-43cb-b3eb-77f52f453297">

We can beautify the layout later.
