### PR TITLE
Fix unique line coverage counting

### DIFF
--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -175,10 +175,8 @@ class Textcov:
   def to_file(self, filename: str) -> None:
     """Writes covered functions and lines to |filename|."""
     file_content = ''
-    for func_name, func_obj in sorted(self.functions.items()):
-      # file_content += f'{func_name}\n'
+    for func_obj in self.functions.values():
       for line_content, line_obj in func_obj.lines.items():
-        # file_content += f'{line_obj.hit_count} | {line_content}\n'
         file_content += f'{line_content}\n' if line_obj.hit_count else ''
 
     with open(filename, 'w') as file:

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -21,7 +21,7 @@ import subprocess
 from typing import List, Optional
 
 # No spaces at the beginning, and ends with a ":".
-FUNCTION_PATTERN = re.compile(r'^([^\s].+):$')
+FUNCTION_PATTERN = re.compile(r'^([^\s].*):$')
 LINE_PATTERN = re.compile(r'^\s*\d+\|\s*([\d\.a-zA-Z]+)\|(.*)')
 
 

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -21,7 +21,7 @@ import subprocess
 from typing import List, Optional
 
 # No spaces at the beginning, and ends with a ":".
-FUNCTION_PATTERN = re.compile(r'^[^\s](.+):$')
+FUNCTION_PATTERN = re.compile(r'^([^\s].+):$')
 LINE_PATTERN = re.compile(r'^\s*\d+\|\s*([\d\.a-zA-Z]+)\|(.*)')
 
 

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -172,6 +172,18 @@ class Textcov:
         continue
     return textcov
 
+  def to_file(self, filename: str) -> None:
+    """Writes covered functions and lines to |filename|."""
+    file_content = ''
+    for func_name, func_obj in sorted(self.functions.items()):
+      # file_content += f'{func_name}\n'
+      for line_content, line_obj in func_obj.lines.items():
+        # file_content += f'{line_obj.hit_count} | {line_content}\n'
+        file_content += f'{line_content}\n' if line_obj.hit_count else ''
+
+    with open(filename, 'w') as file:
+      file.write(file_content)
+
   def merge(self, other: Textcov):
     """Merge another textcov"""
     for function in other.functions.values():

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -105,9 +105,9 @@ class Function:
     """Subtract covered lines."""
 
     # For our analysis purposes, we completely delete any lines that are
-    # seen/covered by the other, rather than subtracting hitcounts.
+    # hit by the other, rather than subtracting hitcounts.
     for line in other.lines.values():
-      if line.contents in self.lines:
+      if line.hit_count and line.contents in self.lines:
         del self.lines[line.contents]
 
 


### PR DESCRIPTION
We count the #unique line coverage of the new fuzz targets by subtracting the lines covered by existing targets.
However, the current code does not exclude unhit lines in existing targets.

This PR fixes that by only subtracting lines with a non-zero hit count.

This PR also:
1. Adds a new helper function to assisting debug this or similar issues in the future.
2. Fixes a minor typo in function pattern when matching `covreport`, which misses the first char in function name.