### PR TITLE
Remove duplicate code in coverage measurement

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -307,8 +307,6 @@ class BuilderRunner:
       new_textcov = textcov.Textcov.from_file(
           f,
           ignore_function_patterns=[
-              # Don't count LLVMFuzzer fuzzer defined functions.
-              re.compile(r'^LLVMFuzzer'),
               # Don't include other functions defined in the target code.
               re.compile(r'^' + re.escape(target_basename) + ':')
           ])

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -464,8 +464,6 @@ class CloudBuilderRunner(BuilderRunner):
         run_result.coverage = textcov.Textcov.from_file(
             f,
             ignore_function_patterns=[
-                # Don't count LLVMFuzzer fuzzer defined functions.
-                re.compile(r'^LLVMFuzzer'),
                 # Don't include other functions defined in the target code.
                 re.compile(r'^' + re.escape(target_basename) + ':')
             ])

--- a/report/aggregate_coverage_diff.py
+++ b/report/aggregate_coverage_diff.py
@@ -50,15 +50,8 @@ def compute_coverage_diff(project: str, coverage_links: list[str]):
     for blob in blobs:
       logging.info('Loading %s', blob.name)
       with blob.open() as f:
-        new_textcov.merge(
-            textcov.Textcov.from_file(
-                f,
-                ignore_function_patterns=[
-                    re.compile(
-                        r'^LLVMFuzzer'
-                    ),  # Don't count LLVMFuzzer fuzzer defined functions.
-                    # TODO: skip other functions defined the target.
-                ]))
+        # TODO: skip other functions defined the target.
+        new_textcov.merge(textcov.Textcov.from_file(f))
 
   new_textcov.subtract_covered_lines(existing_textcov)
   total_lines = coverage_summary['data'][0]['totals']['lines']['count']


### PR DESCRIPTION
The code excludes line coverage of fuzz target, which duplicates #135.