### PR TITLE
Avoid spamming the logs with result path

### DIFF
--- a/report/web.py
+++ b/report/web.py
@@ -253,7 +253,7 @@ def get_targets(benchmark: str, sample: str) -> list[Target]:
   for name in sorted(os.listdir(targets_dir)):
     path = os.path.join(targets_dir, name)
     if os.path.isfile(path) and name.startswith(sample + '.'):
-      print(path)
+      logging.debug(path)
       with open(path) as f:
         code = f.read()
       targets.insert(0, Target(code=code))


### PR DESCRIPTION
Current `web.py` spams logging because it prints out the target path every time we get the target.
This PR fixes that by only log them for dubeg.

This makes the log from large experiments (e.g., `all`) more human-friendly.