### PR TITLE
gitignore: avoid .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ benchmark-sets/split_benchmarks/
 venv/
 .venv/
 __pycache__/
+*.swp


### PR DESCRIPTION
Avoid considering files that are open in vim.