### PR TITLE
Make it possible to point to a local deployment of Fuzz Introspector

### DIFF
--- a/data_prep/README.md
+++ b/data_prep/README.md
@@ -24,8 +24,8 @@ that contains `functions`.
 Use [`introspector.py`](introspector.py) to generate a YAML file of a `C`/`C++` project in `OSS-Fuzz`:
 ```
 # In virtual env under root directory.
-python -m data_prep.introspector <project-name> <num_benchmark_per_project> <output_dir>
-# E.g., python -m data_prep.introspector tinyxml2 5 benchmark-sets/new
+python -m data_prep.introspector <project-name> -m <num_benchmark_per_project> -o <output_dir>
+# E.g., python -m data_prep.introspector tinyxml2 -m 5 -o benchmark-sets/new
 ```
 
 Benchmark files generated in this way prioritize [far-reach-but-low-coverage](https://introspector.oss-fuzz.com/api#api-far-reach-but-low-coverage) functions in `OSS-Fuzz` production, hence easier to achieve higher [`max line coverage diff`](../README.md#Visualizing-Results).

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -46,14 +46,15 @@ INTROSPECTOR_TYPE = ''
 INTROSPECTOR_FUNC_SIG = ''
 
 
-def _set_introspector_endpoints(is_local):
+def _set_introspector_endpoints(is_local: bool):
+  """Sets URLs for Fuzz Introspector endpoints to local or remote endpoints."""
   global INTROSPECTOR_ENDPOINT, INTROSPECTOR_CFG, INTROSPECTOR_FUNCTION, INTROSPECTOR_SOURCE, INTROSPECTOR_XREF, INTROSPECTOR_TYPE, INTROSPECTOR_FUNC_SIG
 
   if is_local:
-    logging.info('Setting Fuzz Introspector endpoint to local')
+    logging.info('Setting Fuzz Introspector endpoint to local.')
     INTROSPECTOR_ENDPOINT = 'http://127.0.0.1:8080/api'
   else:
-    logging.info('Setting Fuzz Introspector endpoint to remote')
+    logging.info('Setting Fuzz Introspector endpoint to remote.')
     INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
 
   INTROSPECTOR_CFG = f'{INTROSPECTOR_ENDPOINT}/annotated-cfg'

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -456,19 +456,19 @@ def get_project_funcs(project_name: str) -> Dict[str, List[Dict]]:
 def _parse_arguments() -> argparse.Namespace:
   """Parses command line args."""
   parser = argparse.ArgumentParser(
-      description='Parse arguments to generate benchmarks')
+      description='Parse arguments to generate benchmarks.')
 
-  parser.add_argument('project', help='Name of the project', type=str)
+  parser.add_argument('project', help='Name of the project.', type=str)
   parser.add_argument('-m',
                       '--max-functions',
                       type=int,
                       default=3,
-                      help='Number of benchmarks to generate')
+                      help='Number of benchmarks to generate.')
   parser.add_argument('-o',
                       '--out',
                       type=str,
                       default='',
-                      help='Output directory')
+                      help='Output directory.')
 
   args = parser.parse_args()
   return args
@@ -478,7 +478,7 @@ if __name__ == '__main__':
   logging.basicConfig(level=logging.INFO)
 
   args = _parse_arguments()
-  if args.out != '':
+  if args.out:
     os.makedirs(args.out, exist_ok=True)
 
   try:

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -46,16 +46,12 @@ INTROSPECTOR_TYPE = ''
 INTROSPECTOR_FUNC_SIG = ''
 
 
-def _set_introspector_endpoints(is_local: bool):
+def _set_introspector_endpoints(endpoint):
   """Sets URLs for Fuzz Introspector endpoints to local or remote endpoints."""
   global INTROSPECTOR_ENDPOINT, INTROSPECTOR_CFG, INTROSPECTOR_FUNCTION, INTROSPECTOR_SOURCE, INTROSPECTOR_XREF, INTROSPECTOR_TYPE, INTROSPECTOR_FUNC_SIG
 
-  if is_local:
-    logging.info('Setting Fuzz Introspector endpoint to local.')
-    INTROSPECTOR_ENDPOINT = 'http://127.0.0.1:8080/api'
-  else:
-    logging.info('Setting Fuzz Introspector endpoint to remote.')
-    INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
+  INTROSPECTOR_ENDPOINT = endpoint
+  logging.info(f'Fuzz Introspector endpoint set to {INTROSPECTOR_ENDPOINT}')
 
   INTROSPECTOR_CFG = f'{INTROSPECTOR_ENDPOINT}/annotated-cfg'
   INTROSPECTOR_FUNCTION = f'{INTROSPECTOR_ENDPOINT}/far-reach-but-low-coverage'
@@ -488,9 +484,10 @@ def _parse_arguments() -> argparse.Namespace:
                       type=str,
                       default='',
                       help='Output directory.')
-  parser.add_argument('-l',
-                      '--local',
-                      action="store_true",
+  parser.add_argument('-e',
+                      '--endpoint',
+                      type=str,
+                      default='https://introspector.oss-fuzz.com/api',
                       help='Set Fuzz Introspecor endpoint to local.')
 
   args = parser.parse_args()
@@ -504,7 +501,7 @@ if __name__ == '__main__':
   if args.out:
     os.makedirs(args.out, exist_ok=True)
 
-  _set_introspector_endpoints(args.local)
+  _set_introspector_endpoints(args.endpoint)
 
   try:
     oss_fuzz_checkout.clone_oss_fuzz()

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -488,7 +488,7 @@ def _parse_arguments() -> argparse.Namespace:
                       '--endpoint',
                       type=str,
                       default='https://introspector.oss-fuzz.com/api',
-                      help='Set Fuzz Introspecor endpoint to local.')
+                      help='Fuzz Introspecor API endpoint.')
 
   args = parser.parse_args()
   return args

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -37,13 +37,31 @@ T = TypeVar('T', str, list, dict)  # Generic type.
 
 TIMEOUT = 10
 MAX_RETRY = 5
-INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
-INTROSPECTOR_CFG = f'{INTROSPECTOR_ENDPOINT}/annotated-cfg'
-INTROSPECTOR_FUNCTION = f'{INTROSPECTOR_ENDPOINT}/far-reach-but-low-coverage'
-INTROSPECTOR_SOURCE = f'{INTROSPECTOR_ENDPOINT}/function-source-code'
-INTROSPECTOR_XREF = f'{INTROSPECTOR_ENDPOINT}/all-cross-references'
-INTROSPECTOR_TYPE = f'{INTROSPECTOR_ENDPOINT}/type-info'
-INTROSPECTOR_FUNC_SIG = f'{INTROSPECTOR_ENDPOINT}/function-signature'
+INTROSPECTOR_ENDPOINT = ''
+INTROSPECTOR_CFG = ''
+INTROSPECTOR_FUNCTION = ''
+INTROSPECTOR_SOURCE = ''
+INTROSPECTOR_XREF = ''
+INTROSPECTOR_TYPE = ''
+INTROSPECTOR_FUNC_SIG = ''
+
+
+def _set_introspector_endpoints(is_local):
+  global INTROSPECTOR_ENDPOINT, INTROSPECTOR_CFG, INTROSPECTOR_FUNCTION, INTROSPECTOR_SOURCE, INTROSPECTOR_XREF, INTROSPECTOR_TYPE, INTROSPECTOR_FUNC_SIG
+
+  if is_local:
+    logging.info('Setting Fuzz Introspector endpoint to local')
+    INTROSPECTOR_ENDPOINT = 'http://127.0.0.1:8080/api'
+  else:
+    logging.info('Setting Fuzz Introspector endpoint to remote')
+    INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
+
+  INTROSPECTOR_CFG = f'{INTROSPECTOR_ENDPOINT}/annotated-cfg'
+  INTROSPECTOR_FUNCTION = f'{INTROSPECTOR_ENDPOINT}/far-reach-but-low-coverage'
+  INTROSPECTOR_SOURCE = f'{INTROSPECTOR_ENDPOINT}/function-source-code'
+  INTROSPECTOR_XREF = f'{INTROSPECTOR_ENDPOINT}/all-cross-references'
+  INTROSPECTOR_TYPE = f'{INTROSPECTOR_ENDPOINT}/type-info'
+  INTROSPECTOR_FUNC_SIG = f'{INTROSPECTOR_ENDPOINT}/function-signature'
 
 
 def _construct_url(api: str, params: dict) -> str:
@@ -469,6 +487,10 @@ def _parse_arguments() -> argparse.Namespace:
                       type=str,
                       default='',
                       help='Output directory.')
+  parser.add_argument('-l',
+                      '--local',
+                      action="store_true",
+                      help='Set Fuzz Introspecor endpoint to local.')
 
   args = parser.parse_args()
   return args
@@ -480,6 +502,8 @@ if __name__ == '__main__':
   args = _parse_arguments()
   if args.out:
     os.makedirs(args.out, exist_ok=True)
+
+  _set_introspector_endpoints(args.local)
 
   try:
     oss_fuzz_checkout.clone_oss_fuzz()


### PR DESCRIPTION
--> This builds on top of https://github.com/google/oss-fuzz-gen/pull/141 so will rebase once that has landed.

Adds ability to use a local deployment of Fuzz Introspector's web api instead of using https://introspector.oss-fuzz.com/

This has several benefits. Deploying a local version and pointing oss-fuzz-gen to this will:
- For larger experiments avoid any timeout issues incurred by too many requests to `introspector.oss-fuzz.com`. Local will have no issues responding to requests.
- Testing new things will go faster as it's not necessary to deploy a new version of the API by way of  `introspector.oss-fuzz.com` before oss-fuzz-gen can use it.
- If for some reason some limitations or regressions are landed on `introspector.oss-fuzz.com` then oss-fuzz-gen testing against introspector isn't blocked because using the local version (where the regression can be fixed) gives the exact same features as `introspector.oss-fuzz.com`.
- it's easier to test against data from different dates. `introspector.oss-fuzz.com` is updated once a day against the latest data from oss-fuzz. However, a local version can create a DB against oss-fuzz's state at any given date.


To test this:

1. Follow the instructions here to set up a local webapp: https://github.com/ossf/fuzz-introspector/tree/main/tools/web-fuzzing-introspection#launching-a-local-version

2. Run in oss-fuzz-gen: `python3 -m data_prep.introspector tinyxml2 -m 5 -o test5 -l`