### PR TITLE
models: make cloud_setup class-specific

### DIFF
--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -287,7 +287,6 @@ class VertexAIModel(GoogleModel):
     logging.info('Using location %s for Vertex AI', location)
     vertexai.init(location=location,)
 
-
   def get_model(self) -> Any:
     return CodeGenerationModel.from_pretrained(self._vertex_ai_model)
 

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -70,7 +70,6 @@ class LLM:
     # Only a subset of models need a cloud specific set up, so
     # we can pass for the remainder of the models as they don't
     # need to implement specific handling of this.
-    pass
 
   @classmethod
   def setup(

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -66,7 +66,7 @@ class LLM:
     self.temperature = temperature
 
   def cloud_setup(self):
-    """Run Cloud specific-setup."""
+    """Runs Cloud specific-setup."""
     # Only a subset of models need a cloud specific set up, so
     # we can pass for the remainder of the models as they don't
     # need to implement specific handling of this.
@@ -278,7 +278,7 @@ class VertexAIModel(GoogleModel):
   _max_output_tokens = 2048
 
   def cloud_setup(self):
-    """Set Vertex AI cloud location."""
+    """Sets Vertex AI cloud location."""
     vertex_ai_locations = os.getenv('VERTEX_AI_LOCATIONS',
                                     'us-central1').split(',')
     location = random.sample(vertex_ai_locations, 1)[0]

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -65,15 +65,12 @@ class LLM:
     self.num_samples = num_samples
     self.temperature = temperature
 
-  @classmethod
-  def cloud_setup(cls):
+  def cloud_setup(self):
     """Run Cloud specific-setup."""
-    vertex_ai_locations = os.getenv('VERTEX_AI_LOCATIONS',
-                                    'us-central1').split(',')
-    location = random.sample(vertex_ai_locations, 1)[0]
-
-    logging.info('Using location %s for vertex AI', location)
-    vertexai.init(location=location,)
+    # Only a subset of models need a cloud specific set up, so
+    # we can pass for the remainder of the models as they don't
+    # need to implement specific handling of this.
+    pass
 
   @classmethod
   def setup(
@@ -280,6 +277,16 @@ class VertexAIModel(GoogleModel):
 
   _vertex_ai_model = ''
   _max_output_tokens = 2048
+
+  def cloud_setup(self):
+    """Set Vertex AI cloud location."""
+    vertex_ai_locations = os.getenv('VERTEX_AI_LOCATIONS',
+                                    'us-central1').split(',')
+    location = random.sample(vertex_ai_locations, 1)[0]
+
+    logging.info('Using location %s for vertex AI', location)
+    vertexai.init(location=location,)
+
 
   def get_model(self) -> Any:
     return CodeGenerationModel.from_pretrained(self._vertex_ai_model)

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -284,7 +284,7 @@ class VertexAIModel(GoogleModel):
                                     'us-central1').split(',')
     location = random.sample(vertex_ai_locations, 1)[0]
 
-    logging.info('Using location %s for vertex AI', location)
+    logging.info('Using location %s for Vertex AI', location)
     vertexai.init(location=location,)
 
 

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -211,7 +211,7 @@ def run(benchmark: Benchmark,
         use_context: bool = False,
         run_timeout: int = RUN_TIMEOUT) -> Optional[AggregatedResult]:
   """Generates code via LLM, and evaluates them."""
-  models.LLM.cloud_setup()
+  model.cloud_setup()
   logging.basicConfig(level=logging.INFO)
 
   if example_pair is None:


### PR DESCRIPTION
This is to avoid confusing output about Vertex AI when using models other than Vertex AI. 

For example, currently when I run e.g. using `openai` model I get output about Vertex AI location:

```sh
$ ./run_all_experiments.py --model=gpt-3.5-turbo --benchmarks-directory=./benchmark-sets/comparison-2/
Running 2 experiment(s) in parallel.                                                                                                                                                                                    
INFO:root:Using location us-central1 for vertex AI                                                                                                                                                                      
Downloaded human-written fuzz targets of tinyxml2 from Google Cloud Bucket: oss-fuzz-llm-public.                                                                                    
Generating targets for tinyxml2 XMLNode * const XMLElement::ShallowClone(XMLDocument *) using gpt-3.5-turbo..                                                                       
Generated:
```

This PR avoids the output about Vertex AI:

```sh
$ ./run_all_experiments.py --model=gpt-3.5-turbo --benchmarks-directory=./benchmark-sets/comparison-2/                                                   
Running 2 experiment(s) in parallel.                                                                        
Downloaded human-written fuzz targets of tinyxml2 from Google Cloud Bucket: oss-fuzz-llm-public.                                                                                                                        
Generating targets for tinyxml2 XMLNode * const XMLElement::ShallowClone(XMLDocument *) using gpt-3.5-turbo..
Generated:  
```