### PR TITLE
Allow generating training data with old experiment results.

### DIFF
--- a/data_prep/parse_training_data.py
+++ b/data_prep/parse_training_data.py
@@ -236,12 +236,18 @@ class Experiment:
     logging.info('Saved to: %s', data_filapath)
 
 
-def _download_files(experiment_dir: str, bucket_url: str) -> None:
+def _parse_gcs_uri(bucket_uri: str) -> tuple[str, str]:
+  """Parses the bucket name and directory prefix from |bucket_uri|."""
+  bucket_name = bucket_uri.removeprefix('gs://').split('/')[0]
+  directory_prefix = bucket_uri.removeprefix(f'gs://{bucket_name}/')
+  return bucket_name, directory_prefix
+
+
+def _download_files(experiment_dir: str, bucket_uri: str) -> None:
   """
-  Downloads files in |bucket_url| to |experiment_dir| and preserve their paths.
+  Downloads files in |bucket_uri| to |experiment_dir| and preserve their paths.
   """
-  bucket_name = bucket_url.removeprefix('gs://').split('/')[0]
-  directory_prefix = bucket_url.removeprefix(f'gs://{bucket_name}/')
+  bucket_name, directory_prefix = _parse_gcs_uri(bucket_uri)
   bucket = STORAGE_CLIENT.bucket(bucket_name)
   blobs = bucket.list_blobs(prefix=directory_prefix)
   blobs_num = len(list(blobs))

--- a/data_prep/parse_training_data.py
+++ b/data_prep/parse_training_data.py
@@ -199,9 +199,13 @@ class Benchmark:
 class Experiment:
   """The directory of an experiment, containing benchmark result directories."""
 
-  def __init__(self, experiment_dir: str, bucket_url: str = '') -> None:
+  def __init__(self, experiment_dir: str, bucket_uri: str = '') -> None:
+    # The local result directory. The directory from bucket_uri will be
+    # downloaded here if this directory does not contain experiment results.
     self.experiment = experiment_dir
-    self.bucket_url = bucket_url
+    # The gcloud bucket result directory uri. It can be an empty string if
+    # experiment_dir already contains experiment results.
+    self.bucket_uri = bucket_uri
     self.benchmarks = []
 
     if bucket_url:

--- a/data_prep/parse_training_data.py
+++ b/data_prep/parse_training_data.py
@@ -111,8 +111,13 @@ class Benchmark:
                         self.benchmark, instance)
         continue
       with open(status_json_path) as file:
-        status = json.load(file)
-        all_status[instance] = status
+        try:
+          status = json.load(file)
+          all_status[instance] = status
+        except Exception as e:
+          logging.warning(e)
+          logging.warning(status_json_path)
+
     return all_status
 
   @property

--- a/data_prep/parse_training_data.py
+++ b/data_prep/parse_training_data.py
@@ -112,8 +112,7 @@ class Benchmark:
         continue
       with open(status_json_path) as file:
         try:
-          status = json.load(file)
-          all_status[instance] = status
+          all_status[instance] = json.load(file)
         except Exception as e:
           logging.warning(e)
           logging.warning(status_json_path)


### PR DESCRIPTION
The current script assumes the result directory is available locally, which does not support old cloud experiment results.
The code change downloads necessary files from old experiment bucket directories and uses them to generate training data.

Note: Future experiments will automatically generate training data, thanks to #148. This is only used to generate training data from past experiments.