### PR TITLE
Try to get generated targets to null terminate where necessary.

### DIFF
--- a/benchmark-sets/comparison/nokogiri.yaml
+++ b/benchmark-sets/comparison/nokogiri.yaml
@@ -1,0 +1,11 @@
+"functions":
+- "name": "gumbo_parse"
+  "params":
+  - "name": "buffer"
+    "type": "char *"
+  "return_type": "struct GumboInternalOutput *"
+  "signature": "GumboOutput * gumbo_parse(const char *)"
+"language": "c"
+"project": "nokogiri"
+"target_name": "parse_fuzzer"
+"target_path": "/src/nokogiri/gumbo-parser/fuzzer/parse_fuzzer.cc"

--- a/prompts/template_xml/problem.txt
+++ b/prompts/template_xml/problem.txt
@@ -1,4 +1,18 @@
 <task>
+EXTREMELY IMPORTANT: If the function to fuzz accepts a <code>const char *</code> or <code>char *</code> argument with no accompanying size or length argument, the pointer passed MUST MUST be null determined!!! For example, consider the function signature:
+<code>
+void function(char *arg); // no size or length argument.
+</code>
+
+In these cases the solution MUST ensure the pointer passed to the argument is null terminated by either adding '\0' to the array, or by using FuzzedDataProvider (ConsumeRandomLengthString or ConsumeBytesAsString). For example:
+<code>
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // null terminate the data before passing it to the function to fuzz.
+  data[size-1] = '\0';
+  function((char *)data);
+}
+</code>
+
 Your goal is to write a fuzzing harness for the provided function header using <code>LLVMFuzzerTestOneInput</code>. It is important that the provided solution compiles and actually calls the function specified by the function header:
 <function header>
 {PROBLEM_CONTENT}


### PR DESCRIPTION
This didn't work when I put it further up in <system> with code-bison-32k, gemini-pro.

gemini-ultra, gemini-1.5 though, did work with the instruction further up, but we can't scale there yet.