### PR TITLE
oss_fuzz_checkout: avoid breaking on permission errors

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -25,7 +25,7 @@ import tempfile
 import yaml
 
 BUILD_DIR: str = 'build'
-GLOBAL_TEMP_DIR: tempfile.TemporaryDirectory
+GLOBAL_TEMP_DIR: tempfile.mkdtemp
 # Assume OSS-Fuzz is at repo root dir by default.
 # This will change if temp_dir is used.
 OSS_FUZZ_DIR: str = os.path.join(
@@ -52,9 +52,9 @@ def _set_temp_oss_fuzz_repo():
   # Holding the temp directory in a global object to ensure it won't be deleted
   # before program ends.
   global GLOBAL_TEMP_DIR
-  GLOBAL_TEMP_DIR = tempfile.TemporaryDirectory()
+  GLOBAL_TEMP_DIR = tempfile.mkdtemp()
   global OSS_FUZZ_DIR
-  OSS_FUZZ_DIR = GLOBAL_TEMP_DIR.name
+  OSS_FUZZ_DIR = GLOBAL_TEMP_DIR
   atexit.register(_remove_temp_oss_fuzz_repo)
   _clone_oss_fuzz_repo()
 

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -25,7 +25,7 @@ import tempfile
 import yaml
 
 BUILD_DIR: str = 'build'
-GLOBAL_TEMP_DIR: tempfile.mkdtemp
+GLOBAL_TEMP_DIR: str = ''
 # Assume OSS-Fuzz is at repo root dir by default.
 # This will change if temp_dir is used.
 OSS_FUZZ_DIR: str = os.path.join(


### PR DESCRIPTION
Change from TemporaryDirectory to mkdtemp. TemporaryDirectory has a destructor that can fail, and the exception can't be caught. This fixes it as there is no destructor on the string returned by `mkdtemp`.