### PR TITLE
Fix report sample page

### DIFF
--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -17,9 +17,12 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1>{{ benchmark }} / {{ sample }}</h1>
+<h1>{{ benchmark }} / {{ sample.id }}</h1>
 Bug: {{ sample.result.crashes and not sample.result.is_driver_fuzz_err }}
+<br>
 Crash reason: {{ sample.result.driver_fuzz_err }}
+<br>
+<br>
 {% for target in targets %}
 {% if target.fixer_prompt %}
 <h3>Fixer prompt #{{ loop.index - 1 }}</h3>

--- a/report/web.py
+++ b/report/web.py
@@ -241,6 +241,22 @@ def get_samples(benchmark: str) -> list[Sample]:
 
   return samples
 
+def match_sample(benchmark: str, target_sample_id: str) -> Sample:
+  """Identifies the samples object and its status of the given sample id."""
+  samples = []
+  results, _ = get_results(benchmark)
+
+  for i, sample_id in enumerate(sample_ids(get_generated_targets(benchmark))):
+    if sample_id != target_sample_id:
+      continue
+    status = 'Running'
+    result = None
+    if results[i]:
+      status = 'Done'
+      result = results[i]
+
+    return Sample(sample_id, status, result)
+
 
 def truncate_logs(logs: str, max_len: int) -> str:
   if len(logs) <= max_len:
@@ -411,7 +427,7 @@ def sample_page(benchmark, sample):
   if _is_valid_benchmark_dir(benchmark):
     return render_template('sample.html',
                            benchmark=benchmark,
-                           sample=sample,
+                           sample=match_sample(benchmark, sample),
                            logs=get_logs(benchmark, sample),
                            run_logs=get_run_logs(benchmark, sample),
                            targets=get_targets(benchmark, sample),

--- a/report/web.py
+++ b/report/web.py
@@ -241,9 +241,9 @@ def get_samples(benchmark: str) -> list[Sample]:
 
   return samples
 
-def match_sample(benchmark: str, target_sample_id: str) -> Sample:
+
+def match_sample(benchmark: str, target_sample_id: str) -> Optional[Sample]:
   """Identifies the samples object and its status of the given sample id."""
-  samples = []
   results, _ = get_results(benchmark)
 
   for i, sample_id in enumerate(sample_ids(get_generated_targets(benchmark))):
@@ -256,6 +256,9 @@ def match_sample(benchmark: str, target_sample_id: str) -> Sample:
       result = results[i]
 
     return Sample(sample_id, status, result)
+  logging.warning('Failed to identify benchmark sample: %s\n  %s', benchmark,
+                  target_sample_id)
+  return None
 
 
 def truncate_logs(logs: str, max_len: int) -> str:


### PR DESCRIPTION
Fixes incorrect usage of `sample`:
It was a string on that page, now changing it to the `Sample` Object so that we can show its results and crash reason on the page.

Preview:
<img width="1848" alt="image" src="https://github.com/google/oss-fuzz-gen/assets/20501961/e04ea927-0854-4a81-ae9d-852c532c4725">
