### PR TITLE
Modify sort keys in web.py

### DIFF
--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -66,11 +66,11 @@ while true; do
   wget2 --quiet --inet4-only --no-host-directories --http2-request-window 10 --recursive localhost:${WEB_PORT:?}/ 2>&1
 
   # Also fetch the sorted reports.
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort/build -O sort/build 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort/cov -O sort/cov 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort/cov_diff -O sort/cov_diff 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort/crash -O sort/crash 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort/status -O sort/status 2>&1
+  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_build -O sort/build 2>&1
+  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_cov -O sort/cov 2>&1
+  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_cov_diff -O sort/cov_diff 2>&1
+  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_crash -O sort/crash 2>&1
+  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_status -O sort/status 2>&1
 
   # Stop the server.
   kill -9 "$pid_web"

--- a/report/web.py
+++ b/report/web.py
@@ -352,7 +352,7 @@ def index_json():
                          model=model)
 
 
-@app.route('/sort/build')
+@app.route('/sort_build')
 def index_sort_build():
   return render_template('index.html',
                          benchmarks=sort_benchmarks(list_benchmarks(),
@@ -360,7 +360,7 @@ def index_sort_build():
                          model=model)
 
 
-@app.route('/sort/cov')
+@app.route('/sort_cov')
 def index_sort_cov():
   return render_template('index.html',
                          benchmarks=sort_benchmarks(list_benchmarks(),
@@ -368,7 +368,7 @@ def index_sort_cov():
                          model=model)
 
 
-@app.route('/sort/cov_diff')
+@app.route('/sort_cov_diff')
 def index_sort():
   return render_template('index.html',
                          benchmarks=sort_benchmarks(list_benchmarks(),
@@ -376,7 +376,7 @@ def index_sort():
                          model=model)
 
 
-@app.route('/sort/crash')
+@app.route('/sort_crash')
 def index_sort_crash():
   return render_template('index.html',
                          benchmarks=sort_benchmarks(list_benchmarks(),
@@ -384,7 +384,7 @@ def index_sort_crash():
                          model=model)
 
 
-@app.route('/sort/status')
+@app.route('/sort_status')
 def index_sort_stauts():
   return render_template('index.html',
                          benchmarks=sort_benchmarks(list_benchmarks(),


### PR DESCRIPTION
This PR fixes the benchmark page link in sorted index pages, e.g.:
https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-03-21-172-dg-comparison/sort/crash

Related: https://github.com/google/oss-fuzz-gen/pull/172/commits/baf80ff4367ca77b1b2b7403bbb535802cc0eb6c