### PR TITLE
Improve the usability of the experiment reports

### DIFF
--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -1,27 +1,60 @@
-<!doctype html>
-<!--
- Copyright 2024 Google LLC
+{#
+Copyright 2024 Google LLC
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
+#}<!doctype html>
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Experiment results</title>
 <style>
-table, th, td {
-  border: 1px solid;
+* {
+    box-sizing: border-box;
+}
+
+html {
+    line-height: 1.15;
+}
+
+body {
+    font-family: sans-serif;
+    font-size: 16px;
+}
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+td, th {
+    border-right: 1px #dedede solid;
+    border-bottom: 1px #dedede solid;
+    padding: 5px;
+    text-align: left;
+}
+td:first-child, th:first-child {
+    border-left: 1px #dedede solid;
+}
+th {
+    border-top: 1px #dedede solid;
+}
+
+tbody tr:nth-child(odd) {
+    background-color: #f4f5ff;
 }
 </style>
 <body>
-LLM: {{ model }}
- {% block content %}{% endblock %}
+    LLM: {{ model }}
+    {% block content %}{% endblock %}
 </body>

--- a/report/templates/benchmark.html
+++ b/report/templates/benchmark.html
@@ -1,22 +1,27 @@
-<!--
- Copyright 2024 Google LLC
+{#
+Copyright 2024 Google LLC
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
-{% extends 'base.html' %}
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}{% extends 'base.html' %}
 
 {% block content %}
+<style>
+td, th {
+    border-right: 1px #dedede solid;
+    padding: 5px;
+    text-align: left;
+}
+</style>
 <h1>{{ benchmark }}</h1>
 <table>
     <tr>
@@ -29,7 +34,7 @@
         <th>Coverage</th>
         <th>Line coverage diff</th>
     </tr>
-{% for sample in samples %}
+    {% for sample in samples %}
     <tr>
         <td><a href="../../sample/{{ benchmark|urlencode }}/{{ sample.id }}">{{ sample.id }}</a></li></td>
         <td>{{ sample.status }}</td>
@@ -49,7 +54,7 @@
         <td>N/A</td>
         {% endif %}
     </tr>
-{% endfor %}
+    {% endfor %}
 </table>
 
 <h2>Prompt</h2>

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -65,7 +65,7 @@ td .signature {
             <th data-sort-number>Build Rate</th>
             <th data-sort-number>Crash Rate</th>
             <th data-sort-number>Bugs</th>
-            <th data-sort-number>Coverage</th>
+            <th data-sort-number>Edge Coverage</th>
             <th data-sort-number>Line Coverage Diff</th>
         </tr>
     </thead>

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -73,7 +73,7 @@ td .signature {
             <th data-sort-number>Build Rate</th>
             <th data-sort-number>Crash Rate</th>
             <th data-sort-number>Bugs</th>
-            <th data-sort-number>Edge Coverage</th>
+            <th data-sort-number>Program Counter Coverage</th>
             <th data-sort-number>Line Coverage Diff</th>
         </tr>
     </thead>

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -1,42 +1,120 @@
-<!--
- Copyright 2024 Google LLC
+{#
+Copyright 2024 Google LLC
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-{% extends 'base.html' %}
+#}{% extends 'base.html' %}
 
 {% block content %}
-<table>
-    <tr>
-        <th>Benchmark</th>
-        <th>Status</th>
-        <th>Build rate</th>
-        <th>Crash rate</th>
-        <th>Bug</th>
-        <th>Coverage</th>
-        <th>Line coverage diff</th>
-    </tr>
-{% for benchmark in benchmarks %}
-    <tr>
-        <td><a href="benchmark/{{ benchmark.id|urlencode }}/index.html">{{ benchmark.signature }}</a></li></td>
-        <td>{{ benchmark.status }}</td>
-        <td>{{ benchmark.result.build_success_rate|percent}}</td>
-        <td><a href="benchmark/{{ benchmark.id|urlencode }}/crash.json"> {{ benchmark.result.crash_rate|percent }} </a></td>
-        <td>{{ benchmark.result.found_bug }}</td>
-        <td>{{ benchmark.result.max_coverage |percent }}</td>
-        <td><a href="{{ benchmark.result.max_coverage_diff_report | cov_report_link }}">{{ benchmark.result.max_line_coverage_diff|percent }}</a></td>
-    </tr>
-{% endfor %}
+
+<style>
+td .benchmark .function,
+td .signature {
+    overflow-wrap: anywhere;
+}
+
+td .signature {
+    width: fit-content;
+    white-space: normal;
+    padding: 5px 2px;
+    margin: 5px 0 0;
+    background: #eee;
+    font-family: monospace;
+    font-size: 14px;
+}
+
+.signature a {
+    text-decoration: none;
+}
+
+.sortable-table th {
+    cursor: pointer;
+}
+
+.sortable-table th:after {
+    content: ' \25be';
+    color: #ccc;
+}
+
+.sortable-table th[data-sorted="asc"]:after {
+    color: #000;
+}
+
+.sortable-table th[data-sorted="desc"]:after {
+    content: ' \25b4';
+    color: #000;
+}
+
+</style>
+
+<table class="sortable-table">
+    <thead>
+        <tr>
+            <th data-sorted="asc">Benchmark</th>
+            <th>Status</th>
+            <th data-sort-number>Build Rate</th>
+            <th data-sort-number>Crash Rate</th>
+            <th data-sort-number>Bugs</th>
+            <th data-sort-number>Coverage</th>
+            <th data-sort-number>Line Coverage Diff</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for benchmark in benchmarks %}
+        <tr>
+            <td data-sort-value="{{ benchmark.id }}">
+                <div class="project">{{ benchmark.project }}</div>
+                <pre class="signature">
+                    <a href="benchmark/{{ benchmark.id|urlencode }}/index.html">{{ benchmark.signature }}</a>
+                </pre>
+            </td>
+            <td data-sort-value="{{ benchmark.status }}">{{ benchmark.status }}</td>
+            <td data-sort-value={{ benchmark.result.build_success_rate|percent }}>{{ benchmark.result.build_success_rate|percent}}</td>
+            <td data-sort-value="{{ benchmark.result.crash_rate|percent }}"><a href="benchmark/{{ benchmark.id|urlencode }}/crash.json"> {{ benchmark.result.crash_rate|percent }} </a></td>
+            <td data-sort-value="{{ benchmark.result.found_bug }}">{{ benchmark.result.found_bug }}</td>
+            <td data-sort-value="{{ benchmark.result.max_coverage |percent }}">{{ benchmark.result.max_coverage |percent }}</td>
+            <td data-sort-value="{{ benchmark.result.max_line_coverage_diff|percent }}"><a href="{{ benchmark.result.max_coverage_diff_report | cov_report_link }}">{{ benchmark.result.max_line_coverage_diff|percent }}</a></td>
+        </tr>
+        {% endfor %}
+    </tbody>
 </table>
+
+<script>
+(function() {
+    const headers = Array.from(document.querySelectorAll('table.sortable-table th'));
+    headers.map((th, colindex) => th.addEventListener('click', () => {
+        const sortAsc = th.dataset.sorted != "asc";
+        const sortNumber = th.dataset.sortNumber != undefined;
+
+        const tbody = document.querySelector('table.sortable-table tbody');
+        const rows = Array.from(tbody.children);
+        rows.sort((a, b) => {
+            let [valueA, valueB] = [a.children[colindex].dataset.sortValue, b.children[colindex].dataset.sortValue];
+            // Swap the values for descending.
+            if (!sortAsc) {
+                [valueB, valueA] = [valueA, valueB];
+            }
+
+            if (sortNumber) {
+                return Number(valueB) - Number(valueA);
+            }
+            return valueA.localeCompare(valueB);
+        });
+        tbody.replaceChildren(...rows);
+        // Move sorted data attribute to the right column
+        headers.map(innerTH => delete innerTH.dataset.sorted);
+        th.dataset.sorted = sortAsc ? "asc" : "desc";
+    }));
+})();
+</script>
 {% endblock %}

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -37,6 +37,13 @@ td .signature {
     text-decoration: none;
 }
 
+.table-index {
+    color: #555;
+    font-size: 12px;
+    text-align: center;
+}
+
+
 .sortable-table th {
     cursor: pointer;
 }
@@ -60,6 +67,7 @@ td .signature {
 <table class="sortable-table">
     <thead>
         <tr>
+            <th></th>
             <th data-sorted="asc">Benchmark</th>
             <th>Status</th>
             <th data-sort-number>Build Rate</th>
@@ -72,6 +80,7 @@ td .signature {
     <tbody>
         {% for benchmark in benchmarks %}
         <tr>
+            <td class="table-index">{{ loop.index }}</td>
             <td data-sort-value="{{ benchmark.id }}">
                 <div class="project">{{ benchmark.project }}</div>
                 <pre class="signature">
@@ -96,6 +105,10 @@ td .signature {
         const sortAsc = th.dataset.sorted != "asc";
         const sortNumber = th.dataset.sortNumber != undefined;
 
+        // Move sorted data attribute to the right column
+        headers.map(innerTH => delete innerTH.dataset.sorted);
+        th.dataset.sorted = sortAsc ? "asc" : "desc";
+
         const tbody = document.querySelector('table.sortable-table tbody');
         const rows = Array.from(tbody.children);
         rows.sort((a, b) => {
@@ -111,9 +124,8 @@ td .signature {
             return valueA.localeCompare(valueB);
         });
         tbody.replaceChildren(...rows);
-        // Move sorted data attribute to the right column
-        headers.map(innerTH => delete innerTH.dataset.sorted);
-        th.dataset.sorted = sortAsc ? "asc" : "desc";
+        // Rewrite the index column
+        rows.map((r, i) => r.children[0].innerText = i+1);
     }));
 })();
 </script>

--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -1,20 +1,19 @@
-<!--
- Copyright 2024 Google LLC
+{#
+Copyright 2024 Google LLC
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-{% extends 'base.html' %}
+#}{% extends 'base.html' %}
 
 {% block content %}
 <h1>{{ benchmark }} / {{ sample.id }}</h1>

--- a/report/web.py
+++ b/report/web.py
@@ -83,7 +83,9 @@ class Benchmark:
           return function_signature
         if function_name.lower().startswith(self.function.lower()):
           if matched_prefix_signature:
-            logging.warning(f'Multiple substring matches found when looking for function name {function_name}')
+            logging.warning(
+                'Multiple substring matches found when looking for function '
+                'name %s', function_name)
           matched_prefix_signature = function_signature
 
     return matched_prefix_signature

--- a/report/web.py
+++ b/report/web.py
@@ -82,6 +82,8 @@ class Benchmark:
         if function_name.lower() == self.function.lower():
           return function_signature
         if function_name.lower().startswith(self.function.lower()):
+          if matched_prefix_signature:
+            logging.warning(f'Multiple substring matches found when looking for function name {function_name}')
           matched_prefix_signature = function_signature
 
     return matched_prefix_signature

--- a/report/web.py
+++ b/report/web.py
@@ -50,32 +50,41 @@ class Benchmark:
   status: str
   result: run_one_experiment.AggregatedResult
   signature: str = ''
+  project: str = ''
+  function: str = ''
 
   def __post_init__(self):
-    self.signature = self.find_signature(self.id) or self.id
+    self.project = '-'.join(self.id.split('-')[1:-1])
+    self.function = self.id.split('-')[-1]
+    self.signature = self.find_signature() or self.id
 
-  @staticmethod
-  def find_signature(benchmark_id: str) -> str:
+  def find_signature(self) -> str:
     """
     Finds the function signature by searching for its |benchmark_id| in
     BENCHMARK_DIR.
     """
-    if not BENCHMARK_DIR:
+    project_path = os.path.join(BENCHMARK_DIR, f'{self.project}.yaml')
+    if not BENCHMARK_DIR or not os.path.isfile(project_path):
       return ''
 
-    for project_yaml in os.listdir(BENCHMARK_DIR):
-      yaml_project_name = project_yaml.removesuffix(".yaml")
-      with open(os.path.join(BENCHMARK_DIR, project_yaml)) as project_yaml_file:
-        if yaml_project_name not in benchmark_id:
-          continue
-        functions = yaml.safe_load(project_yaml_file).get('functions', [])
-        for function in functions:
-          function_name = benchmark_id.removeprefix(
-              f'output-{yaml_project_name}-')
-          if function.get('name', '').lower().startswith(function_name):
-            return f'{yaml_project_name}-{function.get("signature", "")}'
+    matched_prefix_signature = ''
+    with open(project_path) as project_yaml_file:
+      functions = yaml.safe_load(project_yaml_file).get('functions', [])
+      for function in functions:
+        function_name = function.get('name', '')
+        function_signature = function.get('signature', '')
 
-    return ''
+        # Best match is a full match, but sometimes the result directory only
+        # has the first n characters of a long function name so a full match is
+        # not possible.
+        # To avoid returning early on a prefix match when there is a full match
+        # farther down the list, we only return the prefix match at the end.
+        if function_name.lower() == self.function.lower():
+          return function_signature
+        if function_name.lower().startswith(self.function.lower()):
+          matched_prefix_signature = function_signature
+
+    return matched_prefix_signature
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
* The tables are much prettier
* The index.html table has sortable columns
* The index.html table has an index column
* Fix a bug in the signature matching algorithm where it returned early on prefix matches.
* Prevent the licence to show up in the HTML (often multiple times).

Preview: 
![image](https://github.com/google/oss-fuzz-gen/assets/9994172/326f07b0-f5a1-488b-be55-150862284572)
