### PR TITLE
Fix incorrect build result with build success + semantic error

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -436,7 +436,8 @@ class Evaluator:
                  f'{self.builder_runner.fixer_model_name} in '
                  f'{llm_fix_count} iterations of syntax fixing.')
       return logger.return_result(
-          Result(False, False, 0.0, 0.0, '', '', False, semantic_check_result.type))
+          Result(False, False, 0.0, 0.0, '', '', False,
+                 semantic_check_result.type))
         
     logger.log(f'Successfully built {target_path} with '
                f'{self.builder_runner.fixer_model_name} in '
@@ -446,10 +447,12 @@ class Evaluator:
         run_result.coverage is None):
       logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
       return logger.return_result(
-          Result(True, crashes, 0.0, 0.0, '', '', False, semantic_check_result.type))
+          Result(True, crashes, 0.0, 0.0, '', '', False,
+                 semantic_check_result.type))
 
     if semantic_check_result.has_err:
-      logger.log(f'Warning: Failed to fix sematic error {semantic_check_result.type}'
+      logger.log(
+          f'Warning: Failed to fix sematic error {semantic_check_result.type}'
           f' in {generated_oss_fuzz_project}.')
       return logger.return_result(
           Result(True, crashes, 0.0, 0.0, run_result.coverage_report_path,

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -438,7 +438,7 @@ class Evaluator:
       return logger.return_result(
           Result(False, False, 0.0, 0.0, '', '', False,
                  semantic_check_result.type))
-        
+
     logger.log(f'Successfully built {target_path} with '
                f'{self.builder_runner.fixer_model_name} in '
                f'{llm_fix_count} iterations of syntax fixing.')

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -67,7 +67,7 @@ class Result:
   is_driver_fuzz_err: bool = dataclasses.field(kw_only=True, default=False)
   driver_fuzz_err: str = dataclasses.field(kw_only=True, default='')
 
-  def __post_init__(self, *args, **kwargs):
+  def __post_init__(self, *args, **kwargs):  # pylint: disable=unused-argument
     if self.is_driver_fuzz_err:
       self.is_semantic_error = self.is_driver_fuzz_err
     if self.driver_fuzz_err:
@@ -485,7 +485,7 @@ class Evaluator:
     return logger.return_result(
         Result(True, crashes, coverage_percent, coverage_diff,
                run_result.coverage_report_path, run_result.reproducer_path,
-               semantic_error.has_err, semantic_error.type))
+               semantic_check_result.has_err, semantic_check_result.type))
 
   def _load_existing_coverage_summary(self) -> dict:
     """Load existing summary.json."""

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -431,7 +431,7 @@ class Evaluator:
                                       semantic_error)
 
     # Logs and returns the result.
-    if gen_succ:
+    if build_result.succeeded:
       logger.log(f'Successfully built {target_path} with '
                  f'{self.builder_runner.fixer_model_name} in '
                  f'{llm_fix_count} iterations.')


### PR DESCRIPTION
The old code incorrectly treats a failure in fixing semantic errors as a failure in fixing build error, hence it incorrectly labels buildable but semantically wrong fuzz targets as not buildable.
PoE: https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-04-11-daily-comparison/benchmark/output-fribidi-fribidi_log2vis/index.html

This PR fixes it.
