### PR TITLE
Move semantic result to run result

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -29,6 +29,7 @@ from google.cloud import storage
 
 from experiment import oss_fuzz_checkout, textcov
 from experiment.benchmark import Benchmark
+from experiment.fuzz_target_error import SemanticCheckResult
 from experiment.workdir import WorkDirs
 from llm_toolkit import code_fixer
 from llm_toolkit.models import DefaultModel
@@ -38,6 +39,20 @@ JCC_DIR = '/usr/local/bin'
 
 RUN_TIMEOUT: int = 30
 CLOUD_EXP_MAX_ATTEMPT = 5
+
+LIBFUZZER_MODULES_LOADED_REGEX = re.compile(
+    r'^INFO:\s+Loaded\s+\d+\s+(modules|PC tables)\s+\((\d+)\s+.*\).*')
+LIBFUZZER_COV_REGEX = re.compile(r'.*cov: (\d+) ft:')
+LIBFUZZER_CRASH_TYPE_REGEX = re.compile(r'.*Test unit written to.*')
+LIBFUZZER_COV_LINE_PREFIX = re.compile(r'^#(\d+)')
+LIBFUZZER_STACK_FRAME_LINE_PREFIX = re.compile(r'^\s+#\d+')
+CRASH_EXCLUSIONS = re.compile(r'.*(slow-unit-|timeout-|leak-|oom-).*')
+CRASH_STACK_WITH_SOURCE_INFO = re.compile(r'in.*:\d+:\d+$')
+
+LIBFUZZER_LOG_STACK_FRAME_LLVM = '/src/llvm-project/compiler-rt'
+LIBFUZZER_LOG_STACK_FRAME_CPP = '/usr/local/bin/../include/c++'
+
+EARLY_FUZZING_ROUND_THRESHOLD = 3
 
 
 @dataclasses.dataclass
@@ -52,12 +67,17 @@ class BuildResult:
 
 @dataclasses.dataclass
 class RunResult:
+  succeeded: bool = False
   coverage_summary: dict = dataclasses.field(default_factory=dict)
   coverage: Optional[textcov.Textcov] = None
   log_path: str = ''
   corpus_path: str = ''
   coverage_report_path: str = ''
   reproducer_path: str = ''
+  cov_pcs: int = 0
+  total_pcs: int = 0
+  crashes: bool = False
+  semantic_check: SemanticCheckResult = SemanticCheckResult(SemanticCheckResult.NOT_APPLICABLE)
 
   def dict(self):
     return dataclasses.asdict(self)
@@ -119,6 +139,132 @@ class BuilderRunner:
       return False
     return True
 
+  def _parse_stacks_from_libfuzzer_logs(self,
+                                        lines: list[str]) -> list[list[str]]:
+    """Parse stack traces from libFuzzer logs."""
+    # TODO (dongge): Use stack parsing from ClusterFuzz.
+    # There can have over one thread stack in a log.
+    stacks = []
+
+    # A stack -> a sequence of stack frame lines.
+    stack, stack_parsing = [], False
+    for line in lines:
+      is_stack_frame_line = LIBFUZZER_STACK_FRAME_LINE_PREFIX.match(
+          line) is not None
+      if (not stack_parsing) and is_stack_frame_line:
+        # First line.
+        stack_parsing = True
+        stack = [line.strip()]
+      elif stack_parsing and is_stack_frame_line:
+        # Middle line(s).
+        stack.append(line.strip())
+      elif stack_parsing and (not is_stack_frame_line):
+        # Last line.
+        stack_parsing = False
+        stacks.append(stack)
+
+    # Last stack.
+    if stack_parsing:
+      stacks.append(stack)
+
+    return stacks
+
+  def _parse_fuzz_cov_info_from_libfuzzer_logs(
+      self,
+      lines: list[str]) -> tuple[Optional[int], Optional[int], Optional[int]]:
+    """Parses cov of INITED & DONE, and round number from libFuzzer logs."""
+    initcov, donecov, lastround = None, None, None
+
+    for line in lines:
+      if line.startswith('#'):
+        # Parses cov line to get the round number.
+        match = LIBFUZZER_COV_LINE_PREFIX.match(line)
+        roundno = int(match.group(1)) if match else None
+
+        if roundno is not None:
+          lastround = roundno
+          if 'INITED' in line:
+            initcov = int(line.split('cov: ')[1].split(' ft:')[0])
+          elif 'DONE' in line:
+            donecov = int(line.split('cov: ')[1].split(' ft:')[0])
+
+    return initcov, donecov, lastround
+
+  def _stack_func_is_of_testing_project(self, stack_frame: str) -> bool:
+    return (bool(CRASH_STACK_WITH_SOURCE_INFO.match(stack_frame)) and
+            LIBFUZZER_LOG_STACK_FRAME_LLVM not in stack_frame and
+            LIBFUZZER_LOG_STACK_FRAME_CPP not in stack_frame)
+
+  def _parse_libfuzzer_logs(self, log_handle) -> tuple[int, int, bool, SemanticCheckResult]:
+    """Parses libFuzzer logs."""
+    lines = None
+    try:
+      fuzzlog = log_handle.read(-1)
+      # Some crashes can mess up the libfuzzer output and raise decode error.
+      fuzzlog = fuzzlog.decode('utf-8', errors='ignore')
+      lines = fuzzlog.split('\n')
+    except MemoryError as e:
+      # Some logs from abnormal fuzz targets are too large to be parsed.
+      logging.error('%s is too large to parse: %s', log_handle.name, e)
+      return 0, 0, False, SemanticCheckResult(SemanticCheckResult.LOG_MESS_UP)
+
+    cov_pcs, total_pcs, crashes = 0, 0, False
+
+    for line in lines:
+      m = LIBFUZZER_MODULES_LOADED_REGEX.match(line)
+      if m:
+        total_pcs = int(m.group(2))
+        continue
+
+      m = LIBFUZZER_COV_REGEX.match(line)
+      if m:
+        cov_pcs = int(m.group(1))
+        continue
+
+      m = LIBFUZZER_CRASH_TYPE_REGEX.match(line)
+      if m and not CRASH_EXCLUSIONS.match(line):
+        crashes = True
+        continue
+
+    initcov, donecov, lastround = self._parse_fuzz_cov_info_from_libfuzzer_logs(
+        lines)
+
+    # NOTE: Crashes from incorrect fuzz targets will not be counted finally.
+
+    if crashes:
+      symptom = SemanticCheckResult.extract_symptom(fuzzlog)
+      crash_stacks = self._parse_stacks_from_libfuzzer_logs(lines)
+
+      # FP case 1: fuzz target crashes at init or first few rounds.
+      if lastround is None or lastround <= EARLY_FUZZING_ROUND_THRESHOLD:
+        # No cov line has been identified or only INITED round has been passed.
+        # This is very likely the false positive cases.
+        return cov_pcs, total_pcs, True, \
+               SemanticCheckResult(SemanticCheckResult.FP_NEAR_INIT_CRASH,\
+                             symptom, crash_stacks)
+
+      # FP case 2: 1st func of the 1st thread stack is in fuzz target.
+      if len(crash_stacks) > 0:
+        first_stack = crash_stacks[0]
+        # Check the first stack frame of the first stack only.
+        for stack_frame in first_stack[:1]:
+          if self._stack_func_is_of_testing_project(stack_frame):
+            if 'LLVMFuzzerTestOneInput' in stack_frame:
+              return cov_pcs, total_pcs, True, \
+                     SemanticCheckResult(SemanticCheckResult.FP_TARGET_CRASH,\
+                                   symptom, crash_stacks)
+            break
+
+    else:
+      # Another error fuzz target case: no cov increase.
+      if initcov is not None and donecov is not None:
+        if initcov == donecov:
+          return cov_pcs, total_pcs, True, SemanticCheckResult(
+              SemanticCheckResult.NO_COV_INCREASE)
+
+    return cov_pcs, total_pcs, crashes, SemanticCheckResult(
+        SemanticCheckResult.NO_SEMANTIC_ERR)
+
   def build_and_run(self, generated_project: str, target_path: str,
                     iteration: int) -> tuple[BuildResult, Optional[RunResult]]:
     """Builds and runs the fuzz target for fuzzing."""
@@ -144,6 +290,12 @@ class BuilderRunner:
         self.work_dirs.run_logs_target(benchmark_target_name, iteration))
     run_result.coverage, run_result.coverage_summary = (self.get_coverage_local(
         generated_project, benchmark_target_name))
+
+    # Parse libfuzzer logs to get fuzz target runtime details.
+    with open(self.work_dirs.run_logs_target(benchmark_target_name, iteration), 'rb') as f:
+      run_result.cov_pcs, run_result.total_pcs, run_result.crashes, run_result.semantic_check = self._parse_libfuzzer_logs(f)
+      run_result.succeeded = not run_result.semantic_check.has_err
+
     return build_result, run_result
 
   def run_target_local(self, generated_project: str, benchmark_target_name: str,
@@ -486,6 +638,11 @@ class CloudBuilderRunner(BuilderRunner):
                 # Don't include other functions defined in the target code.
                 re.compile(r'^' + re.escape(target_basename) + ':')
             ])
+
+    # Parse libfuzzer logs to get fuzz target runtime details.
+    with open(self.work_dirs.run_logs_target(generated_target_name, iteration), 'rb') as f:
+      run_result.cov_pcs, run_result.total_pcs, run_result.crashes, run_result.semantic_check = self._parse_libfuzzer_logs(f)
+      run_result.succeeded = not run_result.semantic_check.has_err
 
     return build_result, run_result
 

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -57,6 +57,8 @@ EARLY_FUZZING_ROUND_THRESHOLD = 3
 
 @dataclasses.dataclass
 class BuildResult:
+  """Results of compilation & link."""
+
   succeeded: bool = False
   errors: list[str] = dataclasses.field(default_factory=list)
   log_path: str = ''
@@ -67,6 +69,8 @@ class BuildResult:
 
 @dataclasses.dataclass
 class RunResult:
+  """Checked results of conducting short-term fuzzing."""
+
   succeeded: bool = False
   coverage_summary: dict = dataclasses.field(default_factory=dict)
   coverage: Optional[textcov.Textcov] = None
@@ -77,7 +81,8 @@ class RunResult:
   cov_pcs: int = 0
   total_pcs: int = 0
   crashes: bool = False
-  semantic_check: SemanticCheckResult = SemanticCheckResult(SemanticCheckResult.NOT_APPLICABLE)
+  semantic_check: SemanticCheckResult = SemanticCheckResult(
+      SemanticCheckResult.NOT_APPLICABLE)
 
   def dict(self):
     return dataclasses.asdict(self)
@@ -195,7 +200,8 @@ class BuilderRunner:
             LIBFUZZER_LOG_STACK_FRAME_LLVM not in stack_frame and
             LIBFUZZER_LOG_STACK_FRAME_CPP not in stack_frame)
 
-  def _parse_libfuzzer_logs(self, log_handle) -> tuple[int, int, bool, SemanticCheckResult]:
+  def _parse_libfuzzer_logs(
+      self, log_handle) -> tuple[int, int, bool, SemanticCheckResult]:
     """Parses libFuzzer logs."""
     lines = None
     try:
@@ -292,8 +298,10 @@ class BuilderRunner:
         generated_project, benchmark_target_name))
 
     # Parse libfuzzer logs to get fuzz target runtime details.
-    with open(self.work_dirs.run_logs_target(benchmark_target_name, iteration), 'rb') as f:
-      run_result.cov_pcs, run_result.total_pcs, run_result.crashes, run_result.semantic_check = self._parse_libfuzzer_logs(f)
+    with open(self.work_dirs.run_logs_target(benchmark_target_name, iteration),
+              'rb') as f:
+      run_result.cov_pcs, run_result.total_pcs, run_result.crashes, \
+                run_result.semantic_check = self._parse_libfuzzer_logs(f)
       run_result.succeeded = not run_result.semantic_check.has_err
 
     return build_result, run_result
@@ -640,8 +648,10 @@ class CloudBuilderRunner(BuilderRunner):
             ])
 
     # Parse libfuzzer logs to get fuzz target runtime details.
-    with open(self.work_dirs.run_logs_target(generated_target_name, iteration), 'rb') as f:
-      run_result.cov_pcs, run_result.total_pcs, run_result.crashes, run_result.semantic_check = self._parse_libfuzzer_logs(f)
+    with open(self.work_dirs.run_logs_target(generated_target_name, iteration),
+              'rb') as f:
+      run_result.cov_pcs, run_result.total_pcs, run_result.crashes, \
+                  run_result.semantic_check = self._parse_libfuzzer_logs(f)
       run_result.succeeded = not run_result.semantic_check.has_err
 
     return build_result, run_result

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -35,6 +35,7 @@ LLM_FIX_LIMIT = 5
 
 OSS_FUZZ_COVERAGE_BUCKET = 'oss-fuzz-coverage'
 
+
 @dataclasses.dataclass
 class Result:
   """Evaluation result."""
@@ -214,7 +215,8 @@ class Evaluator:
       if run_result:
         error_desc, errors = run_result.semantic_check.get_error_info()
       else:
-        logger.log(f'Warning: Build succeed but no run_result in {generated_oss_fuzz_project}.')
+        logger.log(f'Warning: Build succeed but no run_result in '
+                   f'{generated_oss_fuzz_project}.')
         error_desc, errors = '', []
     else:
       error_desc, errors = None, build_result.errors
@@ -247,7 +249,8 @@ class Evaluator:
     llm_fix_count = 0
     while True:
       # 1. Evaluating generated driver.
-      build_result, run_result = self.builder_runner.build_and_run(generated_oss_fuzz_project, target_path, llm_fix_count)
+      build_result, run_result = self.builder_runner.build_and_run(
+          generated_oss_fuzz_project, target_path, llm_fix_count)
 
       gen_succ = build_result.succeeded and run_result and run_result.succeeded
       if gen_succ or llm_fix_count >= LLM_FIX_LIMIT:
@@ -269,7 +272,9 @@ class Evaluator:
       logger.log(f'Failed to build {target_path} with '
                  f'{self.builder_runner.fixer_model_name} in '
                  f'{llm_fix_count} iterations of syntax fixing.')
-      return logger.return_result(Result(False, False, 0.0, 0.0, '', '', False, SemanticCheckResult.NOT_APPLICABLE))
+      return logger.return_result(
+          Result(False, False, 0.0, 0.0, '', '', False,
+                 SemanticCheckResult.NOT_APPLICABLE))
 
     logger.log(f'Successfully built {target_path} with '
                f'{self.builder_runner.fixer_model_name} in '
@@ -277,20 +282,24 @@ class Evaluator:
 
     if not run_result:
       logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
-      return logger.return_result(Result(True, False, 0.0, 0.0, '', '', False, SemanticCheckResult.NOT_APPLICABLE))
+      return logger.return_result(
+          Result(True, False, 0.0, 0.0, '', '', False,
+                 SemanticCheckResult.NOT_APPLICABLE))
 
     if run_result.coverage_summary is None or run_result.coverage is None:
       logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
-      return logger.return_result(Result(True, run_result.crashes, 0.0, 0.0, '', '', False, run_result.semantic_check.type))
+      return logger.return_result(
+          Result(True, run_result.crashes, 0.0, 0.0, '', '', False,
+                 run_result.semantic_check.type))
 
     if not run_result.succeeded:
-      logger.log(
-          f'Warning: Failed to fix semantic error {run_result.semantic_check.type}'
-          f' in {generated_oss_fuzz_project}.')
+      logger.log(f'Warning: Failed to fix semantic error '
+                 f'{run_result.semantic_check.type}'
+                 f' in {generated_oss_fuzz_project}.')
       return logger.return_result(
-          Result(True, run_result.crashes, 0.0, 0.0, run_result.coverage_report_path,
-                 run_result.reproducer_path, True,
-                 run_result.semantic_check.type))
+          Result(True, run_result.crashes, 0.0, 0.0,
+                 run_result.coverage_report_path, run_result.reproducer_path,
+                 True, run_result.semantic_check.type))
 
     # Gets line coverage (diff) details.
     coverage_summary = self._load_existing_coverage_summary()
@@ -311,8 +320,9 @@ class Evaluator:
       logger.log(f'Warning: total_lines == 0 in {generated_oss_fuzz_project}.')
       coverage_diff = 0.0
 
-    logger.log(f'Result for {generated_oss_fuzz_project}: crashes={run_result.crashes}, '
-               f'coverage={coverage_percent} ({run_result.cov_pcs}/{run_result.total_pcs}), '
+    logger.log(f'Result for {generated_oss_fuzz_project}: '
+               f'crashes={run_result.crashes}, coverage={coverage_percent} '
+               f'({run_result.cov_pcs}/{run_result.total_pcs}), '
                f'coverage diff={coverage_diff} '
                f'({run_result.coverage.covered_lines}/{total_lines})')
     return logger.return_result(

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -33,22 +33,7 @@ from llm_toolkit import code_fixer
 
 LLM_FIX_LIMIT = 5
 
-LIBFUZZER_MODULES_LOADED_REGEX = re.compile(
-    r'^INFO:\s+Loaded\s+\d+\s+(modules|PC tables)\s+\((\d+)\s+.*\).*')
-LIBFUZZER_COV_REGEX = re.compile(r'.*cov: (\d+) ft:')
-LIBFUZZER_CRASH_TYPE_REGEX = re.compile(r'.*Test unit written to.*')
-LIBFUZZER_COV_LINE_PREFIX = re.compile(r'^#(\d+)')
-LIBFUZZER_STACK_FRAME_LINE_PREFIX = re.compile(r'^\s+#\d+')
-CRASH_EXCLUSIONS = re.compile(r'.*(slow-unit-|timeout-|leak-|oom-).*')
-CRASH_STACK_WITH_SOURCE_INFO = re.compile(r'in.*:\d+:\d+$')
-
 OSS_FUZZ_COVERAGE_BUCKET = 'oss-fuzz-coverage'
-
-LIBFUZZER_LOG_STACK_FRAME_LLVM = '/src/llvm-project/compiler-rt'
-LIBFUZZER_LOG_STACK_FRAME_CPP = '/usr/local/bin/../include/c++'
-
-EARLY_FUZZING_ROUND_THRESHOLD = 3
-
 
 @dataclasses.dataclass
 class Result:
@@ -218,164 +203,19 @@ class Evaluator:
       traceback.print_exc()
       return None
 
-  def _parse_stacks_from_libfuzzer_logs(self,
-                                        lines: list[str]) -> list[list[str]]:
-    """Parse stack traces from libFuzzer logs."""
-    # TODO (dongge): Use stack parsing from ClusterFuzz.
-    # There can have over one thread stack in a log.
-    stacks = []
-
-    # A stack -> a sequence of stack frame lines.
-    stack, stack_parsing = [], False
-    for line in lines:
-      is_stack_frame_line = LIBFUZZER_STACK_FRAME_LINE_PREFIX.match(
-          line) is not None
-      if (not stack_parsing) and is_stack_frame_line:
-        # First line.
-        stack_parsing = True
-        stack = [line.strip()]
-      elif stack_parsing and is_stack_frame_line:
-        # Middle line(s).
-        stack.append(line.strip())
-      elif stack_parsing and (not is_stack_frame_line):
-        # Last line.
-        stack_parsing = False
-        stacks.append(stack)
-
-    # Last stack.
-    if stack_parsing:
-      stacks.append(stack)
-
-    return stacks
-
-  def _parse_fuzz_cov_info_from_libfuzzer_logs(
-      self,
-      lines: list[str]) -> tuple[Optional[int], Optional[int], Optional[int]]:
-    """Parses cov of INITED & DONE, and round number from libFuzzer logs."""
-    initcov, donecov, lastround = None, None, None
-
-    for line in lines:
-      if line.startswith('#'):
-        # Parses cov line to get the round number.
-        match = LIBFUZZER_COV_LINE_PREFIX.match(line)
-        roundno = int(match.group(1)) if match else None
-
-        if roundno is not None:
-          lastround = roundno
-          if 'INITED' in line:
-            initcov = int(line.split('cov: ')[1].split(' ft:')[0])
-          elif 'DONE' in line:
-            donecov = int(line.split('cov: ')[1].split(' ft:')[0])
-
-    return initcov, donecov, lastround
-
-  def _stack_func_is_of_testing_project(self, stack_frame: str) -> bool:
-    return (bool(CRASH_STACK_WITH_SOURCE_INFO.match(stack_frame)) and
-            LIBFUZZER_LOG_STACK_FRAME_LLVM not in stack_frame and
-            LIBFUZZER_LOG_STACK_FRAME_CPP not in stack_frame)
-
-  def _parse_libfuzzer_logs(
-      self, log_handle,
-      logger: _Logger) -> tuple[int, int, bool, SemanticCheckResult]:
-    """Parses libFuzzer logs."""
-    lines = None
-    try:
-      fuzzlog = log_handle.read(-1)
-      # Some crashes can mess up the libfuzzer output and raise decode error.
-      fuzzlog = fuzzlog.decode('utf-8', errors='ignore')
-      lines = fuzzlog.split('\n')
-    except MemoryError as e:
-      # Some logs from abnormal fuzz targets are too large to be parsed.
-      logger.log('%s is too large to parse: %s', log_handle.name, e)
-      return 0, 0, False, SemanticCheckResult(SemanticCheckResult.LOG_MESS_UP)
-
-    cov_pcs, total_pcs, crashes = 0, 0, False
-
-    for line in lines:
-      m = LIBFUZZER_MODULES_LOADED_REGEX.match(line)
-      if m:
-        total_pcs = int(m.group(2))
-        continue
-
-      m = LIBFUZZER_COV_REGEX.match(line)
-      if m:
-        cov_pcs = int(m.group(1))
-        continue
-
-      m = LIBFUZZER_CRASH_TYPE_REGEX.match(line)
-      if m and not CRASH_EXCLUSIONS.match(line):
-        crashes = True
-        continue
-
-    initcov, donecov, lastround = self._parse_fuzz_cov_info_from_libfuzzer_logs(
-        lines)
-
-    # NOTE: Crashes from incorrect fuzz targets will not be counted finally.
-
-    if crashes:
-      symptom = SemanticCheckResult.extract_symptom(fuzzlog)
-      crash_stacks = self._parse_stacks_from_libfuzzer_logs(lines)
-
-      # FP case 1: fuzz target crashes at init or first few rounds.
-      if lastround is None or lastround <= EARLY_FUZZING_ROUND_THRESHOLD:
-        # No cov line has been identified or only INITED round has been passed.
-        # This is very likely the false positive cases.
-        return cov_pcs, total_pcs, True, \
-               SemanticCheckResult(SemanticCheckResult.FP_NEAR_INIT_CRASH,\
-                             symptom, crash_stacks)
-
-      # FP case 2: 1st func of the 1st thread stack is in fuzz target.
-      if len(crash_stacks) > 0:
-        first_stack = crash_stacks[0]
-        # Check the first stack frame of the first stack only.
-        for stack_frame in first_stack[:1]:
-          if self._stack_func_is_of_testing_project(stack_frame):
-            if 'LLVMFuzzerTestOneInput' in stack_frame:
-              return cov_pcs, total_pcs, True, \
-                     SemanticCheckResult(SemanticCheckResult.FP_TARGET_CRASH,\
-                                   symptom, crash_stacks)
-            break
-
-    else:
-      # Another error fuzz target case: no cov increase.
-      if initcov is not None and donecov is not None:
-        if initcov == donecov:
-          return cov_pcs, total_pcs, True, SemanticCheckResult(
-              SemanticCheckResult.NO_COV_INCREASE)
-
-    return cov_pcs, total_pcs, crashes, SemanticCheckResult(
-        SemanticCheckResult.NO_SEMANTIC_ERR)
-
-  def _evaluate_generated_fuzz_target(
-      self, generated_oss_fuzz_project: str, target_path: str,
-      generated_target_name: str, iteration: int, logger: _Logger
-  ) -> tuple[BuildResult, Optional[RunResult], int, int, bool,
-             SemanticCheckResult]:
-    """Evaluates the generated fuzz target."""
-    build_result, run_result = self.builder_runner.build_and_run(
-        generated_oss_fuzz_project, target_path, iteration)
-
-    if not build_result.succeeded:
-      # Clear the variables for case that fuzz/build err <=> before/after fix.
-      return build_result, run_result, 0, 0, False, SemanticCheckResult(
-          SemanticCheckResult.NOT_APPLICABLE)
-
-    # Parse libfuzzer logs to get fuzz target runtime details.
-    with open(self.work_dirs.run_logs_target(generated_target_name, iteration),
-              'rb') as f:
-      cov_pcs, total_pcs, crashes, semantic_error = self._parse_libfuzzer_logs(
-          f, logger)
-
-    return build_result, run_result, cov_pcs, total_pcs, crashes, semantic_error
-
   def _fix_generated_fuzz_target(self, ai_binary: str,
                                  generated_oss_fuzz_project: str,
                                  target_path: str, iteration: int,
                                  build_result: BuildResult,
-                                 semantic_error: SemanticCheckResult):
+                                 run_result: Optional[RunResult],
+                                 logger: _Logger):
     """Fixes the generated fuzz target."""
     if build_result.succeeded:
-      error_desc, errors = semantic_error.get_error_info()
+      if run_result:
+        error_desc, errors = run_result.semantic_check.get_error_info()
+      else:
+        logger.log(f'Warning: Build succeed but no run_result in {generated_oss_fuzz_project}.')
+        error_desc, errors = '', []
     else:
       error_desc, errors = None, build_result.errors
     code_fixer.llm_fix(ai_binary, target_path, self.benchmark, iteration,
@@ -407,18 +247,12 @@ class Evaluator:
     llm_fix_count = 0
     while True:
       # 1. Evaluating generated driver.
-      (build_result, run_result, cov_pcs, total_pcs, crashes,
-       semantic_check_result) = self._evaluate_generated_fuzz_target(
-           generated_oss_fuzz_project, target_path, generated_target_name,
-           llm_fix_count, logger)
+      build_result, run_result = self.builder_runner.build_and_run(generated_oss_fuzz_project, target_path, llm_fix_count)
 
-      gen_succ = build_result.succeeded and not semantic_check_result.has_err
-      if gen_succ:
-        # Successfully generate the fuzz target.
-        break
-
-      if llm_fix_count >= LLM_FIX_LIMIT:
-        # Not fix since the fix limit is reached.
+      gen_succ = build_result.succeeded and run_result and run_result.succeeded
+      if gen_succ or llm_fix_count >= LLM_FIX_LIMIT:
+        # Exit cond 1: successfully generate the fuzz target.
+        # Exit cond 2: fix limit is reached.
         break
 
       # 2. Fixing generated driver.
@@ -428,43 +262,42 @@ class Evaluator:
                  f'attempt {llm_fix_count}.')
       self._fix_generated_fuzz_target(ai_binary, generated_oss_fuzz_project,
                                       target_path, llm_fix_count, build_result,
-                                      semantic_check_result)
+                                      run_result, logger)
 
     # Logs and returns the result.
     if not build_result.succeeded:
       logger.log(f'Failed to build {target_path} with '
                  f'{self.builder_runner.fixer_model_name} in '
                  f'{llm_fix_count} iterations of syntax fixing.')
-      return logger.return_result(
-          Result(False, False, 0.0, 0.0, '', '', False,
-                 semantic_check_result.type))
+      return logger.return_result(Result(False, False, 0.0, 0.0, '', '', False, SemanticCheckResult.NOT_APPLICABLE))
 
     logger.log(f'Successfully built {target_path} with '
                f'{self.builder_runner.fixer_model_name} in '
                f'{llm_fix_count} iterations of syntax fixing.')
 
-    if (not run_result or run_result.coverage_summary is None or
-        run_result.coverage is None):
+    if not run_result:
       logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
-      return logger.return_result(
-          Result(True, crashes, 0.0, 0.0, '', '', False,
-                 semantic_check_result.type))
+      return logger.return_result(Result(True, False, 0.0, 0.0, '', '', False, SemanticCheckResult.NOT_APPLICABLE))
 
-    if semantic_check_result.has_err:
+    if run_result.coverage_summary is None or run_result.coverage is None:
+      logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
+      return logger.return_result(Result(True, run_result.crashes, 0.0, 0.0, '', '', False, run_result.semantic_check.type))
+
+    if not run_result.succeeded:
       logger.log(
-          f'Warning: Failed to fix sematic error {semantic_check_result.type}'
+          f'Warning: Failed to fix semantic error {run_result.semantic_check.type}'
           f' in {generated_oss_fuzz_project}.')
       return logger.return_result(
-          Result(True, crashes, 0.0, 0.0, run_result.coverage_report_path,
-                 run_result.reproducer_path, semantic_check_result.has_err,
-                 semantic_check_result.type))
+          Result(True, run_result.crashes, 0.0, 0.0, run_result.coverage_report_path,
+                 run_result.reproducer_path, True,
+                 run_result.semantic_check.type))
 
     # Gets line coverage (diff) details.
     coverage_summary = self._load_existing_coverage_summary()
     total_lines = _compute_total_lines_without_fuzz_targets(
         coverage_summary, generated_target_name)
-    if total_pcs:
-      coverage_percent = cov_pcs / total_pcs
+    if run_result.total_pcs:
+      coverage_percent = run_result.cov_pcs / run_result.total_pcs
     else:
       logger.log(f'Warning: total_pcs == 0 in {generated_oss_fuzz_project}.')
       coverage_percent = 0.0
@@ -478,14 +311,14 @@ class Evaluator:
       logger.log(f'Warning: total_lines == 0 in {generated_oss_fuzz_project}.')
       coverage_diff = 0.0
 
-    logger.log(f'Result for {generated_oss_fuzz_project}: crashes={crashes}, '
-               f'coverage={coverage_percent} ({cov_pcs}/{total_pcs}), '
+    logger.log(f'Result for {generated_oss_fuzz_project}: crashes={run_result.crashes}, '
+               f'coverage={coverage_percent} ({run_result.cov_pcs}/{run_result.total_pcs}), '
                f'coverage diff={coverage_diff} '
                f'({run_result.coverage.covered_lines}/{total_lines})')
     return logger.return_result(
-        Result(True, crashes, coverage_percent, coverage_diff,
+        Result(True, run_result.crashes, coverage_percent, coverage_diff,
                run_result.coverage_report_path, run_result.reproducer_path,
-               semantic_check_result.has_err, semantic_check_result.type))
+               not run_result.succeeded, run_result.semantic_check.type))
 
   def _load_existing_coverage_summary(self) -> dict:
     """Load existing summary.json."""

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -281,13 +281,15 @@ class Evaluator:
                f'{llm_fix_count} iterations of syntax fixing.')
 
     if not run_result:
-      logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
+      logger.log(f'Warning: no run result in {generated_oss_fuzz_project}.')
       return logger.return_result(
           Result(True, False, 0.0, 0.0, '', '', False,
                  SemanticCheckResult.NOT_APPLICABLE))
 
     if run_result.coverage_summary is None or run_result.coverage is None:
-      logger.log(f'Warning: No run_result in {generated_oss_fuzz_project}.')
+      logger.log(
+          f'Warning: No cov info in run result of {generated_oss_fuzz_project}.'
+      )
       return logger.return_result(
           Result(True, run_result.crashes, 0.0, 0.0, '', '', False,
                  run_result.semantic_check.type))


### PR DESCRIPTION
This is an initial attempt to move semantic result into run result (mentioned in [PR 204 comments](https://github.com/google/oss-fuzz-gen/pull/204#discussion_r1555217940)):
- the run and fix loop in `do_check_target` function is simplified
- log parsing logic (originally in `do_check_target`) is moved into the `BuilderRunner` class
- now `SemanticCheckResult` is a member of `RunResult`

Please told me if there is any further improvement idea for the refactor!