### PR TITLE
Fix crash.json page in report.

### DIFF
--- a/report/templates/benchmark.html
+++ b/report/templates/benchmark.html
@@ -30,7 +30,7 @@ td, th {
         <th>Builds</th>
         <th>Crashes</th>
         <th>Bug</th>
-        <th>Crash reason</th>
+        <th>Diagnosis</th>
         <th>Coverage</th>
         <th>Line coverage diff</th>
     </tr>

--- a/report/templates/crash.json
+++ b/report/templates/crash.json
@@ -16,7 +16,7 @@
         "target_binary": "{{ sample.target_binary }}",
         "reproducer": "{{ sample.reproducer }}",
         "run_log": "{{ sample.run_log }}",
-        "source_code": {{ get_benchmark_final_target_code(sample.id) }},
+        "source_code": {{ get_benchmark_final_target_code(sample.id) | replace('\\n', '\\\\n')}},
         "model": "{{ model }}"
     }{% if not loop.last %},{% endif %}
 {% endfor %}

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -82,9 +82,12 @@ while true; do
   gsutil -q -m -h "Content-Type:text/html" \
          -h "Cache-Control:public, max-age=3600" \
          cp -r . "$BUCKET_PATH"
-  # Upload JSONs.
-  find . -name '*.json' -exec gsutil -q -m -h "Content-Type:application/json" \
-    -h "Cache-Control:public, max-age=3600" cp "{}" "${BUCKET_PATH}/{}" \;
+  # Find all JSON files and upload them, removing the leading './'
+  find . -name '*.json' | while read -r file; do
+    file_path="${file#./}"  # Remove the leading "./".
+    gsutil -q -m -h "Content-Type:application/json" \
+        -h "Cache-Control:public, max-age=3600" cp "$file" "$BUCKET_PATH/$file_path"
+  done
 
   cd ..
 

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -80,6 +80,9 @@ while true; do
   gsutil -q -m -h "Content-Type:text/html" \
          -h "Cache-Control:public, max-age=3600" \
          cp -r . "gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/${GCS_DIR:?}"
+  gsutil -q -m -h "Content-Type:application/json" \
+         -h "Cache-Control:public, max-age=3600" \
+         cp -r "./**/*.json" "gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/${GCS_DIR:?}"
 
   cd ..
 

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -77,12 +77,14 @@ while true; do
 
   # Upload the report to GCS.
   echo "Uploading the report."
+  BUCKET_PATH="gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/${GCS_DIR:?}"
+  # Upload HTMLs.
   gsutil -q -m -h "Content-Type:text/html" \
          -h "Cache-Control:public, max-age=3600" \
-         cp -r . "gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/${GCS_DIR:?}"
-  gsutil -q -m -h "Content-Type:application/json" \
-         -h "Cache-Control:public, max-age=3600" \
-         cp -r "./**/*.json" "gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/${GCS_DIR:?}"
+         cp -r . "$BUCKET_PATH"
+  # Upload JSONs.
+  find . -name '*.json' -exec gsutil -q -m -h "Content-Type:application/json" \
+    -h "Cache-Control:public, max-age=3600" cp "{}" "${BUCKET_PATH}/{}" \;
 
   cd ..
 

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -65,12 +65,8 @@ while true; do
   echo "Download results from localhost."
   wget2 --quiet --inet4-only --no-host-directories --http2-request-window 10 --recursive localhost:${WEB_PORT:?}/ 2>&1
 
-  # Also fetch the sorted reports.
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_build -O sort/build 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_cov -O sort/cov 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_cov_diff -O sort/cov_diff 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_crash -O sort/crash 2>&1
-  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/sort_status -O sort/status 2>&1
+  # Also fetch index JSON.
+  wget2 --quiet --inet4-only localhost:${WEB_PORT:?}/json -O json 2>&1
 
   # Stop the server.
   kill -9 "$pid_web"

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -79,7 +79,7 @@ while true; do
          -h "Cache-Control:public, max-age=3600" \
          cp -r . "$BUCKET_PATH"
   # Find all JSON files and upload them, removing the leading './'
-  find . -name '*.json' | while read -r file; do
+  find . -name '*json' | while read -r file; do
     file_path="${file#./}"  # Remove the leading "./".
     gsutil -q -m -h "Content-Type:application/json" \
         -h "Cache-Control:public, max-age=3600" cp "$file" "$BUCKET_PATH/$file_path"

--- a/report/web.py
+++ b/report/web.py
@@ -442,7 +442,7 @@ def benchmark_json(benchmark: str):
     abort(404)
 
   try:
-    return render_template('benchmark.json',
+    return render_template('crash.json',
                            benchmark=match_benchmark(benchmark).signature,
                            samples=get_samples(benchmark),
                            get_benchmark_final_target_code=partial(

--- a/report/web.py
+++ b/report/web.py
@@ -96,7 +96,7 @@ class Sample:
   """Result of a fuzz target sample of a benchmark."""
   id: str
   status: str
-  result: Optional[evaluator.Result] = None
+  result: evaluator.Result
 
   @property
   def stacktrace(self) -> str:
@@ -260,7 +260,7 @@ def get_samples(benchmark: str) -> list[Sample]:
 
   for i, sample_id in enumerate(sample_ids(get_generated_targets(benchmark))):
     status = 'Running'
-    result = None
+    result = evaluator.Result()
     if results[i]:
       status = 'Done'
       result = results[i]
@@ -278,7 +278,7 @@ def match_sample(benchmark: str, target_sample_id: str) -> Optional[Sample]:
     if sample_id != target_sample_id:
       continue
     status = 'Running'
-    result = None
+    result = evaluator.Result()
     if results[i]:
       status = 'Done'
       result = results[i]

--- a/report/web.py
+++ b/report/web.py
@@ -239,20 +239,6 @@ def match_benchmark(benchmark_id: str) -> Benchmark:
   return Benchmark(benchmark_id, status, result)
 
 
-def sort_benchmarks(benchmarks: List[Benchmark],
-                    sort_by: str = 'cov_diff') -> List[Benchmark]:
-  """Keeps benchmarks with the highest line coverage diff on the top."""
-  sort_dict = {
-      'build': lambda b: b.result.build_success_rate,
-      'crash': lambda b: b.result.crash_rate,
-      'cov': lambda b: b.result.max_coverage,
-      'status': lambda b: b.status,
-      'cov_diff': lambda b: b.result.max_line_coverage_diff,
-  }
-  sorted_benchmarks = sorted(benchmarks, key=sort_dict[sort_by], reverse=True)
-  return sorted_benchmarks
-
-
 def get_samples(benchmark: str) -> list[Sample]:
   """Gets the samples and their status of the given benchmark |bnmk|."""
   samples = []
@@ -394,46 +380,6 @@ def index_json():
                          model=model), 200, {
                              'Content-Type': 'application/json'
                          }
-
-
-@app.route('/sort_build')
-def index_sort_build():
-  return render_template('index.html',
-                         benchmarks=sort_benchmarks(list_benchmarks(),
-                                                    sort_by='build'),
-                         model=model)
-
-
-@app.route('/sort_cov')
-def index_sort_cov():
-  return render_template('index.html',
-                         benchmarks=sort_benchmarks(list_benchmarks(),
-                                                    sort_by='cov'),
-                         model=model)
-
-
-@app.route('/sort_cov_diff')
-def index_sort():
-  return render_template('index.html',
-                         benchmarks=sort_benchmarks(list_benchmarks(),
-                                                    sort_by='cov_diff'),
-                         model=model)
-
-
-@app.route('/sort_crash')
-def index_sort_crash():
-  return render_template('index.html',
-                         benchmarks=sort_benchmarks(list_benchmarks(),
-                                                    sort_by='crash'),
-                         model=model)
-
-
-@app.route('/sort_status')
-def index_sort_stauts():
-  return render_template('index.html',
-                         benchmarks=sort_benchmarks(list_benchmarks(),
-                                                    sort_by='status'),
-                         model=model)
 
 
 @app.route('/benchmark/<benchmark>/crash.json')

--- a/report/web.py
+++ b/report/web.py
@@ -391,7 +391,9 @@ def index():
 def index_json():
   return render_template('index.json',
                          benchmarks=list_benchmarks(),
-                         model=model)
+                         model=model), 200, {
+                             'Content-Type': 'application/json'
+                         }
 
 
 @app.route('/sort_build')
@@ -447,7 +449,9 @@ def benchmark_json(benchmark: str):
                            samples=get_samples(benchmark),
                            get_benchmark_final_target_code=partial(
                                get_final_target_code, benchmark),
-                           model=model)
+                           model=model), 200, {
+                               'Content-Type': 'application/json'
+                           }
   except Exception as e:
     logging.warning('Failed to render benchmark crash JSON: %s\n  %s',
                     benchmark, e)


### PR DESCRIPTION
Current reports fail to generate `crash.json` page because `benchmark_json()` misuses its parameter `benchmark` (a `str`) as a `Benchmark` class.

This PR fixes it by adding a new function to generate `Benchmark()` with the `benchmark` string.

The PR also adds the missing index JSON, and removes outdated sorting pages.