### PR TITLE
Capturing `null-deref` as a semantic error 

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -245,7 +245,13 @@ class BuilderRunner:
       symptom = SemanticCheckResult.extract_symptom(fuzzlog)
       crash_stacks = self._parse_stacks_from_libfuzzer_logs(lines)
 
-      # FP case 1: fuzz target crashes at init or first few rounds.
+      # FP case 1: Null-deref, normally indicating inadequate parameter
+      # initialization or wrong function usage.
+      if symptom == 'null-deref':
+        return cov_pcs, total_pcs, True, SemanticCheckResult(
+            SemanticCheckResult.NULL_DEREF, symptom, crash_stacks)
+
+      # FP case 2: fuzz target crashes at init or first few rounds.
       if lastround is None or lastround <= EARLY_FUZZING_ROUND_THRESHOLD:
         # No cov line has been identified or only INITED round has been passed.
         # This is very likely the false positive cases.
@@ -253,7 +259,7 @@ class BuilderRunner:
                SemanticCheckResult(SemanticCheckResult.FP_NEAR_INIT_CRASH,\
                              symptom, crash_stacks)
 
-      # FP case 2: 1st func of the 1st thread stack is in fuzz target.
+      # FP case 3: 1st func of the 1st thread stack is in fuzz target.
       if len(crash_stacks) > 0:
         first_stack = crash_stacks[0]
         # Check the first stack frame of the first stack only.

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -245,11 +245,18 @@ class BuilderRunner:
       symptom = SemanticCheckResult.extract_symptom(fuzzlog)
       crash_stacks = self._parse_stacks_from_libfuzzer_logs(lines)
 
-      # FP case 1: Null-deref, normally indicating inadequate parameter
-      # initialization or wrong function usage.
+      # FP case 1: Common fuzz target errors.
+      # Null-deref, normally indicating inadequate parameter initialization or
+      # wrong function usage.
       if symptom == 'null-deref':
         return cov_pcs, total_pcs, True, SemanticCheckResult(
             SemanticCheckResult.NULL_DEREF, symptom, crash_stacks)
+
+      # Signal, normally indicating assertion failure due to inadequate
+      # parameter initialization or wrong function usage.
+      if symptom == 'signal':
+        return cov_pcs, total_pcs, True, SemanticCheckResult(
+            SemanticCheckResult.SIGNAL, symptom, crash_stacks)
 
       # FP case 2: fuzz target crashes at init or first few rounds.
       if lastround is None or lastround <= EARLY_FUZZING_ROUND_THRESHOLD:

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -258,6 +258,14 @@ class BuilderRunner:
         return cov_pcs, total_pcs, True, SemanticCheckResult(
             SemanticCheckResult.SIGNAL, symptom, crash_stacks)
 
+      # OOM, normally indicating malloc's parameter is too large, e.g., because
+      # of using parameter `size`.
+      # TODO(dongge): Refine this, 1) Merge this with the other oom case found
+      # from reproducer name; 2) Capture the actual number in (malloc(\d+)).
+      if 'out-of-memory' in symptom:
+        return cov_pcs, total_pcs, True, SemanticCheckResult(
+            SemanticCheckResult.FP_OOM, symptom, crash_stacks)
+
       # FP case 2: fuzz target crashes at init or first few rounds.
       if lastround is None or lastround <= EARLY_FUZZING_ROUND_THRESHOLD:
         # No cov line has been identified or only INITED round has been passed.

--- a/experiment/fuzz_target_error.py
+++ b/experiment/fuzz_target_error.py
@@ -48,6 +48,11 @@ class SemanticCheckResult:
   @classmethod
   def extract_symptom(cls, fuzzlog: str) -> str:
     """Extracts crash symptom from fuzzing logs."""
+    # Need to catch this before ASAN.
+    match = cls.SYMPTOM_SCARINESS.match(fuzzlog)
+    if match:
+      return match.group(1)
+
     match = cls.SYMPTOM_ASAN.match(fuzzlog)
     if match:
       return f'ASAN-{match.group(0)}'
@@ -55,10 +60,6 @@ class SemanticCheckResult:
     match = cls.SYMPTOM_LIBFUZZER.match(fuzzlog)
     if match:
       return f'libFuzzer-{match.group(0)}'
-
-    match = cls.SYMPTOM_SCARINESS.match(fuzzlog)
-    if match:
-      return match.group(1)
 
     return ''
 

--- a/experiment/fuzz_target_error.py
+++ b/experiment/fuzz_target_error.py
@@ -30,6 +30,7 @@ class SemanticCheckResult:
   FP_TIMEOUT = 'FP_TIMEOUT'
   NO_COV_INCREASE = 'NO_COV_INCREASE'
   NULL_DEREF = 'NULL_DEREF'
+  SIGNAL = 'SIGNAL'
 
   # Regex for extract crash symptoms.
   # Matches over 18 types of ASAN errors symptoms
@@ -103,8 +104,12 @@ class SemanticCheckResult:
       return (self.NO_COV_INCREASE_MSG_PREFIX + ', indicating the fuzz target'
               ' ineffectively invokes the function under test.')
     if self.type == self.NULL_DEREF:
-      return ('Accessing a null pointer, indicating the fuzz target did not '
-              'properly initialize the parameters.')
+      return ('Accessing a null pointer, indicating improper parameter '
+              'initialization or incorrect function usages in the fuzz target.')
+    if self.type == self.SIGNAL:
+      return ('Abort with signal, indicating the fuzz target has violated some '
+              'assertion in the project, likely due to improper parameter '
+              'initialization or incorrect function usages.')
 
     return ''
 

--- a/experiment/fuzz_target_error.py
+++ b/experiment/fuzz_target_error.py
@@ -49,15 +49,15 @@ class SemanticCheckResult:
   def extract_symptom(cls, fuzzlog: str) -> str:
     """Extracts crash symptom from fuzzing logs."""
     # Need to catch this before ASAN.
-    match = cls.SYMPTOM_SCARINESS.match(fuzzlog)
+    match = cls.SYMPTOM_SCARINESS.search(fuzzlog)
     if match:
       return match.group(1)
 
-    match = cls.SYMPTOM_ASAN.match(fuzzlog)
+    match = cls.SYMPTOM_ASAN.search(fuzzlog)
     if match:
       return f'ASAN-{match.group(0)}'
 
-    match = cls.SYMPTOM_LIBFUZZER.match(fuzzlog)
+    match = cls.SYMPTOM_LIBFUZZER.search(fuzzlog)
     if match:
       return f'libFuzzer-{match.group(0)}'
 

--- a/experiment/fuzz_target_error.py
+++ b/experiment/fuzz_target_error.py
@@ -94,8 +94,8 @@ class SemanticCheckResult:
       return ('Memory leak detected, indicating some memory was not freed '
               'by the fuzz target.')
     if self.type == self.FP_OOM:
-      return ('Out-of-memory error detected, suggesting memory leak in the'
-              ' fuzz target.')
+      return ('Out-of-memory error detected, suggesting the fuzz target '
+              'incorrectly allocates too much memory or has a memory leak.')
     if self.type == self.FP_TIMEOUT:
       return ('Fuzz target timed out at runtime, indicating its usage for '
               'the function under test is incorrect or unrobust.')


### PR DESCRIPTION
Consider `null-deref` as a semantic error instead of a bug:
1. It is likely due to inadequate parameter initialization or incorrect library usage in the fuzz target 
2. It is hardly exploitable.