### PR TITLE
Make it possible to create benchmarks during experimentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv/
 .venv/
 __pycache__/
 *.swp
+generated-benchmark-*

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ results-*/
 oss-fuzz/
 oss-fuzz-data/
 benchmark-sets/split_benchmarks/
+benchmark-sets/generated-benchmark-*
 venv/
 .venv/
 __pycache__/
 *.swp
-generated-benchmark-*

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 import sys
 import time
-from typing import Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, Optional, TypeVar
 from urllib.parse import urlencode
 
 import requests
@@ -46,6 +46,16 @@ INTROSPECTOR_SOURCE = ''
 INTROSPECTOR_XREF = ''
 INTROSPECTOR_TYPE = ''
 INTROSPECTOR_FUNC_SIG = ''
+
+
+def get_oracle_dict() -> Dict[str, Any]:
+  """Returns the oracles available to identify targets."""
+  # Do this in a function to allow for forward-declaration of functions below.
+  oracle_dict = {
+      'far-reach-low-coverage': get_unreached_functions,
+      'low-cov-with-fuzz-keyword': query_introspector_for_keyword_targets
+  }
+  return oracle_dict
 
 
 def set_introspector_endpoints(endpoint):
@@ -155,11 +165,7 @@ def query_introspector_for_keyword_targets(project: str) -> list[dict]:
 
 def query_introspector_for_targets(project, target_oracle) -> list[Dict]:
   """Queries introspector for target functions."""
-  oracle_dict = {
-      'far-reach-low-coverage': get_unreached_functions,
-      'low-cov-with-fuzz-keyword': query_introspector_for_keyword_targets
-  }
-  query_func = oracle_dict.get(target_oracle, None)
+  query_func = get_oracle_dict().get(target_oracle, None)
   if not query_func:
     logging.error('No such oracle "%s"', target_oracle)
     sys.exit(1)

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -336,12 +336,13 @@ def _group_function_params(param_types: list[str],
 
 
 def populate_benchmarks_using_introspector(project: str, language: str,
-                                           limit: int, target_oracles: List[str]):
+                                           limit: int,
+                                           target_oracles: List[str]):
   """Populates benchmark YAML files from the data from FuzzIntrospector."""
 
   functions = []
   for target_oracle in target_oracles:
-    logging.info(f'Extracting functions using oracle {target_oracle}')
+    logging.info('Extracting functions using oracle %s.', target_oracle)
     tmp_functions = query_introspector_for_targets(project, target_oracle)
 
     # Limit the amount of functions from each oracle.
@@ -350,7 +351,6 @@ def populate_benchmarks_using_introspector(project: str, language: str,
   if not functions:
     logging.error('No functions found using the oracles: {target_oracles}')
     return []
-
 
   filenames = [
       os.path.basename(function['function_filename']) for function in functions
@@ -396,7 +396,7 @@ def populate_benchmarks_using_introspector(project: str, language: str,
 
     if len(potential_benchmarks) >= (limit * len(target_oracles)):
       break
-  print("Length of potential targets: %d"%(len(potential_benchmarks)))
+  print("Length of potential targets: %d" % (len(potential_benchmarks)))
 
   return potential_benchmarks
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -349,7 +349,7 @@ def populate_benchmarks_using_introspector(project: str, language: str,
     functions += tmp_functions[:limit]
 
   if not functions:
-    logging.error('No functions found using the oracles: {target_oracles}')
+    logging.error('No functions found using the oracles: %s', target_oracles)
     return []
 
   filenames = [

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -100,13 +100,10 @@ GCS_REPORT_DIR="${SUB_DIR:?}/${EXPERIMENT_NAME:?}"
 bash report/upload_report.sh "${LOCAL_RESULTS_DIR:?}" "${GCS_REPORT_DIR:?}" "${BENCHMARK_SET:?}" "${MODEL:?}" &
 pid_report=$!
 
-#--benchmarks-directory "benchmark-sets/${BENCHMARK_SET:?}" \
 
 # Run the experiment
 $PYTHON run_all_experiments.py \
-  -g low-cov-with-fuzz-keyword,far-reach-low-coverage \
-  -gp avahi,cppitertools,eigen,flex,tinyxml2,htslib \
-  -gm 6 \
+  --benchmarks-directory "benchmark-sets/${BENCHMARK_SET:?}" \
   --run-timeout "${RUN_TIMEOUT:?}" \
   --cloud-experiment-name "${EXPERIMENT_NAME:?}" \
   --cloud-experiment-bucket 'oss-fuzz-gcb-experiment-run-logs' \

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -100,9 +100,13 @@ GCS_REPORT_DIR="${SUB_DIR:?}/${EXPERIMENT_NAME:?}"
 bash report/upload_report.sh "${LOCAL_RESULTS_DIR:?}" "${GCS_REPORT_DIR:?}" "${BENCHMARK_SET:?}" "${MODEL:?}" &
 pid_report=$!
 
+#--benchmarks-directory "benchmark-sets/${BENCHMARK_SET:?}" \
+
 # Run the experiment
 $PYTHON run_all_experiments.py \
-  --benchmarks-directory "benchmark-sets/${BENCHMARK_SET:?}" \
+  -g low-cov-with-fuzz-keyword,far-reach-low-coverage \
+  -gp htslib \
+  -gm 6 \
   --run-timeout "${RUN_TIMEOUT:?}" \
   --cloud-experiment-name "${EXPERIMENT_NAME:?}" \
   --cloud-experiment-bucket 'oss-fuzz-gcb-experiment-run-logs' \

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -105,7 +105,7 @@ pid_report=$!
 # Run the experiment
 $PYTHON run_all_experiments.py \
   -g low-cov-with-fuzz-keyword,far-reach-low-coverage \
-  -gp htslib \
+  -gp avahi,cppitertools,eigen,flex,tinyxml2,htslib \
   -gm 6 \
   --run-timeout "${RUN_TIMEOUT:?}" \
   --cloud-experiment-name "${EXPERIMENT_NAME:?}" \

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -55,16 +55,16 @@ class Result:
 
 
 def get_next_generated_benchmarks_dir() -> str:
-    """Retuns the next folder to be used for generated benchmarks."""
-    max_idx = -1
-    for benchmark_folder in os.listdir():
-        try:
-            max_idx = max(max_idx, int(benchmark_folder.replace(GENERATED_BENCHMARK_DIR, '')))
-        except (ValueError, TypeError) as exc:
-            pass
-    max_idx += 1
-    return f'{GENERATED_BENCHMARK_DIR}{max_idx}'
-
+  """Retuns the next folder to be used for generated benchmarks."""
+  max_idx = -1
+  for benchmark_folder in os.listdir():
+    try:
+      max_idx = max(max_idx,
+                    int(benchmark_folder.replace(GENERATED_BENCHMARK_DIR, '')))
+    except (ValueError, TypeError) as _:
+      pass
+  max_idx += 1
+  return f'{GENERATED_BENCHMARK_DIR}{max_idx}'
 
 
 def get_experiment_configs(
@@ -80,13 +80,18 @@ def get_experiment_configs(
   elif args.generate_benchmarks:
     logging.info('Generating benchmarks.')
     outdir = get_next_generated_benchmarks_dir()
-    logging.info(f'Setting benchmark directory to {outdir}')
+    logging.info('Setting benchmark directory to %s.', outdir)
     os.makedirs(outdir, exist_ok=True)
     args.benchmarks_directory = outdir
-    benchmarks_to_generate = [heuristic.strip() for heuristic in args.generate_benchmarks.split(',')]
-    projects_to_target = [project.strip() for project in args.projects.split(',')]
+    benchmarks_to_generate = [
+        heuristic.strip() for heuristic in args.generate_benchmarks.split(',')
+    ]
+    projects_to_target = [
+        project.strip() for project in args.projects.split(',')
+    ]
     for project in projects_to_target:
-      benchmarks = introspector.populate_benchmarks_using_introspector(project, 'cpp', args.max_benchmark_targets, benchmarks_to_generate)
+      benchmarks = introspector.populate_benchmarks_using_introspector(
+          project, 'cpp', args.max_benchmark_targets, benchmarks_to_generate)
       if benchmarks:
         benchmarklib.Benchmark.to_yaml(benchmarks, outdir)
     benchmark_yamls = [
@@ -193,9 +198,19 @@ def parse_args() -> argparse.Namespace:
                       '--introspector-endpoint',
                       type=str,
                       default=introspector.DEFAULT_INTROSPECTOR_ENDPOINT)
-  parser.add_argument('-g', '--generate-benchmarks', help='Benchmarks to create', type=str)
-  parser.add_argument('-p', '--projects', help='Projects to target, comma separated string.', type=str)
-  parser.add_argument('-m', '--max-benchmark-targets', help='Max targets to generate per benchmark heuristic.', type=int, default=5)
+  parser.add_argument('-g',
+                      '--generate-benchmarks',
+                      help='Benchmarks to create',
+                      type=str)
+  parser.add_argument('-p',
+                      '--projects',
+                      help='Projects to target, comma separated string.',
+                      type=str)
+  parser.add_argument('-m',
+                      '--max-benchmark-targets',
+                      help='Max targets to generate per benchmark heuristic.',
+                      type=int,
+                      default=5)
   parser.add_argument(
       '--delay',
       type=int,
@@ -216,10 +231,12 @@ def parse_args() -> argparse.Namespace:
             benchmark_yaml.endswith('yml')), (
                 "--benchmark-yaml needs to take an YAML file.")
 
-  assert bool(benchmark_yaml) != bool(args.benchmarks_directory) or args.generate_benchmarks, (
-      'One and only one of --benchmark-yaml and --benchmarks-directory is '
-      'required. The former takes one benchmark YAML file, the latter '
-      'takes: a directory of them.')
+  assert bool(benchmark_yaml) != bool(
+      args.benchmarks_directory) or args.generate_benchmarks, (
+          'One and only one of --benchmark-yaml and --benchmarks-directory is '
+          'required, or --generate-benchmarks. --benchmark-yaml takes one '
+          'benchmark YAML file, --benchmarks-directory takes: a directory of '
+          'them and --generate-benchmarks generates them during analysis.')
 
   # Validate templates.
   assert os.path.isdir(args.template_directory), (

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -69,7 +69,7 @@ def get_next_generated_benchmarks_dir() -> str:
 
 
 def generate_benchmarks(args: argparse.Namespace) -> None:
-  """Generate benchmarks, write to filesystem and set args benchmark dir."""
+  """Generates benchmarks, write to filesystem and set args benchmark dir."""
   logging.info('Generating benchmarks.')
   benchmark_dir = get_next_generated_benchmarks_dir()
   logging.info('Setting benchmark directory to %s.', benchmark_dir)

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -201,10 +201,14 @@ def parse_args() -> argparse.Namespace:
                       '--introspector-endpoint',
                       type=str,
                       default=introspector.DEFAULT_INTROSPECTOR_ENDPOINT)
-  parser.add_argument('-g',
-                      '--generate-benchmarks',
-                      help='Generate benchmarks and use those for analysis.',
-                      type=str)
+  parser.add_argument(
+      '-g',
+      '--generate-benchmarks',
+      help=('Generate benchmarks and use those for analysis. This is a string '
+            'of comma-separated heuristics to use when identifying benchmark '
+            'targets. Options available: '
+            f'{", ".join(introspector.get_oracle_dict().keys())}'),
+      type=str)
   parser.add_argument(
       '-gp',
       '--generate-benchmarks-projects',


### PR DESCRIPTION
This makes it possible to run experiments without having to generate benchmarks prior, and also makes it possible select one or more benchmarks to generate for X amount of projects.

Example run:

```sh
./run_all_experiments.py \
  --model=gpt-3.5-turbo -g low-cov-with-fuzz-keyword,far-reach-low-coverage -p htslib -m 6
```

Run for multiple projects:

```sh
./run_all_experiments.py \
  --model=gpt-3.5-turbo -g low-cov-with-fuzz-keyword,far-reach-low-coverage -p htslib,tinyxml2 -m 6
```