### PR TITLE
experimental: add another build heuristic

### DIFF
--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -60,7 +60,7 @@ empty_oss_fuzz_docker = """# Copyright 2018 Google Inc.
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
-                      pkg-config curl check
+                      pkg-config curl check libcpputest-dev re2c
 RUN rm /usr/local/bin/cargo && \
  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y && \
  apt-get install -y cargo


### PR DESCRIPTION
Add another build heuristic that deals with project that declare a specific compiler in their `Makefile`. For example, some projects will set
`CC = gcc` and in these cases we need to adjust such that the Makefile doesn't hardcode the compiler but rather uses the one supplied by OSS-Fuzz