### PR TITLE
Fix target name and path for readstat

### DIFF
--- a/benchmark-sets/all/readstat.yaml
+++ b/benchmark-sets/all/readstat.yaml
@@ -49,5 +49,5 @@
   "signature": "const void * ck_double_hash_lookup(double, ck_hash_table_t *)"
 "language": "c++"
 "project": "readstat"
-"target_name": "fuzz_grammar_sav_date"
-"target_path": "/src/readstat/src/fuzz/fuzz_grammar_sav_date.c"
+"target_name": "fuzz_format_sav"
+"target_path": "/src/readstat/src/fuzz/fuzz_format_sav.c"


### PR DESCRIPTION
The previous one wasn't built: https://github.com/google/oss-fuzz/blob/bf577d8664b7f7c06ba42f95c01f9161c73cd5ff/projects/readstat/build.sh#L38