### PR TITLE
Pass code block to fixer prompt, not the raw LLM response (#259)

### DIFF
--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -278,8 +278,7 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
             llm_fix_id: int, error_desc: Optional[str], errors: list[str],
             fixer_model_name: str) -> None:
   """Reads and fixes |target_path| in place with LLM based on |error_log|."""
-  with open(target_path) as target_file:
-    raw_code = target_file.read()
+  fuzz_target_source_code = parser.parse_code(target_path)
 
   _, target_ext = os.path.splitext(os.path.basename(target_path))
   response_dir = f'{os.path.splitext(target_path)[0]}-F{llm_fix_id}'
@@ -288,7 +287,7 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
 
   apply_llm_fix(ai_binary,
                 benchmark,
-                raw_code,
+                fuzz_target_source_code,
                 error_desc,
                 errors,
                 prompt_path,
@@ -328,7 +327,7 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
 
 def apply_llm_fix(ai_binary: str,
                   benchmark: benchmarklib.Benchmark,
-                  raw_code: str,
+                  fuzz_target_source_code: str,
                   error_desc: Optional[str],
                   errors: list[str],
                   prompt_path: str,
@@ -344,7 +343,8 @@ def apply_llm_fix(ai_binary: str,
   )
 
   builder = prompt_builder.DefaultTemplateBuilder(fixer_model)
-  prompt = builder.build_fixer_prompt(benchmark, raw_code, error_desc, errors)
+  prompt = builder.build_fixer_prompt(benchmark, fuzz_target_source_code,
+                                      error_desc, errors)
   prompt.save(prompt_path)
 
   fixer_model.generate_code(prompt, response_dir)

--- a/prompts/template_xml/fixer_priming.txt
+++ b/prompts/template_xml/fixer_priming.txt
@@ -3,3 +3,6 @@ Given the following C++ fuzz harness and its build error message, fix the code t
 If there is undeclared identifier or unknown type name error, fix it by finding and including the related libraries.
 
 Note that some code may need to be wrapped with <code>extern "C"</code> as their source is C program.
+
+MUST RETURN THE FULL CODE, INCLUDING UNCHANGED PARTS.
+EXTREMELY IMPORTANT: AVOID USING <code>goto</code>. If you have to write code using <code>goto</code>, you MUST MUST also declare all variables BEFORE the <code>goto</code>. Never introduce new variables after the <code>goto</code>.


### PR DESCRIPTION
Passing the raw response can confuse LLM when it contains more text than the code block, which occurred on `Gemini 1.5`.
Also, `Gemini 1.5`'s response structure seems to be different from `code-bison-32k`.

This PR does three things:
1. Make the response parser compatible with both models.
2. Pass the code block in response to LLM fixer, not the raw response.
3. More instructions in the code-fixing prompt to avoid common mistakes.