### PR TITLE
Experiment with Gemini 1.5 and --context

### DIFF
--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -46,7 +46,7 @@ spec:
         - name: LLM_NUM_EVA
           value: '10'
         - name: VERTEX_AI_LOCATIONS
-          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,me-central1,me-central2,me-west1,northamerica-northeast1,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
+          value: 'asia-northeast1,asia-northeast3,asia-southeast1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west9,northamerica-northeast1,us-central1,us-east4,us-west1,us-west4'
       # imagePullSecrets:
       # - name: oss-fuzz-base-artifect
       volumes:

--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -46,7 +46,7 @@ spec:
         - name: LLM_NUM_EVA
           value: '10'
         - name: VERTEX_AI_LOCATIONS
-          value: 'us-central1,us-east4,us-west1,us-west4,northamerica-northeast1'
+          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,me-central1,me-central2,me-west1,northamerica-northeast1,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
       # imagePullSecrets:
       # - name: oss-fuzz-base-artifect
       volumes:

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -74,7 +74,7 @@ fi
 # The LLM used to generate and fix fuzz targets.
 if [[ $MODEL = '' ]]
 then
-  MODEL='vertex_ai_gemini-1-5'
+  MODEL='vertex_ai_code-bison-32k'
   echo "LLM was not specified as the fifth argument. Defaulting to ${MODEL:?}."
 fi
 

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -74,7 +74,7 @@ fi
 # The LLM used to generate and fix fuzz targets.
 if [[ $MODEL = '' ]]
 then
-  MODEL='vertex_ai_code-bison-32k'
+  MODEL='vertex_ai_gemini-1-5'
   echo "LLM was not specified as the fifth argument. Defaulting to ${MODEL:?}."
 fi
 

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -111,6 +111,7 @@ $PYTHON run_all_experiments.py \
   --work-dir ${LOCAL_RESULTS_DIR:?} \
   --num-samples 10 \
   --delay "${DELAY:?}" \
+  --context \
   --model "$MODEL"
 
 export ret_val=$?

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -111,7 +111,6 @@ $PYTHON run_all_experiments.py \
   --work-dir ${LOCAL_RESULTS_DIR:?} \
   --num-samples 10 \
   --delay "${DELAY:?}" \
-  --context \
   --model "$MODEL"
 
 export ret_val=$?


### PR DESCRIPTION
Supersedes #249.

Conclusion:
`Gemini-1.5` + context > `Gemini-1.5`  ~= `Code-bison-32k` > `Code-bison-32k` + context


Gemini-1.5 + context:
https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-05-11-weekly-all/

Gemini-1.5 without context:
https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-05-14-weekly-all/

Code-bison-32k without context:
https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-05-16-weekly-all/

Code-bison-32k + context:
https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-05-18-weekly-all/