### PR TITLE
Modify context generation slightly (xrefs)

### DIFF
--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -169,7 +169,7 @@ class ContextRetriever:
     return xrefs
 
   def _truncate_xrefs(self, xrefs: list[str]) -> list[str]:
-    """Truncates xrefs to 10 lines before and after the 
+    """Truncates xrefs to 10 lines before and after the
     function name is referenced."""
     truncated = []
     for xref in xrefs:

--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -169,12 +169,14 @@ class ContextRetriever:
     return xrefs
 
   def _truncate_xrefs(self, xrefs: list[str]) -> list[str]:
+    """Truncates xrefs to 10 lines before and after the 
+    function name is referenced."""
     truncated = []
     for xref in xrefs:
       lines = xref.split('\n')
       line_index = -1
-      start_index = 0
-      end_index = len(lines) - 1
+      start = 0
+      end = len(lines) - 1
       for index, line in enumerate(lines):
         if self._benchmark.function_name in line:
           line_index = index
@@ -182,9 +184,9 @@ class ContextRetriever:
       # If name was not found, then just return the entire function.
       # If it was, truncate it.
       if line_index != -1:
-        start_index = 0 if line_index <= 10 else line_index - 10
-        end_index = end_index if line_index >= end_index - 10 else line_index + 10
-      truncated.append('\n'.join(lines[start_index:end_index]))
+        start = start if line_index <= 10 else line_index - 10
+        end = end if line_index >= end - 10 else line_index + 10
+      truncated.append('\n'.join(lines[start:end]))
 
     return truncated
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -145,7 +145,7 @@ class DefaultTemplateBuilder(PromptBuilder):
         headers='\n'.join(context_info['files']),
         must_insert=context_info['decl'],
         func_source=context_info['func_source'],
-        xrefs='\n'.join(context_info['xrefs']),
+        xrefs=context_info['xrefs'],
     )
 
   def _select_examples(self, examples: list[list],

--- a/prompts/template_xml/context.txt
+++ b/prompts/template_xml/context.txt
@@ -23,8 +23,11 @@ Here is the source code of the function being tested:
 {% endif %}
 {% if xrefs %}
 
-Here is the source code for functions which reference the function being tested:
+Here is the source code for locations which reference the function being tested:
+{% for xref in xrefs %}
+Reference location {{ loop.index }}:
 <code>
-{{ xrefs }}
+{{ xref }}
 </code>
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
Truncate xrefs, so that the source code of the entire function(s) xref'ing the function under test is not included.

Additionally, modify context generation so we talk about lines where the code is xref'd, as opposed to functions.