### PR TITLE
Capture multiple errors in LLM query

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -198,11 +198,7 @@ class Evaluator:
 
   def check_target(self, ai_binary, target_path: str) -> Optional[Result]:
     # Print out exceptions from multiprocessing.Pool.
-    try:
-      return self.do_check_target(ai_binary, target_path)
-    except BaseException:
-      traceback.print_exc()
-      return None
+    return self.do_check_target(ai_binary, target_path)
 
   def _fix_generated_fuzz_target(self, ai_binary: str,
                                  generated_oss_fuzz_project: str,

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -19,7 +19,6 @@ import json
 import os
 import re
 import shutil
-import traceback
 from typing import Optional
 
 from google.cloud import storage

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -259,9 +259,14 @@ class Evaluator:
       logger.log(f'Fixing {target_path} with '
                  f'{self.builder_runner.fixer_model_name}, '
                  f'attempt {llm_fix_count}.')
-      self._fix_generated_fuzz_target(ai_binary, generated_oss_fuzz_project,
-                                      target_path, llm_fix_count, build_result,
-                                      run_result, logger)
+      try:
+        self._fix_generated_fuzz_target(ai_binary, generated_oss_fuzz_project,
+                                        target_path, llm_fix_count,
+                                        build_result, run_result, logger)
+      except Exception as e:
+        logger.log('Exception occurred when fixing fuzz target in attempt '
+                   f'{llm_fix_count}: {e}')
+        break
 
     # Logs and returns the result.
     if not build_result.succeeded:

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -195,10 +195,6 @@ class Evaluator:
               f'{self.benchmark.target_path}\n')
     return name
 
-  def check_target(self, ai_binary, target_path: str) -> Optional[Result]:
-    # Print out exceptions from multiprocessing.Pool.
-    return self.do_check_target(ai_binary, target_path)
-
   def _fix_generated_fuzz_target(self, ai_binary: str,
                                  generated_oss_fuzz_project: str,
                                  target_path: str, iteration: int,
@@ -222,7 +218,7 @@ class Evaluator:
         os.path.join(oss_fuzz_checkout.OSS_FUZZ_DIR, 'projects',
                      generated_oss_fuzz_project, os.path.basename(target_path)))
 
-  def do_check_target(self, ai_binary: str, target_path: str) -> Result:
+  def check_target(self, ai_binary, target_path: str) -> Result:
     """Builds and runs a target."""
     generated_target_name = os.path.basename(target_path)
     sample_id = os.path.splitext(generated_target_name)[0]

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 from abc import abstractmethod
 from typing import Any, Callable, Type
 
@@ -129,27 +130,43 @@ class LLM:
   def prompt_type(self) -> type[prompts.Prompt]:
     """Returns the expected prompt type."""
 
-  def with_retry_on_error(self, func: Callable,
-                          err_types: tuple[Type[Exception], ...]) -> Any:
+  def _delay_for_retry(self, attempt_count: int) -> None:
+    """Sleeps for a while based on the |attempt_count|."""
+    # Exponentially increase from 5 to 80 seconds + some random to jitter.
+    delay = 5 * 2**attempt_count + random.randint(1, 5)
+    logging.warning('Retry in %d seconds...', delay)
+    time.sleep(delay)
+
+  def _is_retryable_error(self, err: Exception, api_error: Type[Exception],
+                          tb: traceback.StackSummary) -> bool:
+    """Validates if |err| is worth retrying."""
+    if isinstance(err, api_error):
+      return True
+
+    # A known case from vertex package.
+    if (isinstance(err, ValueError) and
+        'Content roles do not match' in str(err) and tb[-1].filename.endswith(
+            'vertexai/generative_models/_generative_models.py')):
+      return True
+
+    return False
+
+  def with_retry_on_error(  # pylint: disable=inconsistent-return-statements
+      self, func: Callable, api_err: Type[Exception]) -> Any:
     """
     Retry when the function returns an expected error with exponential backoff.
     """
-    for attempt in range(self._max_attempts):
+    for attempt in range(1, self._max_attempts + 1):
       try:
         return func()
-      except err_types as err:
-        # Exponentially increase from 5 to 80 seconds
-        # + some random to jitter.
-        delay = 5 * 2**attempt + random.randint(1, 5)
-        print(f'Error generating LLM response\n'
-              f'{err}')
-
-        if attempt == self._max_attempts - 1:
+      except Exception as err:
+        logging.warning('LLM API Error when responding (attempt %d): %s',
+                        attempt, err)
+        tb = traceback.extract_tb(err.__traceback__)
+        if (not self._is_retryable_error(err, api_err, tb) or
+            attempt == self._max_attempts):
           raise err
-
-        print(f'Retry in {delay}s...')
-        time.sleep(delay)
-    return None
+        self._delay_for_retry(attempt_count=attempt)
 
   def _save_output(self, index: int, content: str, response_dir: str) -> None:
     """Saves the raw |content| from the model ouput."""
@@ -203,7 +220,7 @@ class GPT(LLM):
                                                model=self.name,
                                                n=self.num_samples,
                                                temperature=self.temperature),
-        (openai.OpenAIError,))
+        openai.OpenAIError)
     if log_output:
       print(completion)
     for index, choice in enumerate(completion.choices):  # type: ignore
@@ -309,7 +326,7 @@ class VertexAIModel(GoogleModel):
     for index in range(self.num_samples):
       response = self.with_retry_on_error(
           lambda: self.do_generate(model, prompt.get(), parameters),
-          (GoogleAPICallError, ValueError))
+          GoogleAPICallError)
       self._save_output(index, response, response_dir)
 
 

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -165,6 +165,7 @@ class LLM:
         tb = traceback.extract_tb(err.__traceback__)
         if (not self._is_retryable_error(err, api_err, tb) or
             attempt == self._max_attempts):
+          traceback.print_exc()
           raise err
         self._delay_for_retry(attempt_count=attempt)
 

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -191,8 +191,9 @@ def check_targets(
     for i, target_stat in enumerate(
         p.starmap(evaluator.check_target, ai_target_pairs)):
       if target_stat is None:
-        print(f'Error evaluating target {generated_targets[i]}')
-        continue
+        logging.error('This should never happen: Error evaluating target: %s',
+                      generated_targets[i])
+        target_stat = exp_evaluator.Result()
 
       target_stats.append((i, target_stat))
 


### PR DESCRIPTION
This PR captures the following error from Vertex AI model:
```python
ERROR 2024-05-08T14:54:27.598104660Z File "/venv/lib/python3.11/site-packages/vertexai/generative_models/_generative_models.py", line 1653, in _append_gapic_content
ERROR 2024-05-08T14:54:27.598107350Z raise ValueError(
ERROR 2024-05-08T14:54:27.598117270Z ValueError: Content roles do not match: model !=
```

Background:
Some benchmarks from our full experiment break when querying LLM, causing [non-terminating experiments](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-05-08-weekly-all/benchmark/output-apache-httpd-register_hooks/index.html).
For example, here we have the prompt but not the response:
https://pantheon.corp.google.com/storage/browser/oss-fuzz-gcb-experiment-run-logs/Result-reports/scheduled/2024-05-08-weekly-all/results/output-apache-httpd-register_hooks/fixed_targets/03-F4;tab=objects?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&e=-13802955&mods=logs_tg_prod&project=oss-fuzz&prefix=&forceOnObjectsSortingFiltering=false

This is likely due to the `ValueError` in Vertex AI model, e.g. the ones in:
https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22oss-fuzz%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22llm-experiment-large%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fbatch_kubernetes_io%2Fcontroller-uid%3D%22db33e6af-1965-46a7-b00c-8026d6231baf%22%20severity%3E%3DDEFAULT%0A;cursorTimestamp=2024-05-08T14:54:27.598117270Z;startTime=2024-05-08T14:33:00.000Z;endTime=2024-05-08T15:00:00.000Z?project=oss-fuzz&e=-13802955&mods=logs_tg_prod

There is not much OSS-Fuzz-Gen can do to avoid this, so we retry instead.