### PR TITLE
Capture errors when building and running fuzz targets

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -287,17 +287,13 @@ class BuilderRunner:
                                    symptom, crash_stacks)
             break
 
-    else:
+    elif initcov == donecov and lastround is not None:
       # Another error fuzz target case: no cov increase.
-      if initcov is not None and donecov is not None:
-        if initcov == donecov:
-          return cov_pcs, total_pcs, False, SemanticCheckResult(
-              SemanticCheckResult.NO_COV_INCREASE)
-      if initcov == donecov == None != lastround:
-        # No interesting inputs were found. This may also happen if the target
-        # rejected all inputs we tried.
-        return cov_pcs, total_pcs, False, SemanticCheckResult(
-            SemanticCheckResult.NO_COV_INCREASE)
+      # A special case is initcov == donecov == None, which indicates no
+      # interesting inputs were found. This may happen if the target rejected
+      # all inputs we tried.
+      return cov_pcs, total_pcs, False, SemanticCheckResult(
+          SemanticCheckResult.NO_COV_INCREASE)
 
     return cov_pcs, total_pcs, crashes, SemanticCheckResult(
         SemanticCheckResult.NO_SEMANTIC_ERR)

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -190,9 +190,9 @@ class BuilderRunner:
 
         if roundno is not None:
           lastround = roundno
-          if 'INITED' in line:
+          if 'INITED' in line and 'cov: ' in line:
             initcov = int(line.split('cov: ')[1].split(' ft:')[0])
-          elif 'DONE' in line:
+          elif 'DONE' in line and 'cov: ' in line:
             donecov = int(line.split('cov: ')[1].split(' ft:')[0])
 
     return initcov, donecov, lastround
@@ -292,6 +292,11 @@ class BuilderRunner:
         if initcov == donecov:
           return cov_pcs, total_pcs, False, SemanticCheckResult(
               SemanticCheckResult.NO_COV_INCREASE)
+      if initcov == donecov == None != lastround:
+        # No interesting inputs were found. This may also happen if the target
+        # rejected all inputs we tried.
+        return cov_pcs, total_pcs, False, SemanticCheckResult(
+            SemanticCheckResult.NO_COV_INCREASE)
 
     return cov_pcs, total_pcs, crashes, SemanticCheckResult(
         SemanticCheckResult.NO_SEMANTIC_ERR)

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -312,8 +312,7 @@ class BuilderRunner:
     except Exception as err:
       logging.warning(
           'Error occurred when building and running fuzz target locally'
-          '(attempt %d): %s', iteration, err)
-      traceback.print_exc()
+          '(attempt %d) %s: %s', iteration, err, traceback.format_exc())
       raise err
 
   def build_and_run_local(
@@ -620,7 +619,7 @@ class CloudBuilderRunner(BuilderRunner):
     except Exception as err:
       logging.warning(
           'Error occurred when building and running fuzz target on cloud'
-          '(attempt %d): %s', iteration, err)
+          '(attempt %d) %s: %s', iteration, err, traceback.format_exc())
       traceback.print_exc()
       raise err
 

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -240,8 +240,14 @@ class Evaluator:
     llm_fix_count = 0
     while True:
       # 1. Evaluating generated driver.
-      build_result, run_result = self.builder_runner.build_and_run(
-          generated_oss_fuzz_project, target_path, llm_fix_count)
+      try:
+        build_result, run_result = self.builder_runner.build_and_run(
+            generated_oss_fuzz_project, target_path, llm_fix_count)
+      except Exception as e:
+        logger.log('Exception occurred when building and running fuzz target '
+                   f'in attempt {llm_fix_count}: {e}')
+        build_result = BuildResult()
+        run_result = None
 
       gen_succ = build_result.succeeded and run_result and run_result.succeeded
       if gen_succ or llm_fix_count >= LLM_FIX_LIMIT:

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -165,7 +165,9 @@ class LLM:
         tb = traceback.extract_tb(err.__traceback__)
         if (not self._is_retryable_error(err, api_err, tb) or
             attempt == self._max_attempts):
-          traceback.print_exc()
+          logging.warning(
+              'LLM API cannot fix error when responding (attempt %d) %s: %s',
+              attempt, err, traceback.format_exc())
           raise err
         self._delay_for_retry(attempt_count=attempt)
 


### PR DESCRIPTION
This PR fixes a `libfuzzer` parser error and captures other errors when building and running fuzz targets.

Related:
https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-05-15-273-dg-273-comparison/benchmark/output-libusb-libusb_get_string_descriptor_ascii/index.html

https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22oss-fuzz%22%0Aresource.labels.location%3D%22us-central1-c%22%0Aresource.labels.cluster_name%3D%22llm-experiment%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fbatch_kubernetes_io%2Fcontroller-uid%3D%22cb8a5fcb-948d-4faf-b1b7-bd16baee7f83%22%20severity%3E%3DDEFAULT%0A;cursorTimestamp=2024-05-15T07:34:10.709184162Z;startTime=2024-05-15T07:14:00.000Z?e=-13802955&mods=logs_tg_prod&project=oss-fuzz

https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/a110773c-213b-47ed-9f66-eda54f0266b5;step=7?e=-13802955&mods=logs_tg_prod&project=oss-fuzz

