### PR TITLE
Match another oom pattern in crash log

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -263,7 +263,7 @@ class BuilderRunner:
       # of using parameter `size`.
       # TODO(dongge): Refine this, 1) Merge this with the other oom case found
       # from reproducer name; 2) Capture the actual number in (malloc(\d+)).
-      if 'out-of-memory' in symptom:
+      if 'out-of-memory' in symptom or 'out of memory' in symptom:
         return cov_pcs, total_pcs, True, SemanticCheckResult(
             SemanticCheckResult.FP_OOM, symptom, crash_stacks)
 


### PR DESCRIPTION
The previous pattern does not catch this:
https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-05-16-276-dg-276-1-comparison/sample/output-libusb-libusb_get_string_descriptor_ascii/03