### PR TITLE
Add missing extension `.c++` to report

### DIFF
--- a/report/web.py
+++ b/report/web.py
@@ -42,7 +42,7 @@ BENCHMARK_DIR = ''
 
 MAX_RUN_LOGS_LEN = 16 * 1024
 
-TARGET_EXTS = ('.c', '.cc', '.cpp', '.cxx', '.java', '.py')
+TARGET_EXTS = ('.c', '.cc', '.cpp', '.cxx', '.c++', '.java', '.py')
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This report did not include fuzz targets with `.c++`, causing [previous report](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-05-18-weekly-all/benchmark/output-capnproto-_zn5capnp13dynamicstruct7builder5adopten2kj9stringptreons_6orphanins_12dynamicvalueeee/index.html) failed to show them.