### PR TITLE
Retry a different vertex ai location if one failed to initialize

### DIFF
--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -304,12 +304,13 @@ class VertexAIModel(GoogleModel):
     while vertex_ai_locations:
       location = random.choice(vertex_ai_locations)
       try:
-        logging.info('Using location %s for Vertex AI', location)
+        logging.info('Using location (%s) for Vertex AI (%s).', location,
+                     self.name)
         vertexai.init(location=location)
         return
       except ValueError as e:
-        logging.warning('Initialization failed for location (%s): %s', location,
-                        e)
+        logging.warning('Failed to use location (%s) for Vertex AI (%s): %s',
+                        self.name, location, e)
         vertex_ai_locations.remove(location)
         os.environ['VERTEX_AI_LOCATIONS'] = ','.join(vertex_ai_locations)
 


### PR DESCRIPTION
Some experiment trials failed due to [the failure to initialize the vertex AI model with the given location](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2024-05-20T21:40:30.302955392Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22oss-fuzz%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22llm-experiment-large%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fbatch_kubernetes_io%2Fcontroller-uid%3D%226b65ab48-fbd1-4f95-968e-8acf8c36f40c%22%20severity%3E%3DWARNING%0A%0A%0A%0A-textPayload%3D~%22Cannot%20find%20cloud%20run%20log%22%0A-textPayload%3D~%22Multiple%20substring%20matches%22%0A-textPayload%3D~%22Failed%20to%20parse%20error%20message%22%0A-textPayload%3D~%22Unexpected%20empty%20error%20message%22%0A-textPayload%3D~%22could%20not%20find%20specified%20function%22%0A-textPayload%3D~%22introspector.oss-fuzz.com%22%0A-textPayload%3D~%22report.web%22%0A-textPayload%3D~%22Failed%20to%20get%20signature%20from%20FI:%22%0Atimestamp%3D%222024-05-20T21:40:30.302955392Z%22%0AinsertId%3D%22ffxxinjqhavhbaof%22;startTime=2024-05-14T23:38:10.871Z?project=oss-fuzz).
This PR automatically retries with a different location and removes the location from ENV var so that other trials won't use it.
