### PR TITLE
experimental: extend builds and minor refactoring

### DIFF
--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -281,10 +281,7 @@ class AutogenScannerSH(AutoBuildBase):
 
   def __init__(self):
     super().__init__()
-    self.matches_found = {
-        'configure.ac': [],
-        'autogen.sh': []
-    }
+    self.matches_found = {'configure.ac': [], 'autogen.sh': []}
 
   def steps_to_build(self):
     cmds_to_exec_from_root = ['./autogen.sh', './configure', 'make']

--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -283,8 +283,7 @@ class AutogenScannerSH(AutoBuildBase):
     super().__init__()
     self.matches_found = {
         'configure.ac': [],
-        'autogen.sh': [],
-        'Makefile': [],
+        'autogen.sh': []
     }
 
   def steps_to_build(self):

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -23,12 +23,10 @@ from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
 import build_generator
-import templates
-
 import cxxfilt
 import openai
+import templates
 import yaml
-
 
 MAX_FUZZ_PER_HEURISTIC = 15
 INTROSPECTOR_OSS_FUZZ_DIR = '/src/inspector'
@@ -40,6 +38,7 @@ FUZZER_PRE_HEADERS = '''#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 '''
+
 
 def setup_model(model: str):
   global LLM_MODEL
@@ -835,7 +834,8 @@ def refine_static_libs(results):
 def get_language_defaults(language: str):
   compilers_and_flags = {
       'c': ('$CC', '$CFLAGS', '/src/empty-fuzzer.c', templates.C_BASE_TEMPLATE),
-      'c++': ('$CXX', '$CXXFLAGS', '/src/empty-fuzzer.cpp', templates.CPP_BASE_TEMPLATE),
+      'c++': ('$CXX', '$CXXFLAGS', '/src/empty-fuzzer.cpp',
+              templates.CPP_BASE_TEMPLATE),
   }
   return compilers_and_flags[language]
 
@@ -1118,8 +1118,8 @@ def create_clean_oss_fuzz_from_success(github_repo: str, success_dir: str,
 
   # Create Dockerfile
   project_repo_dir = github_repo.split('/')[-1]
-  dockerfile = templates.CLEAN_OSS_FUZZ_DOCKER.format(repo_url=github_repo,
-                                   project_repo_dir=project_repo_dir)
+  dockerfile = templates.CLEAN_OSS_FUZZ_DOCKER.format(
+      repo_url=github_repo, project_repo_dir=project_repo_dir)
   with open(os.path.join(oss_fuzz_folder, 'Dockerfile'), 'w') as docker_out:
     docker_out.write(dockerfile)
 
@@ -1157,7 +1157,8 @@ def create_clean_clusterfuzz_lite_from_success(github_repo: str,
 
   # Create Dockerfile
   project_repo_dir = github_repo.split('/')[-1]
-  dockerfile = templates.CLEAN_DOCKER_CFLITE.format(project_repo_dir=project_repo_dir)
+  dockerfile = templates.CLEAN_DOCKER_CFLITE.format(
+      project_repo_dir=project_repo_dir)
   with open(os.path.join(cflite_folder, 'Dockerfile'), 'w') as docker_out:
     docker_out.write(dockerfile)
 

--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -26,8 +26,8 @@ import templates
 
 silent_global = False
 
+SHARED_MEMORY_RESULTS_DIR = 'autogen-results'
 
-SHARED_MEMORY_RESULTS_DIR='autogen-results'
 
 def setup_worker_project(oss_fuzz_base: str, project_name: str, llm_model: str):
   """Setup empty OSS-Fuzz project used for analysis."""
@@ -37,9 +37,9 @@ def setup_worker_project(oss_fuzz_base: str, project_name: str, llm_model: str):
 
   os.makedirs(temp_project_dir)
   with open(os.path.join(temp_project_dir, 'project.yaml'), 'w') as f:
-    f.write(templates.empty_project_yaml)
+    f.write(templates.EMPTY_PROJECT_YAML)
   with open(os.path.join(temp_project_dir, 'build.sh'), 'w') as f:
-    f.write(templates.empty_oss_fuzz_build)
+    f.write(templates.EMPTY_OSS_FUZZ_BUILD)
   with open(os.path.join(temp_project_dir, 'Dockerfile'), 'w') as f:
     f.write(templates.AUTOGEN_DOCKER_FILE)
 
@@ -79,9 +79,8 @@ def run_coverage_runs(oss_fuzz_base: str, worker_name: str) -> None:
   as reported by the code coverage generation. This must be done outside of
   the harness generation because we need the OSS-Fuzz base-runner image, where
   the generation is based on the OSS-Fuzz base-builder image."""
-  worker_out = os.path.join(
-      oss_fuzz_base, 'build', 'out', worker_name,
-      SHARED_MEMORY_RESULTS_DIR)
+  worker_out = os.path.join(oss_fuzz_base, 'build', 'out', worker_name,
+                            SHARED_MEMORY_RESULTS_DIR)
 
   for auto_fuzz_dir in os.listdir(worker_out):
     print(auto_fuzz_dir)

--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -22,63 +22,12 @@ import sys
 import threading
 from typing import List
 
+import templates
+
 silent_global = False
 
-empty_oss_fuzz_build = """#!/bin/bash -eu
-# Copyright 2018 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-"""
 
-empty_oss_fuzz_docker = """# Copyright 2018 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
-                      pkg-config curl check libcpputest-dev re2c
-RUN rm /usr/local/bin/cargo && \
- curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y && \
- apt-get install -y cargo
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install pydantic-core pyyaml cxxfilt openai==1.16.2
-RUN python3 -m pip install --upgrade google-cloud-aiplatform
-COPY *.py *.json $SRC/
-WORKDIR $SRC
-COPY build.sh $SRC/"""
-
-empty_project_yaml = """homepage: "https://github.com/google/oss-fuzz"
-language: c++
-primary_contact: "info@oss-fuzz.com"
-auto_ccs:
--
-main_repo: 'https://github.com/samtools/htslib.git'
-"""
-
+SHARED_MEMORY_RESULTS_DIR='autogen-results'
 
 def setup_worker_project(oss_fuzz_base: str, project_name: str, llm_model: str):
   """Setup empty OSS-Fuzz project used for analysis."""
@@ -88,11 +37,11 @@ def setup_worker_project(oss_fuzz_base: str, project_name: str, llm_model: str):
 
   os.makedirs(temp_project_dir)
   with open(os.path.join(temp_project_dir, 'project.yaml'), 'w') as f:
-    f.write(empty_project_yaml)
+    f.write(templates.empty_project_yaml)
   with open(os.path.join(temp_project_dir, 'build.sh'), 'w') as f:
-    f.write(empty_oss_fuzz_build)
+    f.write(templates.empty_oss_fuzz_build)
   with open(os.path.join(temp_project_dir, 'Dockerfile'), 'w') as f:
-    f.write(empty_oss_fuzz_docker)
+    f.write(templates.AUTOGEN_DOCKER_FILE)
 
   if llm_model == 'vertex':
     json_config = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', None)
@@ -103,7 +52,7 @@ def setup_worker_project(oss_fuzz_base: str, project_name: str, llm_model: str):
     shutil.copyfile(json_config, os.path.join(temp_project_dir, 'creds.json'))
 
   # Copy over the generator
-  files_to_copy = {'build_generator.py', 'manager.py'}
+  files_to_copy = {'build_generator.py', 'manager.py', 'templates.py'}
   for target_file in files_to_copy:
     shutil.copyfile(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), target_file),
@@ -132,7 +81,7 @@ def run_coverage_runs(oss_fuzz_base: str, worker_name: str) -> None:
   the generation is based on the OSS-Fuzz base-builder image."""
   worker_out = os.path.join(
       oss_fuzz_base, 'build', 'out', worker_name,
-      'autogen-results-%d' % (int(worker_name.split('-')[-1])))
+      SHARED_MEMORY_RESULTS_DIR)
 
   for auto_fuzz_dir in os.listdir(worker_out):
     print(auto_fuzz_dir)
@@ -277,7 +226,7 @@ def run_on_targets(target,
 
   openai_api_key = os.getenv('OPENAI_API_KEY', None)
 
-  outdir = '/out/autogen-results-%d' % (idx)
+  outdir = '/out/' + SHARED_MEMORY_RESULTS_DIR
   with open('status-log.txt', 'a') as f:
     f.write("Targeting: %s :: %d\n" % (target, idx))
   run_autogen(target,

--- a/experimental/c-cpp/templates.py
+++ b/experimental/c-cpp/templates.py
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Holds templates used by the auto-generator both inside and outside the
+OSS-Fuzz base builder."""
 
-empty_oss_fuzz_build = '''#!/bin/bash -eu
+EMPTY_OSS_FUZZ_BUILD = '''#!/bin/bash -eu
 # Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +33,7 @@ empty_oss_fuzz_build = '''#!/bin/bash -eu
 ################################################################################
 '''
 
-base_docker_file = '''# Copyright 2018 Google Inc.
+BASE_DOCKER_HEAD = '''# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -120,10 +122,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     return 0;
 }'''
 
-
 # Docker file used for starting the auto-gen workflow within an OSS-Fuzz
 # base-builder image.
-AUTOGEN_DOCKER_FILE = base_docker_file + '''
+AUTOGEN_DOCKER_FILE = BASE_DOCKER_HEAD + '''
 RUN rm /usr/local/bin/cargo && \
  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y && \
  apt-get install -y cargo
@@ -134,7 +135,7 @@ COPY *.py *.json $SRC/
 WORKDIR $SRC
 COPY build.sh $SRC/'''
 
-empty_project_yaml = """homepage: "https://github.com/google/oss-fuzz"
+EMPTY_PROJECT_YAML = """homepage: "https://github.com/google/oss-fuzz"
 language: c++
 primary_contact: "info@oss-fuzz.com"
 auto_ccs:
@@ -143,13 +144,13 @@ main_repo: 'https://github.com/google/oss-fuzz'
 """
 
 # Docker file used for OSS-Fuzz integrations.
-CLEAN_OSS_FUZZ_DOCKER = base_docker_file + '''
+CLEAN_OSS_FUZZ_DOCKER = BASE_DOCKER_HEAD + '''
 COPY *.sh *.cpp *.c $SRC/
 RUN git clone --recurse-submodules {repo_url} {project_repo_dir}
 WORKDIR {project_repo_dir}
 '''
 
-CLEAN_DOCKER_CFLITE = base_docker_file + '''
+CLEAN_DOCKER_CFLITE = BASE_DOCKER_HEAD + '''
 COPY . $SRC/{project_repo_dir}
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
 COPY .clusterfuzzlite/*.cpp $SRC/

--- a/experimental/c-cpp/templates.py
+++ b/experimental/c-cpp/templates.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+empty_oss_fuzz_build = '''#!/bin/bash -eu
+# Copyright 2024 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+'''
+
+base_docker_file = '''# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake autopoint \
+                      libtool cmake pkg-config curl check libcpputest-dev \
+                      flex bison re2c
+'''
+
+CFLITE_TEMPLATE = '''name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}
+'''
+
+# Empty CPP harness that is used to confirm compilation when generating
+# auto-build scripts.
+CPP_BASE_TEMPLATE = '''#include <stdint.h>
+#include <iostream>
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    std::string input(reinterpret_cast<const char*>(data), size);
+
+    // Insert fuzzer contents here
+    // input string contains fuzz input.
+
+    // end of fuzzer contents
+
+    return 0;
+}'''
+
+# Empty C harness that is used to confirm compilation when generating
+# auto-build scripts.
+C_BASE_TEMPLATE = '''#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    printf("Hello world\\n");
+    // Insert fuzzer contents here
+    // input string contains fuzz input.
+
+    // end of fuzzer contents
+
+    return 0;
+}'''
+
+
+# Docker file used for starting the auto-gen workflow within an OSS-Fuzz
+# base-builder image.
+AUTOGEN_DOCKER_FILE = base_docker_file + '''
+RUN rm /usr/local/bin/cargo && \
+ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y && \
+ apt-get install -y cargo
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install pydantic-core pyyaml cxxfilt openai==1.16.2
+RUN python3 -m pip install --upgrade google-cloud-aiplatform
+COPY *.py *.json $SRC/
+WORKDIR $SRC
+COPY build.sh $SRC/'''
+
+empty_project_yaml = """homepage: "https://github.com/google/oss-fuzz"
+language: c++
+primary_contact: "info@oss-fuzz.com"
+auto_ccs:
+-
+main_repo: 'https://github.com/google/oss-fuzz'
+"""
+
+# Docker file used for OSS-Fuzz integrations.
+CLEAN_OSS_FUZZ_DOCKER = base_docker_file + '''
+COPY *.sh *.cpp *.c $SRC/
+RUN git clone --recurse-submodules {repo_url} {project_repo_dir}
+WORKDIR {project_repo_dir}
+'''
+
+CLEAN_DOCKER_CFLITE = base_docker_file + '''
+COPY . $SRC/{project_repo_dir}
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+COPY .clusterfuzzlite/*.cpp $SRC/
+COPY .clusterfuzzlite/*.c $SRC/
+WORKDIR {project_repo_dir}
+'''


### PR DESCRIPTION
- Adjusts the autogen.sh build to be more general (no need to have
  Makefile as this can be generated by the autogen.sh in some cases).
- Uses a unified place for templating
- Minor adjustment in directory name of shared folder
  "autogen-results-X" is now always just "autogen-results"