### PR TITLE
oss-fuzz-checkout: enable using own venv

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -104,6 +104,10 @@ def postprocess_oss_fuzz() -> None:
   if os.path.exists(os.path.join(OSS_FUZZ_DIR, VENV_DIR)):
     return
 
+  # If already in a virtualenv environment assume all is set up
+  if os.environ['VIRTUAL_ENV']:
+    return
+
   result = sp.run(['python3', '-m', 'venv', VENV_DIR],
                   check=True,
                   capture_output=True,

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -105,7 +105,7 @@ def postprocess_oss_fuzz() -> None:
     return
 
   # If already in a virtualenv environment assume all is set up
-  if os.environ['VIRTUAL_ENV']:
+  if os.environ.get('VIRTUAL_ENV', ''):
     return
 
   result = sp.run(['python3', '-m', 'venv', VENV_DIR],


### PR DESCRIPTION
This is useful when having a shared virtual environment with other projects. For example, on my local dev I use a virtualenv environment with both fuzz introspector and oss-fuzz-gen requirements, but this is currently being blocked by the logic here trying to launch a new venv.