### PR TITLE
run_all_experiments: set introspector endpoint as early as possible

### DIFF
--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -288,12 +288,15 @@ def _print_experiment_results(results: list[Result]):
 def main():
   logging.basicConfig(level=logging.INFO)
   args = parse_args()
+
+  # Set introspector endpoint before performing any operations to ensure the
+  # right API endpoint is used throughout.
+  introspector.set_introspector_endpoints(args.introspector_endpoint)
+
   run_one_experiment.prepare()
 
   experiment_configs = get_experiment_configs(args)
   experiment_results = []
-
-  introspector.set_introspector_endpoints(args.introspector_endpoint)
 
   print(f'Running {NUM_EXP} experiment(s) in parallel.')
   if NUM_EXP == 1:


### PR DESCRIPTION
Otherwise we will use the default endpoint when we also generate benchmarks during the run (happens inside of `get_experiment_configs`). This commit ensures we use the right endpoint in both local and cloud-based runs.