### PR TITLE
introspector: allow oracles to return empty lists

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -172,7 +172,6 @@ def query_introspector_for_targets(project, target_oracle) -> list[Dict]:
   query_func = get_oracle_dict().get(target_oracle, None)
   if not query_func:
     logging.error('No such oracle "%s"', target_oracle)
-    print("Exit 2")
     sys.exit(1)
   return query_func(project)
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -159,10 +159,7 @@ def _get_data(resp: Optional[requests.Response], key: str,
 def query_introspector_oracle(project: str, oracle_api: str) -> list[dict]:
   """Queries a fuzz target oracle API from Fuzz Introspector."""
   resp = _query_introspector(oracle_api, {'project': project})
-  functions = _get_data(resp, 'functions', [])
-  if functions:
-    return functions
-  sys.exit(1)
+  return _get_data(resp, 'functions', [])
 
 
 def query_introspector_for_keyword_targets(project: str) -> list[dict]:
@@ -175,11 +172,9 @@ def query_introspector_for_targets(project, target_oracle) -> list[Dict]:
   query_func = get_oracle_dict().get(target_oracle, None)
   if not query_func:
     logging.error('No such oracle "%s"', target_oracle)
+    print("Exit 2")
     sys.exit(1)
-  functions = query_func(project)
-  if functions:
-    return functions
-  sys.exit(1)
+  return query_func(project)
 
 
 def query_introspector_cfg(project: str) -> dict:


### PR DESCRIPTION
We have multiple oracles for finding target functions and some of these may return empty for some projects. For example, the following command:

```sh
./run_all_experiments.py \
  --model=gpt-3.5-turbo \
  -g low-cov-with-fuzz-keyword,far-reach-low-coverage \
  -gp $PROJECT \
  -gm 6 \
  -e http://127.0.0.1:8080/api
```

returns 0 interesting functions for the `low-cov-with-fuzz-keyword` oracle. However, the next oracle returns a list of candidates, so we should not exit upon the first oracle returning an empty list of candidate functions.

This allows oracles to return empty list of functions without exiting.