### PR TITLE
ci: adjust timezone

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,6 +2,9 @@ FROM debian:12
 
 ENV DEBIAN_FRONTEND interactive
 
+# Set the same timezone as the main Dockerfile
+ENV TZ='Australia/Sydney'
+
 # Install packages used by the Experiment. Python and Git are required for the experiment.
 # Curl, certs, and gnupg are required to install gcloud.
 RUN apt-get update && \


### PR DESCRIPTION
This is to make the output of the CI consistent with the environment in which experiments run. It's now set to match: https://github.com/google/oss-fuzz-gen/blob/68c69a0ef888003371a12cb65b2ba5e27bc1a767/Dockerfile#L41

Otherwise we run into inconsistencies where e.g. https://github.com/google/oss-fuzz-gen/pull/300 reports:

```sh
Step #1: PR: https://github.com/google/oss-fuzz-gen/pull/300
Step #1: JOB: https://console.cloud.google.com/kubernetes/job/us-central1-c/llm-experiment/default/ofg-pr-300-dk
Step #1: REPORT: https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-05-28-300-dk-comparison/index.html
Step #1: BUCKET: https://console.cloud.google.com/storage/browser/oss-fuzz-gcb-experiment-run-logs/Result-reports/ofg-pr/2024-05-28-300-dk-comparison
Step #1: BUCKET GS: `gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/ofg-pr/2024-05-28-300-dk-comparison`
```

The actual URLs are on "...2024-05-29..." e.g.  https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-05-29-300-dk-comparison/index.html