### PR TITLE
Fix text coverage analysis for jvm projects

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -332,16 +332,21 @@ class Evaluator:
     # Gets line coverage (diff) details.
     coverage_summary = self._load_existing_coverage_summary()
 
+    total_lines = _compute_total_lines_without_fuzz_targets(
+        coverage_summary, generated_target_name)
     if self.benchmark.language == 'jvm':
-      # The summary.json generated from Jacoco.xml report
-      # of JVM project does not have total lines information.
-      # This fix Use the total lines calculation from the
-      # jacoco.xml report of the current run directly for
-      # JVM projects.
-      total_lines = run_result.coverage.total_lines
-    else:
-      total_lines = _compute_total_lines_without_fuzz_targets(
-          coverage_summary, generated_target_name)
+      # The Jacoco.xml coverage report used to generate
+      # summary.json on OSS-Fuzz for JVM projects does
+      # not trace the source file location. Thus the convertion
+      # may miss some classes because they are not there
+      # during coverage report generation.
+      # This fix get the total lines calculation from the
+      # jacoco.xml report of the current run directly and
+      # compare with the total_lines retrieved from summary.json
+      # Then the larger total_lines is used which is assumed
+      # to be more accurate.
+      total_lines = max(total_lines, run_result.coverage.total_lines)
+
     if run_result.total_pcs:
       coverage_percent = run_result.cov_pcs / run_result.total_pcs
     else:

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -321,11 +321,7 @@ class Textcov:
 
   def is_fuzzer_class(self, class_item) -> bool:
     """Determine if the class_item is a fuzzer class."""
-    method_elements = class_item.find('./method[@name=\"fuzzerTestOneInput\"]')
-    if method_elements:
-      return True
-
-    return False
+    return bool(class_item.find('./method[@name=\"fuzzerTestOneInput\"]'))
 
   def determine_jvm_arguments_type(self, desc: str) -> List[str]:
     """

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -243,6 +243,10 @@ class Textcov:
     class_method_items = []
     for item in jacoco_report.iter():
       if item.tag == 'class':
+        # Skip fuzzer classes
+        if textcov.is_fuzzer_class(item):
+          continue
+
         # Get class name and skip fuzzing and testing classes
         class_name = item.attrib['name'].replace('/', '.')
         if 'test' in class_name.lower() or 'fuzzer' in class_name.lower():
@@ -314,6 +318,14 @@ class Textcov:
   @property
   def total_lines(self):
     return sum(len(f.lines) for f in self.functions.values())
+
+  def is_fuzzer_class(self, class_item) -> bool:
+    """Determine if the class_item is a fuzzer class."""
+    method_elements = class_item.find('./method[@name=\"fuzzerTestOneInput\"]')
+    if method_elements:
+      return True
+
+    return False
 
   def determine_jvm_arguments_type(self, desc: str) -> List[str]:
     """


### PR DESCRIPTION
This PR fixes line calculation for JVM projects in textcov analysis. It also filter out fuzzer classes from the coverage analysis to decrease noise.