### PR TITLE
report: enable experiment run with local introspector

### DIFF
--- a/report/docker_local_run.sh
+++ b/report/docker_local_run.sh
@@ -16,7 +16,7 @@
 PROJECTS=htslib,tinyxml2
 BENCHMARK_HEURISTICS=far-reach-low-coverage
 ROOT_FI=/tmp/fuzz-introspector
-OSS_FUZZ_GEN_MODEL=gpt-3.5-turbo
+OSS_FUZZ_GEN_MODEL=${LLM_MODEL}
 
 BASE_DIR=$PWD
 

--- a/report/docker_local_run.sh
+++ b/report/docker_local_run.sh
@@ -22,7 +22,7 @@ OSS_FUZZ_GEN_MODEL=${LLM_MODEL}
 BASE_DIR=$PWD
 
 # Clean and set up Fuzz Introspector
-ROOT_FI=`mktemp -d -p "$DIR"`
+ROOT_FI=$(mktemp -d)
 echo "Using Fuzz Introspector dir: ${ROOT_FI}"
 echo $WORK_DIR
 git clone https://github.com/ossf/fuzz-introspector $ROOT_FI

--- a/report/docker_local_run.sh
+++ b/report/docker_local_run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECTS=htslib,tinyxml2
+BENCHMARK_HEURISTICS=far-reach-low-coverage
+ROOT_FI=/tmp/fuzz-introspector
+OSS_FUZZ_GEN_MODEL=gpt-3.5-turbo
+
+BASE_DIR=$PWD
+
+# Clean and set up Fuzz Introspector
+ROOT_FI=`mktemp -d -p "$DIR"`
+echo "Using Fuzz Introspector dir: ${ROOT_FI}"
+echo $WORK_DIR
+git clone https://github.com/ossf/fuzz-introspector $ROOT_FI
+cd $ROOT_FI
+python3 -m pip install -r ./requirements.txt
+
+
+# Create a local DB
+cd tools/web-fuzzing-introspection/app/static/assets/db/
+python3 ./web_db_creator_from_summary.py \
+  --includes="${PROJECTS}"
+
+# Start webserver DB                                                            
+echo "Shutting down server in case it's running"
+curl --silent http://localhost:8080/api/shutdown || true
+
+echo "[+] Launching FI webapp"
+cd $ROOT_FI/tools/web-fuzzing-introspection/app/
+FUZZ_INTROSPECTOR_SHUTDOWN=1 python3 ./main.py >> /dev/null &
+
+SECONDS=5
+while true
+do
+  # Checking if exists
+  MSG=$(curl -v --silent 127.0.0.1:8080 2>&1 | grep "Fuzzing" | wc -l)
+  if [[ $MSG > 0 ]]; then
+    echo "Found it"
+    break
+  fi
+  echo "- Waiting for webapp to load. Sleeping ${SECONDS} seconds."
+  sleep ${SECONDS}
+done
+
+# Run the experiment
+echo "Running the experiment"
+cd $BASE_DIR
+./run_all_experiments.py \
+    --model=$OSS_FUZZ_GEN_MODEL \
+    -g ${BENCHMARK_HEURISTICS} \
+    -gp ${PROJECTS} \
+    -gm 6 \
+    -e http://127.0.0.1:8080/api
+
+echo "Shutting down started webserver"
+curl --silent http://localhost:8080/api/shutdown || true

--- a/report/docker_local_run.sh
+++ b/report/docker_local_run.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PROJECTS=htslib,tinyxml2
+# Comma separated project list
+PROJECTS=${TARGET_PROJECTS}
 BENCHMARK_HEURISTICS=far-reach-low-coverage
 ROOT_FI=/tmp/fuzz-introspector
 OSS_FUZZ_GEN_MODEL=${LLM_MODEL}
@@ -34,7 +35,7 @@ cd tools/web-fuzzing-introspection/app/static/assets/db/
 python3 ./web_db_creator_from_summary.py \
   --includes="${PROJECTS}"
 
-# Start webserver DB                                                            
+# Start webserver DB
 echo "Shutting down server in case it's running"
 curl --silent http://localhost:8080/api/shutdown || true
 


### PR DESCRIPTION
Script for running an experiment using a local version of Fuzz Introspector's webapp.

For reference, there is also a more end-to-end version of this, which will run both the harness itself and the building of the introspector reports [here](https://github.com/ossf/fuzz-introspector/tree/main/scripts/oss-fuzz-gen-e2e). The logic in this PR is focused on using a local version of Fuzz Introspector's webapp such that all requests to `../api/..` happens to the local webapp.

Sample run:

```sh
export OPENAI_API_KEY=....
git clone https://github.com/google/oss-fuzz-gen
cd oss-fuzz-gen
python3.11 -m virtualenv .venv
. .venv/bin/activate
python3 -m pip install -r ./requirements.txt
TARGET_PROJECTS=htslib,tinyxml2 LLM_MODEL=gpt-3.5-turbo ./report/docker_local_run.sh
python3 -m report.web ./results/ 8012
```