### PR TITLE
Re-config resource to avoid job creation failures

### DIFF
--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -42,7 +42,7 @@ spec:
           name: results-volume
         env:
         - name: LLM_NUM_EXP
-          value: '30'
+          value: '40'
         - name: LLM_NUM_EVA
           value: '10'
         - name: VERTEX_AI_LOCATIONS
@@ -63,3 +63,15 @@ spec:
                 requests:
                   storage: 1000Gi
       restartPolicy: OnFailure
+      backoffLimit: 5
+      ttlSecondsAfterFinished: 432000  # 7 days.
+      podFailurePolicy:
+        rules:
+          - action: FailJob
+            onExitCodes:
+            containerName: experiment  # Optional
+            operator: NotIn            # One of: In, NotIn
+            values: [0]
+          - action: Ignore             # One of: Ignore, FailJob, Count
+            onPodConditions:
+            - type: DisruptionTarget   # Indicates Pod disruption

--- a/ci/request_pr_exp.py
+++ b/ci/request_pr_exp.py
@@ -39,7 +39,7 @@ BENCHMARK_SET = 'comparison'
 LLM_NAME = 'vertex_ai_code-bison-32k'
 EXP_DELAY = 0
 FUZZING_TIMEOUT = 300
-REQUEST_CPU = 45
+REQUEST_CPU = 4
 REQUEST_MEM = 40
 
 PR_LINK_PREFIX = 'https://github.com/google/oss-fuzz-gen/pull'


### PR DESCRIPTION
1. Clean the job 7 days after it is completed (finishes/fails) to release resource.
2. Reduce each job's CPU request to 4 (according to daily exp, they only use <1  now)
3. Fail the job when the container fails.
4. Retry each job 5 times before giving up.
5. Allow running 40 benchmarks in parallel.
