### PR TITLE
run_one_experiment: ensure no parallel executions in local runs

### DIFF
--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -223,6 +223,7 @@ def run(benchmark: Benchmark,
         run_timeout: int = RUN_TIMEOUT,
         dry_run: bool = False) -> Optional[AggregatedResult]:
   """Generates code via LLM, and evaluates them."""
+  global NUM_EVA
   model.cloud_setup()
   logging.basicConfig(level=logging.INFO)
 

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -226,6 +226,11 @@ def run(benchmark: Benchmark,
   model.cloud_setup()
   logging.basicConfig(level=logging.INFO)
 
+  # Ensure three is no parallel executions in local rus, as this causes Docker
+  # to reuse contianers which breaks the flow.
+  if not cloud_experiment_name:
+    NUM_EVA = 1
+
   if example_pair is None:
     example_pair = prompt_builder.EXAMPLES[benchmark.language]
 


### PR DESCRIPTION
This causes issues with docker container reuse.

It's mentioned in the code: https://github.com/google/oss-fuzz-gen/blob/18e1af1569be850e588ee5b0319303bca583b622/run_one_experiment.py#L34-L39 

But I think a better workflow would be to adjust this automatically if there is no cloud run anyways.