### PR TITLE
project_src: stop containers that were started to collected src

### DIFF
--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -271,7 +271,15 @@ def _copy_project_src_from_local(project: str, out: str):
     logging.error('Failed to copy /src from OSS-Fuzz image of %s:', project)
     logging.error('STDOUT: %s', result.stdout)
     logging.error('STDERR: %s', result.stderr)
+
+    # Shut down the container that was just started before throwing exception.
+    sp.run(['docker', 'container', 'stop', f'{project}-container'])
+
     raise Exception(f'Failed to run docker command: {" ".join(copy_src)}')
+
+  # Shut down the container that was just started.
+  sp.run(['docker', 'container', 'stop', f'{project}-container'])
+
   logging.info('Done copying %s /src to %s.', project, out)
 
 

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -279,7 +279,12 @@ def _copy_project_src_from_local(project: str, out: str):
     logging.info('Done copying %s /src to %s.', project, out)
   finally:
     # Shut down the container that was just started.
-    sp.run(['docker', 'container', 'stop', f'{project}-container'])
+    result = sp.run(['docker', 'container', 'stop', f'{project}-container'],
+                    capture_output=True, stdin=sp.DEVNULL, check=False)
+    if result.returncode:
+      logging.error('Failed to stop container image: %s-container', project)
+      logging.error('STDOUT: %s', result.stdout)
+      logging.error('STDERR: %s', result.stderr)
 
 
 def _identify_fuzz_targets(out: str, interesting_filenames: list[str],

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -280,7 +280,9 @@ def _copy_project_src_from_local(project: str, out: str):
   finally:
     # Shut down the container that was just started.
     result = sp.run(['docker', 'container', 'stop', f'{project}-container'],
-                    capture_output=True, stdin=sp.DEVNULL, check=False)
+                    capture_output=True,
+                    stdin=sp.DEVNULL,
+                    check=False)
     if result.returncode:
       logging.error('Failed to stop container image: %s-container', project)
       logging.error('STDOUT: %s', result.stdout)


### PR DESCRIPTION
Without doing this the containers are left hanging, which causes issues for local runs since the specific container is used multiple times in a single experiment.