### PR TITLE
[JVM] Add handling for generic argument types

### DIFF
--- a/prompts/template_xml/jvm_arg_description.txt
+++ b/prompts/template_xml/jvm_arg_description.txt
@@ -1,0 +1,4 @@
+<argument>
+Arugment #{ARG_COUNT} requires an object instance of {ARG_TYPE}.
+Please create the needed arguments with the correct type to be used for this argument.
+</argument>

--- a/prompts/template_xml/jvm_generic_arg_description.txt
+++ b/prompts/template_xml/jvm_generic_arg_description.txt
@@ -1,0 +1,4 @@
+<argument>
+Arugment #{ARG_COUNT} requires an object instance of {ARG_TYPE} with generic types of {ARG_GENERIC}.
+Please match the correct generic type when creating object to be used for this argument.
+</argument>

--- a/prompts/template_xml/jvm_problem_constructor.txt
+++ b/prompts/template_xml/jvm_problem_constructor.txt
@@ -5,3 +5,7 @@ The target method is the constructor of {CONSTRUCTOR_CLASS} with the following s
 The constructor signature follows the format of <code>[Full qualified name of the class].(method_arguments)</code>.
 For example, for the constructor of class <code>Test</code> of package <code>org.test</code> which takes in a single integer would have the following signature:
 <code>[org.test.Test].<init>(int)</code>
+Here is the list of arguments of the target constructor with descriptions.
+<arguments>
+{ARGUMENTS}
+</arguments>

--- a/prompts/template_xml/jvm_problem_method.txt
+++ b/prompts/template_xml/jvm_problem_method.txt
@@ -4,3 +4,7 @@
 The method signature follows the format of <code>[Full qualified name of the class].method_name(method_arguments)</code>.
 For example, for a method <code>test</code> in class <code>Test</code> of package <code>org.test</code> which takes in a single integer would have the following method signature:
 <code>[org.test.Test].test(int)</code>
+Here is the list of arguments of the target method with descriptions.
+<arguments>
+{ARGUMENTS}
+</arguments>

--- a/prompts/template_xml/jvm_specific_data_filler.txt
+++ b/prompts/template_xml/jvm_specific_data_filler.txt
@@ -34,4 +34,5 @@ the generic type of that arguments is matched.
 If the required arguments is an array but it is not found in the first column of the above mapping table, please use array initiazation approach and filled it with random number of data of the required
 argument types.
 </item>
+</requirement>
 </data_mapping>

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -253,7 +253,7 @@ def run(benchmark: Benchmark,
     if benchmark.language == 'jvm':
       # For Java projects
       builder = prompt_builder.DefaultJvmTemplateBuilder(
-          model, benchmark.project, template_dir)
+          model, benchmark.project, benchmark.params, template_dir)
     else:
       # For C/C++ projects
       builder = prompt_builder.DefaultTemplateBuilder(model, template_dir)


### PR DESCRIPTION
For Java projects, some of the methods may require arguments with generic types. This PR proposes a fix to include generic type suggestions in the prompts to allow the LLM generate a better result related to methods with generic type arguments.