### PR TITLE
[JVM] Fix argument name bug

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -343,6 +343,7 @@ def _get_arg_names(function: dict, project: str, language: str) -> list[str]:
     # The fuzz-introspector front end of JVM projects cannot get the original
     # argument name. Thus the argument name here uses arg{Count} as arugment
     # name reference.
+    jvm_args = _get_clean_arg_types(function, project)
     arg_names = [f'arg{i}' for i in range(len(jvm_args))]
   else:
     arg_names = (function.get('arg-names') or

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -341,14 +341,9 @@ def _get_arg_names(function: dict, project: str, language: str) -> list[str]:
   """Returns the function argument names."""
   if language == 'jvm':
     # The fuzz-introspector front end of JVM projects cannot get the original
-    # argument name. Thus the argument name here uses var_{argument_type} as
-    # argument name reference. Some argument types are full-qualified names of
-    # Java classes with [] and . and that is not allowed for Java variable names
-    # and they are removed and form the temporary argment name for reference.
-    jvm_args = _get_clean_arg_types(function, project)
-    arg_names = [
-        f'var_{name.split(".")[-1].replace("[]", "")}' for name in jvm_args
-    ]
+    # argument name. Thus the argument name here uses arg{Count} as arugment
+    # name reference.
+    arg_names = [f'arg{i}' for i in range(len(jvm_args))]
   else:
     arg_names = (function.get('arg-names') or
                  function.get('function_argument_names', []))


### PR DESCRIPTION
As some of the arguments may have the exact same object types, the current name generation for method arguments could result in using the same name for multiple arguments of the same method. This PR proposes a fix to generate argument names according to its position to avoid duplication.