### PR TITLE
experiment: make LLM_FIX_LIMIT adjustable

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -30,7 +30,7 @@ from experiment.fuzz_target_error import SemanticCheckResult
 from experiment.workdir import WorkDirs
 from llm_toolkit import code_fixer
 
-LLM_FIX_LIMIT = 5
+LLM_FIX_LIMIT = int(os.getenv('LLM_FIX_LIMIT', '5'))
 
 OSS_FUZZ_COVERAGE_BUCKET = 'oss-fuzz-coverage'
 


### PR DESCRIPTION
During development it's convenient to being able to adjust this, for example when focus during development is on aspects of OSS-Fuzz-gen that is unrelated to code fixing it's convenient to decrease this to speed up evaluation.