### PR TITLE
Expand the function candidates for projects

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -49,6 +49,8 @@ INTROSPECTOR_XREF = ''
 INTROSPECTOR_TYPE = ''
 INTROSPECTOR_FUNC_SIG = ''
 INTROSPECTOR_ADDR_TYPE = ''
+INTROSPECTOR_ALL_FUNCTIONS = ''
+INTROSPECTOR_ALL_JVM_CONSTRUCTORS = ''
 
 
 def get_oracle_dict() -> Dict[str, Any]:
@@ -131,7 +133,7 @@ def _query_introspector(api: str, params: dict) -> Optional[requests.Response]:
           'Error: %s', _construct_url(api, params), err)
       break
 
-  return ""
+  return None
 
 
 def _get_data(resp: Optional[requests.Response], key: str,
@@ -275,7 +277,8 @@ def get_all_functions(project):
 
 
 def get_all_jvm_constructors(project):
-  functions = query_introspector_oracle(project, INTROSPECTOR_ALL_JVM_CONSTRUCTORS)
+  functions = query_introspector_oracle(project,
+                                        INTROSPECTOR_ALL_JVM_CONSTRUCTORS)
   functions = [f for f in functions if _get_arg_count(f) > 0]
   return functions
 
@@ -655,14 +658,14 @@ if __name__ == '__main__':
   else:
     # No eligible functions from introspector oracle, try finding from
     # all functions and (for JVM project only) constructors
-    target_oracle = ['all-functions']
+    additional_oracle = ['all-functions']
     if cur_project_language == 'jvm':
-      target_oracle.append('all-jvm-constructors')
+      additional_oracle.append('all-jvm-constructors')
 
     benchmarks = populate_benchmarks_using_introspector(args.project,
                                                         cur_project_language,
                                                         args.max_functions,
-                                                        target_oracle)
+                                                        additional_oracle)
 
     if benchmarks:
       benchmarklib.Benchmark.to_yaml(benchmarks, args.out)

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -362,14 +362,10 @@ def _get_arg_names(function: dict, project: str, language: str) -> list[str]:
   """Returns the function argument names."""
   if language == 'jvm':
     # The fuzz-introspector front end of JVM projects cannot get the original
-    # argument name. Thus the argument name here uses var_{argument_type} as
-    # argument name reference. Some argument types are full-qualified names of
-    # Java classes with [] and . and that is not allowed for Java variable names
-    # and they are removed and form the temporary argment name for reference.
+    # argument name. Thus the argument name here uses arg{Count} as arugment
+    # name reference.
     jvm_args = _get_clean_arg_types(function, project)
-    arg_names = [
-        f'var_{name.split(".")[-1].replace("[]", "")}' for name in jvm_args
-    ]
+    arg_names = [f'arg{i}' for i in range(len(jvm_args))]
   else:
     arg_names = (function.get('arg-names') or
                  function.get('function_argument_names', []))


### PR DESCRIPTION
For some of the projects, the query oracle from fuzz-introspector API may return a very limited set of function candidates for generating fuzzers. After certain type of filtering, it could result in an empty list of candidates. This PR proposes an improvement by extending the search from the full function list if there are no more candidates to work on after the filtering is applied on oss-fuzz-gen.