### PR TITLE
Fix bug in jvm prebuild check

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -134,13 +134,13 @@ class BuilderRunner:
     # overloaded methods. Thus it need to use the regex to identify
     # if there are method calls with unknown variable names that match
     # the target method.
-    base_arg_regex = r'[a-zA-Z_$][a-zA-Z_$0-9(),.]*'
+    base_arg_regex = r'[\s]*[a-zA-Z_$][a-zA-Z_$0-9(),.]*'
     signature = self.benchmark.function_signature
     name = signature.split('].')[1].split('(')[0]
     arg_count = len(signature.split('(')[1].split(')')[0].split(','))
 
-    pattern = r'(%s\(%s\))' % (name, ', '.join([base_arg_regex] * arg_count))
-    match = re.search(pattern, code)
+    pattern = r'(%s\(%s\))' % (name, ','.join([base_arg_regex] * arg_count))
+    match = re.search(pattern, ''.join(code.splitlines()))
 
     return bool(match)
 


### PR DESCRIPTION
The prebuild check for JVM projects has missed the consideration of a method call across multiple lines, this cause some prebuild check failed to locate the target method call when it is split into multiple lines which result in false negative denial of possible valid fuzzing harnesses. This PR proposes a fix in the prebuild check to ensure multiple lines target method call could be recognised and fix the problem of false negative denial of possible valid fuzzing harnesses.