### PR TITLE
introspector: add another target oracle api

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -90,7 +90,6 @@ def set_introspector_endpoints(endpoint):
       f'{INTROSPECTOR_ENDPOINT}/addr-to-recursive-dwarf-info')
 
 
-
 def _construct_url(api: str, params: dict) -> str:
   """Constructs an encoded url for the |api| with |params|."""
   return api + '?' + urlencode(params)

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -43,6 +43,7 @@ INTROSPECTOR_ENDPOINT = ''
 INTROSPECTOR_CFG = ''
 INTROSPECTOR_ORACLE_FAR_REACH = ''
 INTROSPECTOR_ORACLE_KEYWORD = ''
+INTROSPECTOR_ORACLE_EASY_PARAMS = ''
 INTROSPECTOR_FUNCTION_SOURCE = ''
 INTROSPECTOR_PROJECT_SOURCE = ''
 INTROSPECTOR_XREF = ''
@@ -56,7 +57,8 @@ def get_oracle_dict() -> Dict[str, Any]:
   # Do this in a function to allow for forward-declaration of functions below.
   oracle_dict = {
       'far-reach-low-coverage': get_unreached_functions,
-      'low-cov-with-fuzz-keyword': query_introspector_for_keyword_targets
+      'low-cov-with-fuzz-keyword': query_introspector_for_keyword_targets,
+      'easy-params-far-reach': query_introspector_for_easy_param_targets,
   }
   return oracle_dict
 
@@ -66,7 +68,8 @@ def set_introspector_endpoints(endpoint):
   global INTROSPECTOR_ENDPOINT, INTROSPECTOR_CFG, INTROSPECTOR_FUNC_SIG, \
       INTROSPECTOR_FUNCTION_SOURCE, INTROSPECTOR_PROJECT_SOURCE, \
       INTROSPECTOR_XREF, INTROSPECTOR_TYPE, INTROSPECTOR_ORACLE_FAR_REACH, \
-      INTROSPECTOR_ORACLE_KEYWORD, INTROSPECTOR_ADDR_TYPE
+      INTROSPECTOR_ORACLE_KEYWORD, INTROSPECTOR_ADDR_TYPE, \
+      INTROSPECTOR_ORACLE_EASY_PARAMS
 
   INTROSPECTOR_ENDPOINT = endpoint
   logging.info('Fuzz Introspector endpoint set to %s', INTROSPECTOR_ENDPOINT)
@@ -76,6 +79,8 @@ def set_introspector_endpoints(endpoint):
       f'{INTROSPECTOR_ENDPOINT}/far-reach-but-low-coverage')
   INTROSPECTOR_ORACLE_KEYWORD = (
       f'{INTROSPECTOR_ENDPOINT}/far-reach-low-cov-fuzz-keyword')
+  INTROSPECTOR_ORACLE_EASY_PARAMS = (
+      f'{INTROSPECTOR_ENDPOINT}/easy-params-far-reach')
   INTROSPECTOR_FUNCTION_SOURCE = f'{INTROSPECTOR_ENDPOINT}/function-source-code'
   INTROSPECTOR_PROJECT_SOURCE = f'{INTROSPECTOR_ENDPOINT}/project-source-code'
   INTROSPECTOR_XREF = f'{INTROSPECTOR_ENDPOINT}/all-cross-references'
@@ -83,6 +88,7 @@ def set_introspector_endpoints(endpoint):
   INTROSPECTOR_FUNC_SIG = f'{INTROSPECTOR_ENDPOINT}/function-signature'
   INTROSPECTOR_ADDR_TYPE = (
       f'{INTROSPECTOR_ENDPOINT}/addr-to-recursive-dwarf-info')
+
 
 
 def _construct_url(api: str, params: dict) -> str:
@@ -165,6 +171,12 @@ def query_introspector_oracle(project: str, oracle_api: str) -> list[dict]:
 def query_introspector_for_keyword_targets(project: str) -> list[dict]:
   """Queries FuzzIntrospector for targets with interesting fuzz keywords."""
   return query_introspector_oracle(project, INTROSPECTOR_ORACLE_KEYWORD)
+
+
+def query_introspector_for_easy_param_targets(project: str) -> list[dict]:
+  """Queries Fuzz Introspector for targets that have fuzzer-friendly params,
+  such as data buffers."""
+  return query_introspector_oracle(project, INTROSPECTOR_ORACLE_EASY_PARAMS)
 
 
 def query_introspector_for_targets(project, target_oracle) -> list[Dict]:


### PR DESCRIPTION
Introspector supports an additional API oracle for target querying. It would be nice to make this available for prompt development.