### PR TITLE
project_src: fix C harness identification

### DIFF
--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -125,8 +125,7 @@ def _get_harness(src_file: str, out: str, language: str) -> tuple[str, str]:
 
   content = _format_source(src_file)
 
-  if (language == 'c++' or
-      language == 'c') and 'int LLVMFuzzerTestOneInput' not in content:
+  if language in {'c++', 'c'} and 'int LLVMFuzzerTestOneInput' not in content:
     return '', ''
   if language == 'jvm' and 'static void fuzzerTestOneInput' not in content:
     return '', ''

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -125,9 +125,11 @@ def _get_harness(src_file: str, out: str, language: str) -> tuple[str, str]:
 
   content = _format_source(src_file)
 
-  if language in {'c++', 'c'} and 'int LLVMFuzzerTestOneInput' not in content:
+  if language.lower() in {'c++', 'c'
+                         } and 'int LLVMFuzzerTestOneInput' not in content:
     return '', ''
-  if language == 'jvm' and 'static void fuzzerTestOneInput' not in content:
+  if language.lower(
+  ) == 'jvm' and 'static void fuzzerTestOneInput' not in content:
     return '', ''
 
   short_path = src_file[len(out):]

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -125,7 +125,7 @@ def _get_harness(src_file: str, out: str, language: str) -> tuple[str, str]:
 
   content = _format_source(src_file)
 
-  if language == 'c++' and 'int LLVMFuzzerTestOneInput' not in content:
+  if (language == 'c++' or language == 'c') and 'int LLVMFuzzerTestOneInput' not in content:
     return '', ''
   if language == 'jvm' and 'static void fuzzerTestOneInput' not in content:
     return '', ''

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -125,7 +125,8 @@ def _get_harness(src_file: str, out: str, language: str) -> tuple[str, str]:
 
   content = _format_source(src_file)
 
-  if (language == 'c++' or language == 'c') and 'int LLVMFuzzerTestOneInput' not in content:
+  if (language == 'c++' or
+      language == 'c') and 'int LLVMFuzzerTestOneInput' not in content:
     return '', ''
   if language == 'jvm' and 'static void fuzzerTestOneInput' not in content:
     return '', ''


### PR DESCRIPTION
There is an issue when identifying harnesses for C projects. Currently, because of a missing language check all files in a C project will be considered valid C harnesses. Thus, when we identify the harnesss to subtitute our auto-gen code with we pick one from the "potential harness" list

https://github.com/google/oss-fuzz-gen/blob/0bed2b5a60d4af36bc0bc7565c57558bb08897da/data_prep/introspector.py#L422 

which effectively means that the majority of times (chance of `pick_one` choosing a valid harness is total harnesses divided by total C files (and many others prior to https://github.com/google/oss-fuzz-gen/pull/317)) a non-harness will be selected for substitution. Consequently, the auto-gen code will not be used.

This was causing a lot of weirdness with a C-specific prompt I'm building since we would substitute fuzzing code into randomly picked files, essentially causing an entire build to fail as we would replace arbitrary files with harness code.