### PR TITLE
Report generation tool supports GCS path for input/ouput paths

### DIFF
--- a/report/web.py
+++ b/report/web.py
@@ -34,6 +34,8 @@ import run_one_experiment
 from experiment import evaluator
 from experiment.workdir import WorkDirs
 
+logging.getLogger().setLevel(os.environ.get('LOGLEVEL', 'WARN').upper())
+
 MAX_RUN_LOGS_LEN = 16 * 1024
 
 TARGET_EXTS = ('.c', '.cc', '.cpp', '.cxx', '.c++', '.java', '.py')
@@ -600,7 +602,8 @@ class GenerateReport:
               self._results.get_final_target_code, benchmark_id))
       self._write(f'benchmark/{benchmark_id}/crash.json', rendered)
     except Exception as e:
-      print(f'Failed to write benchmark/{benchmark_id}/crash.json:\n{e}')
+      logging.error('Failed to write benchmark/%s/crash.json:\n%s',
+                    benchmark_id, e)
 
   def _write_benchmark_sample(self, benchmark_id: str, sample_id: str):
     """Generate the sample page and write to filesystem."""
@@ -614,7 +617,8 @@ class GenerateReport:
           targets=self._results.get_targets(benchmark_id, sample_id))
       self._write(f'sample/{benchmark_id}/{sample_id}', rendered)
     except Exception as e:
-      print(f'Failed to write sample/{benchmark_id}/{sample_id}:\n{e}')
+      logging.error('Failed to write sample/%s/%s:\n%s', benchmark_id,
+                    sample_id, e)
 
 
 def _parse_arguments() -> argparse.Namespace:


### PR DESCRIPTION
Using `gs://` paths the report generation tool directly read/write files directly from/to GCS.

The experiment nodes will continue using local file system. But now we have additional flexibility to regenerate reports without downloading the results which can be very big (hundreds of GBs for "all" benchmark set). This is a necessary first step for implementing trends report (go/oss-fuzz-gen-reports) which will require back-filling existing reports.

Testing it on a daily comparison result, it took ~11 minutes to generate. This is still pretty slow but we can optimize further later. For now this is good enough if we need to regenerate reports after an experiment is done.
