### PR TITLE
Fix FN when matching func in driver

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -152,7 +152,8 @@ class BuilderRunner:
     min_func_name = self._get_minimum_func_name(
         self.benchmark.function_signature)
 
-    return min_func_name in generated_code
+    pattern = rf'\b{min_func_name}\b'
+    return re.search(pattern, generated_code) is not None
 
   def _pre_build_check(self, target_path: str,
                        build_result: BuildResult) -> bool:


### PR DESCRIPTION
This pull request enhances the accuracy of function validation in the [_contains_target_function](https://github.com/google/oss-fuzz-gen/blob/8d8a8bd877ac4baf4a405c12b6ba1faf8fe35de1/experiment/builder_runner.py#L147) method. The original implementation used a simple substring check [min_func_name in generated_code](https://github.com/google/oss-fuzz-gen/blob/8d8a8bd877ac4baf4a405c12b6ba1faf8fe35de1/experiment/builder_runner.py#L155), which could lead to false positives when function names are similar but not identical, such as sf_open versus sf_open_fd.

For example:
![Screenshot 2024-06-18 at 5 38 39 PM](https://github.com/google/oss-fuzz-gen/assets/168942718/e1bac9c2-6f32-4a42-9458-9e91383bedeb)
