### PR TITLE
introspector: avoid static functions for targets by default 

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -38,6 +38,10 @@ T = TypeVar('T', str, list, dict)  # Generic type.
 TIMEOUT = 45
 MAX_RETRY = 5
 
+# By default exclude static functions when identifying fuzz target candidates
+# to generate benchmarks.
+ORACLE_AVOID_STATIC_FUNCTIONS=bool(int(os.getenv('OSS_FUZZ_AVOID_STATIC_FUNCTIONS', '1')))
+
 DEFAULT_INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
 INTROSPECTOR_ENDPOINT = ''
 INTROSPECTOR_CFG = ''
@@ -171,7 +175,7 @@ def _get_data(resp: Optional[requests.Response], key: str,
 
 def query_introspector_oracle(project: str, oracle_api: str) -> list[dict]:
   """Queries a fuzz target oracle API from Fuzz Introspector."""
-  resp = _query_introspector(oracle_api, {'project': project})
+  resp = _query_introspector(oracle_api, {'project': project, 'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS})
   return _get_data(resp, 'functions', [])
 
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -40,7 +40,8 @@ MAX_RETRY = 5
 
 # By default exclude static functions when identifying fuzz target candidates
 # to generate benchmarks.
-ORACLE_AVOID_STATIC_FUNCTIONS=bool(int(os.getenv('OSS_FUZZ_AVOID_STATIC_FUNCTIONS', '1')))
+ORACLE_AVOID_STATIC_FUNCTIONS = bool(
+    int(os.getenv('OSS_FUZZ_AVOID_STATIC_FUNCTIONS', '1')))
 
 DEFAULT_INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
 INTROSPECTOR_ENDPOINT = ''
@@ -175,7 +176,10 @@ def _get_data(resp: Optional[requests.Response], key: str,
 
 def query_introspector_oracle(project: str, oracle_api: str) -> list[dict]:
   """Queries a fuzz target oracle API from Fuzz Introspector."""
-  resp = _query_introspector(oracle_api, {'project': project, 'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS})
+  resp = _query_introspector(oracle_api, {
+      'project': project,
+      'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS
+  })
   return _get_data(resp, 'functions', [])
 
 


### PR DESCRIPTION
Introspector added a heuristic for avoiding static functions and we should use this by default when picking fuzz targets. This avoids hitting harnesses that will fail.

I made this default, but with an option as I assume it will more or less never be desired to have static functions as potential targets. However, there are cases where harnesses for static functions are interesting, although it would require either (1) removal of `static` by the harness construction logic or (2) adding the harness to the relevant file. For these reasons I keep it as an option, in case someone wants to give those types of harnesses a go.

Tested with:

```sh
./run_all_experiments.py \
  --model=${MODEL}
  -g far-reach-low-coverage,low-cov-with-fuzz-keyword,easy-params-far-reach \
  -gp croaring \
  -gm 15 \
  --prompt-builder CSpecific \
  -e http://127.0.0.1:8080/api
```

Can confirm the success build ratio of auto generated fuzz harnesses increases.