### PR TITLE
runner: fix log message

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -525,10 +525,10 @@ class BuilderRunner:
                stderr=sp.STDOUT,
                check=True)
       except sp.CalledProcessError:
-        print(f'Failed to run {generated_project} with {sanitizer}')
+        print(f'Failed to build harnesses for {generated_project} with {sanitizer}')
         return False
 
-    print(f'Successfully run {generated_project} with {sanitizer}')
+    print(f'Successfully build harnesses for {generated_project} with {sanitizer}')
     return True
 
   def get_coverage_local(

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -525,10 +525,11 @@ class BuilderRunner:
                stderr=sp.STDOUT,
                check=True)
       except sp.CalledProcessError:
-        print(f'Failed to build harnesses for {generated_project} with {sanitizer}')
+        print(
+            f'Failed to build fuzzer for {generated_project} with {sanitizer}')
         return False
 
-    print(f'Successfully build harnesses for {generated_project} with {sanitizer}')
+    print(f'Successfully build fuzzer for {generated_project} with {sanitizer}')
     return True
 
   def get_coverage_local(


### PR DESCRIPTION
The logs are about building rather than running a given harness, which was a bit confusing when debugging. I assume because it was copied or so from here: https://github.com/google/oss-fuzz-gen/blob/bb7d3f80fb6feba4319b56e64f9603f3b0965999/experiment/builder_runner.py#L429-L432