### PR TITLE
runner: fix unused JVM coverage var

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -321,7 +321,7 @@ class BuilderRunner:
                                    symptom, crash_stacks)
             break
 
-    elif initcov == donecov and lastround is not None:
+    elif check_cov_increase and initcov == donecov and lastround is not None:
       # Another error fuzz target case: no cov increase.
       # A special case is initcov == donecov == None, which indicates no
       # interesting inputs were found. This may happen if the target rejected


### PR DESCRIPTION
@arthurscchan `check_cov_increase` was added in https://github.com/google/oss-fuzz-gen/pull/236/files#diff-0b3fc09b0cd7a72a95a428b53477f27c2f85c45c483f7bf6a4c8666233b8a887R239 but never actually did anything?

Turned out to be a missing check when collecting coverage, which can cause false negatives. This PR fixes it.