### PR TITLE
report: use argparse to parse arguments

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -111,7 +111,8 @@ max coverage diff sample: <result-dir>/output-tinyxml2-tinyxml2-xmldocument-prin
 To visualize these results via a web UI, with more details on the
 exact prompts used, samples generated, and other logs, run:
 ```bash
-python -m report.web <results-dir> <port>
+python -m report.web -r <results-dir> -o <output-dir>
+python -m http.server <port> -d <output-dir>
 ```
 Where `<results-dir>` is the directory passed to `--work-dir` in your
 experiments (default value `./results`).

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -56,7 +56,7 @@ mkdir results-report
 
 update_report() {
   # Generate the report
-  $PYTHON -m report.web "${RESULTS_DIR:?}" "${BENCHMARK_SET:?}" "$MODEL" results-report
+  $PYTHON -m report.web -r "${RESULTS_DIR:?}" -b "${BENCHMARK_SET:?}" -m "$MODEL" -o results-report
 
   cd results-report || exit 1
 

--- a/report/web.py
+++ b/report/web.py
@@ -514,12 +514,25 @@ class GenerateReport:
 def _parse_arguments() -> argparse.Namespace:
   """Parses command line args."""
   parser = argparse.ArgumentParser(
-      description = 'Parse arguments to launch the web report generation.')
+      description='Parse arguments to launch the web report generation.')
 
-  parser.add_argument('--results-dir', '-r', help='Directory with results from OSS-Fuzz-gen.', required=True)
-  parser.add_argument('--output-dir', '-o', help='Directory to store statically generated web report.', default='results-report')
-  parser.add_argument('--benchmark-set', '-b', help='Directory with benchmarks used for the experiment.', default='')
-  parser.add_argument('--model', '-m', help='Model used for the experiment.', default='')
+  parser.add_argument('--results-dir',
+                      '-r',
+                      help='Directory with results from OSS-Fuzz-gen.',
+                      required=True)
+  parser.add_argument(
+      '--output-dir',
+      '-o',
+      help='Directory to store statically generated web report.',
+      default='results-report')
+  parser.add_argument('--benchmark-set',
+                      '-b',
+                      help='Directory with benchmarks used for the experiment.',
+                      default='')
+  parser.add_argument('--model',
+                      '-m',
+                      help='Model used for the experiment.',
+                      default='')
 
   return parser.parse_args()
 
@@ -527,7 +540,8 @@ def _parse_arguments() -> argparse.Namespace:
 def main():
   args = _parse_arguments()
 
-  results = Results(results_dir=args.results_dir, benchmark_set=args.benchmark_set)
+  results = Results(results_dir=args.results_dir,
+                    benchmark_set=args.benchmark_set)
   jinja_env = JinjaEnv(template_globals={'model': args.model})
   gr = GenerateReport(results=results,
                       jinja_env=jinja_env,

--- a/report/web.py
+++ b/report/web.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """A local server to visualize experiment result."""
 
+import argparse
 import dataclasses
 import json
 import logging
@@ -510,18 +511,27 @@ class GenerateReport:
       print(f'Failed to write sample/{benchmark_id}/{sample_id}:\n{e}')
 
 
-def main():
-  # TODO(Dongge): Use argparser as this script gets more complex.
-  results_dir = sys.argv[1]
-  benchmark_set = sys.argv[2] if len(sys.argv) > 2 else ''
-  model = sys.argv[3] if len(sys.argv) > 3 else ''
-  output_dir = sys.argv[4] if len(sys.argv) > 4 else 'results-report'
+def _parse_arguments() -> argparse.Namespace:
+  """Parses command line args."""
+  parser = argparse.ArgumentParser(
+      description = 'Parse arguments to launch the web report generation.')
 
-  results = Results(results_dir=results_dir, benchmark_set=benchmark_set)
-  jinja_env = JinjaEnv(template_globals={'model': model})
+  parser.add_argument('--results-dir', '-r', help='Directory with results from OSS-Fuzz-gen.', required=True)
+  parser.add_argument('--output-dir', '-o', help='Directory to store statically generated web report.', default='results-report')
+  parser.add_argument('--benchmark-set', '-b', help='Directory with benchmarks used for the experiment.', default='')
+  parser.add_argument('--model', '-m', help='Model used for the experiment.', default='')
+
+  return parser.parse_args()
+
+
+def main():
+  args = _parse_arguments()
+
+  results = Results(results_dir=args.results_dir, benchmark_set=args.benchmark_set)
+  jinja_env = JinjaEnv(template_globals={'model': args.model})
   gr = GenerateReport(results=results,
                       jinja_env=jinja_env,
-                      output_dir=output_dir)
+                      output_dir=args.output_dir)
   gr.generate()
 
 

--- a/report/web.py
+++ b/report/web.py
@@ -514,7 +514,8 @@ class GenerateReport:
 def _parse_arguments() -> argparse.Namespace:
   """Parses command line args."""
   parser = argparse.ArgumentParser(
-      description='Parse arguments to launch the web report generation.')
+      description='Report generation tool reads raw experiment output files and '
+      'generates a report in the form of HTML files in a directory hierarchy.')
 
   parser.add_argument('--results-dir',
                       '-r',

--- a/report/web.py
+++ b/report/web.py
@@ -513,9 +513,9 @@ class GenerateReport:
 
 def _parse_arguments() -> argparse.Namespace:
   """Parses command line args."""
-  parser = argparse.ArgumentParser(
-      description='Report generation tool reads raw experiment output files and '
-      'generates a report in the form of HTML files in a directory hierarchy.')
+  parser = argparse.ArgumentParser(description=(
+      'Report generation tool reads raw experiment output files and '
+      'generates a report in the form of HTML files in a directory hierarchy.'))
 
   parser.add_argument('--results-dir',
                       '-r',


### PR DESCRIPTION
Use argparse for the report generation and adjust USAGE.md accordingly. A benefit of this is that instructions will only be deprecated if we change argument names in the future.