### PR TITLE
introspector: add option for only collecting oracles with references

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -178,11 +178,12 @@ def _get_data(resp: Optional[requests.Response], key: str,
 
 def query_introspector_oracle(project: str, oracle_api: str) -> list[dict]:
   """Queries a fuzz target oracle API from Fuzz Introspector."""
-  resp = _query_introspector(oracle_api, {
-      'project': project,
-      'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS,
-      'only-referenced-functions': ORACLE_ONLY_REFERENCED_FUNCTIONS,
-  })
+  resp = _query_introspector(
+      oracle_api, {
+          'project': project,
+          'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS,
+          'only-referenced-functions': ORACLE_ONLY_REFERENCED_FUNCTIONS,
+      })
   return _get_data(resp, 'functions', [])
 
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -42,6 +42,8 @@ MAX_RETRY = 5
 # to generate benchmarks.
 ORACLE_AVOID_STATIC_FUNCTIONS = bool(
     int(os.getenv('OSS_FUZZ_AVOID_STATIC_FUNCTIONS', '1')))
+ORACLE_ONLY_REFERENCED_FUNCTIONS = bool(
+    int(os.getenv('OSS_FUZZ_ONLY_REFERENCED_FUNCTIONS', '0')))
 
 DEFAULT_INTROSPECTOR_ENDPOINT = 'https://introspector.oss-fuzz.com/api'
 INTROSPECTOR_ENDPOINT = ''
@@ -178,7 +180,8 @@ def query_introspector_oracle(project: str, oracle_api: str) -> list[dict]:
   """Queries a fuzz target oracle API from Fuzz Introspector."""
   resp = _query_introspector(oracle_api, {
       'project': project,
-      'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS
+      'exclude-static-functions': ORACLE_AVOID_STATIC_FUNCTIONS,
+      'only-referenced-functions': ORACLE_ONLY_REFERENCED_FUNCTIONS,
   })
   return _get_data(resp, 'functions', [])
 


### PR DESCRIPTION
FI added an option for oracles to only return functions with cross references. This is convenient to avoid e.g. rewritten `main` functions, and is also convenient for cases where the prompt integrates features that are based on cross-references. This PR makes it possible to leverage this feature.

Ref: https://github.com/ossf/fuzz-introspector/pull/1614