### PR TITLE
Expand the benchmark list

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -37,6 +37,7 @@ T = TypeVar('T', str, list, dict)  # Generic type.
 
 TIMEOUT = 45
 MAX_RETRY = 5
+REDUNDANT_LIMIT_MULTIPLIER = 10
 
 # By default exclude static functions when identifying fuzz target candidates
 # to generate benchmarks.
@@ -453,7 +454,11 @@ def populate_benchmarks_using_introspector(project: str, language: str,
     tmp_functions = query_introspector_for_targets(project, target_oracle)
 
     # Limit the amount of functions from each oracle.
-    functions += tmp_functions[:limit]
+    # As the later fuzzing harnesses generation could be failed,
+    # thus the benchmark size need to be much larger then the
+    # needed limit to allow oss-fuzz-gen to generate enough
+    # fuzzing harnesses even if there are some failing cases.
+    functions += tmp_functions[:(limit * REDUNDANT_LIMIT_MULTIPLIER)]
 
   if not functions:
     logging.error('No functions found using the oracles: %s', target_oracles)


### PR DESCRIPTION
In many projects, the fuzzing harnesses generation process is not good and result in many failing fuzzing harnesses. The current logic of oss-fuzz-gen first generates a limited list of benchmark from introspector oracles. Then it will try to generate  fuzzing harnesses for all targets in the benchmark list. This logic will significantly reduce the number of success fuzzing harnesses if the original benchmark list contains some bad targets.
This PR fixes that by adding a multiplier for the limit and generate a much larger benchmark list in the beginning to provides a bigger list of candidates. During the generation process, if the fuzzing harnesses build fails or crash during execution test, it will skip that target and try on the next target on list. This PR also adds in logic to determine if enough successful fuzzing harnesses has been generated. If yes, then it will exit and print the result to ensure the number of successful fuzzing harnesses does not passed the limit while ensuring higher ratio of success result.

**This PR is still in testing stage and are not yet ready for review.**