### PR TITLE
Revert Gemini 1.5 model.

### DIFF
--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -430,7 +430,7 @@ class GeminiV1D5(GeminiModel):
   context_window = 2000000
 
   name = 'vertex_ai_gemini-1-5'
-  _vertex_ai_model = 'gemini-1.5-pro-preview-0514'
+  _vertex_ai_model = 'gemini-1.5-pro-preview-0409'
 
 
 class AIBinaryModel(GoogleModel):


### PR DESCRIPTION
Our project is [not allowed to use version 0514](https://pantheon.corp.google.com/logs/query;aroundTime=2024-06-21T07:21:22.542363283Z;cursorTimestamp=2024-06-21T07:21:22.542363283Z;duration=PT1H;pinnedLogId=2024-06-21T07:21:22.542363283Z%2Fg942n23o7grufv34;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22oss-fuzz%22%0Aresource.labels.location%3D%22us-central1-c%22%0Aresource.labels.cluster_name%3D%22llm-experiment%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fbatch_kubernetes_io%2Fcontroller-uid%3D%2296d19a6d-9712-40cb-806f-0e99152e294f%22%20severity%3E%3DDEFAULT%0Atimestamp%3D%222024-06-21T07:21:22.542363283Z%22%0AinsertId%3D%22g942n23o7grufv34%22;storageScope=project?project=oss-fuzz):
```
google.api_core.exceptions.FailedPrecondition: 400 Project is not allowed to use Publisher Model `projects/oss-fuzz/locations/me-central1/publishers/google/models/gemini-1.5-pro-preview-0514`
```
