### PR TITLE
JVM: Add logic to build prompts with reference to source code

### DIFF
--- a/experiment/benchmark.py
+++ b/experiment/benchmark.py
@@ -146,7 +146,7 @@ class Benchmark:
       # name of the result directory. To avoid confusion in the directory name,
       # these special characters in the id (coming from the function signature)
       # are removed. Additional special characters exist for constructors which
-      # will shown as <init> or <cinit> because constructors does not have names.
+      # will shown as <init> because constructors does not have names.
       self.function_signature = self.function_name
       self.id = self.id.replace('<', '').replace('>', '')
       self.id = self.id.replace('[', '').replace(']', '')

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -548,8 +548,10 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
     # Query for source code of target method callsites
     xref_source_list = []
-    for xref in introspector.query_introspector_cross_references(self.project_name, signature):
-      xref_source = query_introspector_function_source(self.project_name, xref)
+    for xref in introspector.query_introspector_cross_references(
+        self.project_name, signature):
+      xref_source = introspector.query_introspector_function_source(
+          self.project_name, xref)
       if xref_source:
         xref_source_list.append(xref_source)
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -540,6 +540,21 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
     return '\n'.join(argument_descriptions)
 
+  def _format_source_reference(self, signature: str) -> Tuple[str, str]:
+    """Formats the source code reference for this target."""
+    # Query for source code of the target method
+    source_code = introspector.query_introspector_function_source(
+        self.project_name, signature)
+
+    # Query for source code of target method callsites
+    xref_source_list = []
+    for xref in introspector.query_introspector_cross_references(self.project_name, signature):
+      xref_source = query_introspector_function_source(self.project_name, xref)
+      if xref_source:
+        xref_source_list.append(xref_source)
+
+    return source_code, '\n'.join(xref_source_list)
+
   def _format_problem(self, signature: str) -> str:
     """Formats a problem based on the prompt template."""
     problem = self._get_template(self.problem_template_file)
@@ -548,6 +563,11 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
                               self._format_requirement(signature))
     problem = problem.replace('{DATA_MAPPING}', self._format_data_filler())
     problem = problem.replace('{ARGUMENTS}', self._format_arguments())
+
+    self_source, cross_source = self._format_source_reference(signature)
+    problem = problem.replace('{SELF_SOURCE}', self_source)
+    problem = problem.replace('{CROSS_SOURCE}', cross_source)
+
     return problem
 
   def _prepare_prompt(self, base: str, final_problem: str):

--- a/prompts/template_xml/jvm_problem_constructor.txt
+++ b/prompts/template_xml/jvm_problem_constructor.txt
@@ -9,3 +9,9 @@ Here is the list of arguments of the target constructor with descriptions.
 <arguments>
 {ARGUMENTS}
 </arguments>
+Here is the source code of the target constructor for reference.
+<code>
+{SELF_SOURCE}
+</code>
+Here is a list of source codes of methods that directly invoke the target consturctor for reference.
+{CROSS_SOURCE}

--- a/prompts/template_xml/jvm_problem_method.txt
+++ b/prompts/template_xml/jvm_problem_method.txt
@@ -8,3 +8,9 @@ Here is the list of arguments of the target method with descriptions.
 <arguments>
 {ARGUMENTS}
 </arguments>
+Here is the source code of the target method for reference.
+<code>
+{SELF_SOURCE}
+</code>
+Here is a list of source codes of methods that directly invoke the target method for reference.
+{CROSS_SOURCE}


### PR DESCRIPTION
This PR adds new elements for JVM prompt building. The new elements include the source code of the target function and also the source code of cross-reference which directly invokes the target method. This information is added to the existing prompts for JVM projects to provide better information for the LLM to generate better fuzzing harnesses.