### PR TITLE
Fix for Incorrect File Extension in Generated Report Links

### DIFF
--- a/report/templates/benchmark.html
+++ b/report/templates/benchmark.html
@@ -36,7 +36,7 @@ td, th {
     </tr>
     {% for sample in samples %}
     <tr>
-        <td><a href="../../sample/{{ benchmark|urlencode }}/{{ sample.id }}">{{ sample.id }}</a></li></td>
+        <td><a href="../../sample/{{ benchmark|urlencode }}/{{ sample.id }}.html">{{ sample.id }}</a></li></td>
         <td>{{ sample.status }}</td>
         {% if sample.result %}
         <td style="color: {{ 'green' if sample.result.compiles else 'black' }}">{{ sample.result.compiles }}</td>

--- a/report/web.py
+++ b/report/web.py
@@ -161,7 +161,7 @@ class GenerateReport:
           logs=self._results.get_logs(benchmark.id, sample.id),
           run_logs=self._results.get_run_logs(benchmark.id, sample.id),
           targets=sample_targets)
-      self._write(f'sample/{benchmark.id}/{sample.id}', rendered)
+      self._write(f'sample/{benchmark.id}/{sample.id}.html', rendered)
     except Exception as e:
       logging.error('Failed to write sample/%s/%s:\n%s', benchmark.id,
                     sample.id, e)


### PR DESCRIPTION
Currently, when generating reports using the command outlined [here](https://github.com/google/oss-fuzz-gen/blob/main/USAGE.md#results-report), the sample pages are named solely by `sample_id`, with no file extension. This results in the browser prompting users to download the file, named like '01', instead of displaying it as an HTML page when they click the link. This behavior occurs because the links lack the `.html` suffix, which is crucial for web browsers to recognize and render the content appropriately.

![image](https://github.com/google/oss-fuzz-gen/assets/38575222/415cdb40-f604-401e-aaf6-1ffbba6e65b0)

To address this issue, I have modified the code in `.report/web.py` and updated the templates in `report/template/benchmark.html` to automatically append the .html suffix to the filenames. This change ensures that the generated links function correctly, allowing the HTML pages to be displayed directly in the browser.

![image](https://github.com/google/oss-fuzz-gen/assets/38575222/178bf846-f2e8-418b-849a-cbf0d7b4c860)


Hope it helps.