### PR TITLE
JVM: fix bug for using wrong template

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -484,7 +484,7 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
   def _format_general_argument(self, count: int, arg_type: str) -> str:
     """Formats general argument description."""
-    argument = self._get_template(self.generic_arg_description_template_file)
+    argument = self._get_template(self.arg_description_template_file)
     argument = argument.replace('{ARG_COUNT}', str(count))
     argument = argument.replace('{ARG_TYPE}', arg_type)
 


### PR DESCRIPTION
This PR fixes a bug in JVM prompts creation which use a wrong template file for some argument types.