### PR TITLE
JVM: Fix wrong template mapping name

### DIFF
--- a/prompts/template_xml/jvm_requirement.txt
+++ b/prompts/template_xml/jvm_requirement.txt
@@ -88,7 +88,7 @@ Each item in this list has two attributes, <class_name> tag contains the class n
 contains the fully qualified name of the given class.
 <list>
 <item><class_name>FuzzedDataProvider</class_name><full_class_name>com.code_intelligence.jazzer.api.FuzzedDataProvider</full_class_name></item>
-{OTHER_IMPORT_STATEMENTS}
+{IMPORT_MAPPINGS}
 </list>
 </requirements>
 


### PR DESCRIPTION
This PR fixes a bug in JVM prompts creation which uses a wrong mapping name in one of the template.