### PR TITLE
JVM: Fix bug in discovering of JVM constructor target

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -139,6 +139,12 @@ class BuilderRunner:
     name = signature.split('].')[1].split('(')[0]
     arg_count = len(signature.split('(')[1].split(')')[0].split(','))
 
+    if '<init>' in name:
+      # JVM constructor name <init> does not exist in result code
+      # Retrieve the class name to locate a constructor call
+      class_name = signature[1:].split('].')[0].split('.')[-1]
+      name = f'new {class_name}'
+
     pattern = r'(%s\(%s\))' % (name, ','.join([base_arg_regex] * arg_count))
     match = re.search(pattern, ''.join(code.splitlines()))
 


### PR DESCRIPTION
There is a bug in `_contains_target_jvm_method` function which fails all constructors because the constructor name `<init>` never exists in the harness generated by the LLM model. This PR fixes that by retrieving the class name for locating the target constructor call in the generated harness.