### PR TITLE
JVM: Fix argument type suggestions in prompts

### DIFF
--- a/prompts/template_xml/jvm_specific_data_filler.txt
+++ b/prompts/template_xml/jvm_specific_data_filler.txt
@@ -31,8 +31,11 @@ If the required arguments are instance of java.util.Collection<T> class or any o
 the generic type of that arguments is matched.
 </item>
 <item>
-If the required arguments is an array but it is not found in the first column of the above mapping table, please use array initiazation approach and filled it with random number of data of the required
+If the required argument is an array but it is not found in the first column of the above mapping table, please use array initiazation approach and filled it with random number of data of the required
 argument types.
+</item>
+<item>
+If the required argument are instance of java.lang.Object, please use any method mentioned in the second column of the above table. Please do not use method that is not exist in the above table.
 </item>
 </requirement>
 </data_mapping>

--- a/prompts/template_xml/jvm_specific_data_filler.txt
+++ b/prompts/template_xml/jvm_specific_data_filler.txt
@@ -35,7 +35,8 @@ If the required argument is an array but it is not found in the first column of 
 argument types.
 </item>
 <item>
-If the required argument are instance of java.lang.Object, please use any method mentioned in the second column of the above table. Please do not use method that is not exist in the above table.
+If the required argument are instance of java.lang.Object, please use any method mentioned in the second column of the above table. Please do not use method that is not exist in the above table. Never
+call the FuzzedDataProvider::consumeObject() as this is not a supported method.
 </item>
 </requirement>
 </data_mapping>

--- a/prompts/template_xml/jvm_specific_data_filler.txt
+++ b/prompts/template_xml/jvm_specific_data_filler.txt
@@ -1,5 +1,5 @@
 <data_mapping>
-Here is a markdown table showing methods should be used for generate random data of some argument types:
+Here is a markdown table showing methods that should be used to generate random data of some argument types:
 
   | Argument types | Methods for generating random data |
   | int or java.lang.Integer | FuzzedDataProvider::consumeInt() or FuzzedDataProvider::consumeInt(int, int) or FuzzedDataProvider::pickValue(int[]) |
@@ -24,18 +24,18 @@ Here is a markdown table showing methods should be used for generate random data
   | java.lang.String[] or java.lang.CharSequence[] | FuzzedDataProvider::pickValues(T[], int) or FuzzedDataProvider::pickValues(Collection<T>, int) or new String[]{java.lang.String} |
 
 <requirement>
-<item>If the arugment types are found in the first column of the above table, you must use one of the methods in the second column of the same row for creating random data of that argument type.</item>
+<item>If the argument types are found in the first column of the above table, you must use one of the methods in the second column of the same row to create random data of that argument type.</item>
 <item>Do not use any other methods to create the argument types that exist in the first column of this table.</item>
 <item>
-If the required arguments are instance of java.util.Collection<T> class or any of its subclass, try creating the needed class and fill it with random data with any of the methods in the above table if
-the generic type of that arguments is matched.
+If the required arguments are instances of java.util.Collection<T> class or any of its subclass, try creating the needed class and fill it with random data with any of the methods in the above table if
+the generic type of that argument is matched.
 </item>
 <item>
-If the required argument is an array but it is not found in the first column of the above mapping table, please use array initiazation approach and filled it with random number of data of the required
+If the required argument is an array but it is not found in the first column of the above mapping table, please use the array initialisation approach and fill it with random numbers of data of the required
 argument types.
 </item>
 <item>
-If the required argument are instance of java.lang.Object, please use any method mentioned in the second column of the above table. Please do not use method that is not exist in the above table. Never
+If the required argument are instance of java.lang.Object, please use any method mentioned in the second column of the above table. Please do not use any methods that do not exist in the above table. Never
 call the FuzzedDataProvider::consumeObject() as this is not a supported method.
 </item>
 </requirement>


### PR DESCRIPTION
This PR fixes the prompts for JVM method argument type suggestion on java.lang.Object instance.