### PR TITLE
JVM: Fix non-exist method call

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -767,12 +767,13 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
         'data.getObject()', 'data.consumeString(data.remainingBytes()/2)')
 
     # The fixes here change the calling of data.consumeInt(int) to
-    # data.consumeInt(int,int)
-    for method_call in re.findall(r'(data\.consumeInt\(([0-9]*)\))',
-                                  generated_code):
-      generated_code = generated_code.replace(
-          method_call[0], method_call[0].replace(method_call[1],
-                                                 f'0, {method_call[1]}'))
+    # data.consumeInt(0, int). For example, data.consumeInt(12345) will
+    # be replaced by data.consumeInt(0, 12345)
+    for wrong_method_call in re.findall(r'(data\.consumeInt\(([0-9]*)\))',
+                                        generated_code):
+      old_method_call = wrong_method_call[0]
+      new_method_call = f'data.consumeInt(0, {wrong_method_call[1]})'
+      generated_code = generated_code.replace(old_method_call, new_method_call)
 
     return generated_code
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -751,6 +751,19 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     # Do nothing for jvm project now.
     return self._prompt
 
+  def post_process_generated_code(self, generated_code: str) -> str:
+    """Allows prompt builder to adjust the generated code."""
+    # For unknown reason, LLM model keeps generating harnesses using
+    # FuzzedDataProvider::consumeObject() or FuzzedDataProvider::getObject()
+    # methods for generating random java.lang.Object intance which is
+    # actually not a valid method in FuzzedDataProvider. Try to change the
+    # calling of them to FuzzedDataProvider::consumeString(int) instead.
+
+    generated_code = generated_code.replace('data.consumeObject()', 'data.consumeString(data.remainingBytes()/2)')
+    generated_code = generated_code.replace('data.getObject()', 'data.consumeString(data.remainingBytes()/2)')
+
+    return generated_code
+
 
 class CSpecificBuilder(PromptBuilder):
   """Builder specifically targeted C (and excluding C++)."""

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -759,8 +759,10 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     # actually not a valid method in FuzzedDataProvider. Try to change the
     # calling of them to FuzzedDataProvider::consumeString(int) instead.
 
-    generated_code = generated_code.replace('data.consumeObject()', 'data.consumeString(data.remainingBytes()/2)')
-    generated_code = generated_code.replace('data.getObject()', 'data.consumeString(data.remainingBytes()/2)')
+    generated_code = generated_code.replace(
+        'data.consumeObject()', 'data.consumeString(data.remainingBytes()/2)')
+    generated_code = generated_code.replace(
+        'data.getObject()', 'data.consumeString(data.remainingBytes()/2)')
 
     return generated_code
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -759,17 +759,20 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     # FuzzedDataProvider::consumeInt(int) to generate random Object / Integer
     # instance. These methods are not valid in FuzzedDataProvider.
 
-    # The fixes here change the calling of data.consumeObject() and data.getObject()
-    # to data.consumeString(int)
+    # The fixes here change the calling of data.consumeObject() and
+    # data.getObject() to data.consumeString(int)
     generated_code = generated_code.replace(
         'data.consumeObject()', 'data.consumeString(data.remainingBytes()/2)')
     generated_code = generated_code.replace(
         'data.getObject()', 'data.consumeString(data.remainingBytes()/2)')
 
-    # The fixes here change the calling of data.consumeInt(int) to data.consumeInt(int,int)
-    for method_call in re.findall(r'(data\.consumeInt\(([0-9]*)\))', generated_code):
+    # The fixes here change the calling of data.consumeInt(int) to
+    # data.consumeInt(int,int)
+    for method_call in re.findall(r'(data\.consumeInt\(([0-9]*)\))',
+                                  generated_code):
       generated_code = generated_code.replace(
-          method_call[0], method_call[0].replace(method_call[1], f'0, {method_call[1]}'))
+          method_call[0], method_call[0].replace(method_call[1],
+                                                 f'0, {method_call[1]}'))
 
     return generated_code
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -769,7 +769,7 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     # The fixes here change the calling of data.consumeInt(int) to
     # data.consumeInt(0, int). For example, data.consumeInt(12345) will
     # be replaced by data.consumeInt(0, 12345)
-    for wrong_method_call in re.findall(r'(data\.consumeInt\(([0-9]*)\))',
+    for wrong_method_call in re.findall(r'(data\.consumeInt\(([0-9]+)\))',
                                         generated_code):
       old_method_call = wrong_method_call[0]
       new_method_call = f'data.consumeInt(0, {wrong_method_call[1]})'


### PR DESCRIPTION
For unknown reasons, when a random java.lang.Object instance is needed for method arguments, the LLM model always generates the needed instance with `FuzzedDataProvider::consumeObject()` or `FuzzedDataProvider::getObject()`. These two methods are not valid and never exist. Similar case happens for integer instance. the LLM model use a non-exist `FuzzedDataProvider::consumeInt(int)` for integer data generation.

This PR adds a temporary fix to replace the call to these methods with a valid one.

The `FuzzedDataProvider::consumeObject()` or `FuzzedDataProvider::getObject()` are replaced by `FuzzedDataProvider::consumeString(int)` as String is one of the subclasses for the Object instance.

The `FuzzedDataProvider::consumeInt(int)` is replaced by `FuzzedDataProvider::consumeInt(int, int)` for getting the correct internet within range.