### PR TITLE
JVM: Fix prompt for primitive class array

### DIFF
--- a/prompts/template_xml/jvm_specific_data_filler.txt
+++ b/prompts/template_xml/jvm_specific_data_filler.txt
@@ -4,19 +4,19 @@ Here is a markdown table showing methods should be used for generate random data
   | Argument types | Methods for generating random data |
   | int or java.lang.Integer | FuzzedDataProvider::consumeInt() or FuzzedDataProvider::consumeInt(int, int) or FuzzedDataProvider::pickValue(int[]) |
   | int[] | FuzzedDataProvider::consumeInts(int) or FuzzedDataProvider::pickValues(T[], int) or FuzzedDataProvider::pickValues(Collection<T>, int) |
-  | java.lang.Integer[] | org.apache.commons.lang3.ArrayUtils::toObject(int[])|
+  | java.lang.Integer[] | new Integer[]{int...} |
   | boolean or java.lang.Boolean | FuzzedDataProvider::consumeBoolean() or FuzzedDataProvider::pickValue(boolean[]) |
   | boolean[] | FuzzedDataProvider::consumeBooleans(int) or FuzzedDataProvider::pickValues(T[], int) or FuzzedDataProvider::pickValues(Collection<T>, int) |
-  | java.lang.Boolean[] | org.apache.commons.lang3.ArrayUtils::toObject(boolean[]) |
+  | java.lang.Boolean[] | new Boolean[]{boolean...} |
   | byte or java.lang.Byte | FuzzedDataProvider::consumeByte() or FuzzedDataProvider::consumeByte(byte,byte) or FuzzedDataProvider::pickValue(byte[]) |
   | byte[] | FuzzedDataProvider::consumeBytes(int) or FuzzedDataProvider::consumeRemainingAsBytes() or FuzzedDataProvider::pickValues(T[], int) or FuzzedDataProvider::pickValues(Collection<T>, int) |
-  | java.lang.Byte[] | org.apache.commons.lang3.ArrayUtils::toObject(byte[]) |
+  | java.lang.Byte[] | new Byte[] {byte...} |
   | short or java.lang.Short | FuzzedDataProvider::consumeShort() or FuzzedDataProvider::consumeShort(short, short) or FuzzedDataProvider::pickValue(short[]) |
   | short[] | FuzzedDataProvider::consumeShorts(int) or FuzzedDataProvider::pickValues(T[], int) or FuzzedDataProvider::pickValues(Collection<T>, int) |
-  | java.lang.Short[] | org.apache.commons.lang3.ArrayUtils::toObject(short[]) |
+  | java.lang.Short[] | new Short[] {short...} |
   | long or java.lang.Long | FuzzedDataProvider::consumeLong() or FuzzedDataProvider::consumeLong(long, long) or FuzzedDataProvider::pickValue(long[]) |
   | long[] | FuzzedDataProvider::consumeLongs(int) or FuzzedDataProvider::pickValues(T[], int) or FuzzedDataProvider::pickValues(Collection<T>, int) |
-  | java.lang.Long[] | org.apache.commons.lang3.ArrayUtils::toObject(long[]) |
+  | java.lang.Long[] | new Long[] {long...} |
   | float or java.lang.Float | FuzzedDataProvider::consumeFloat() or FuzzedDataProvider::consumeRegularFloat() or FuzzedDataProvider::consumeRegularFloat(float, float) or FuzzedDataProvider::consumeProbabilityFloat() or or FuzzedDataProvider::pickValue(float[]) |
   | double or java.lang.Double | FuzzedDataProvider::consumeDouble() or FuzzedDataProvider::consumeRegularDouble() or FuzzedDataProvider::consumeRegularDouble(double, double) or FuzzedDataProvider::consumeProbabilityDouble() or FuzzedDataProvider::pickValue(double[]) |
   | char or java.lang.Character | FuzzedDataProvider::consumeChar() or FuzzedDataProvider::consumeCharNoSurrogates() or FuzzedDataProvider::consumeChar(char, char) or FuzzedDataProvider::pickValue(char[]) |


### PR DESCRIPTION
The prompt suggests if a random primitive class array is needed as an argument, the ArrayUtils.toObject() method is called to box the primitive array. This requires an extra Apache-commons-lang library which may not exist in most JVM projects in OSS-Fuzz. Thus this case the generated fuzzers with the use of ArrayUtils fail to compile. This PR fixes that by replacing the suggestion with something local approach.