### PR TITLE
JVM: Fix name of fuzzing harness

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -197,17 +197,6 @@ class Evaluator:
 
     shutil.copytree(existing_project_path, generated_project_path)
 
-    # Fix public java class name in target_file
-    if self.benchmark.language == 'jvm':
-      with open(target_file, 'r') as file:
-        code = file.read()
-
-      new = os.path.basename(self.benchmark.target_path).replace('.java', '')
-      code = code.replace('public class Fuzz', f'public class {new}')
-
-      with open(target_file, 'w') as file:
-        file.write(code)
-
     # Copy generated fuzzers to generated_project_path
     shutil.copyfile(
         target_file,

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -680,7 +680,10 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     requirement = requirement.replace('{IMPORT_MAPPINGS}', '\n'.join(mappings))
 
     harness_name = os.path.basename(self.target_path).replace('.java', '')
-    requirement = requirement.replace('{HARNESS_NAME}', harness_name)
+    if harness_name:
+      requirement = requirement.replace('{HARNESS_NAME}', harness_name)
+    else:
+      requirement = requirement.replace('{HARNESS_NAME}', 'Fuzz')
 
     return requirement
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -541,11 +541,13 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
                model: models.LLM,
                project_name: str,
                function_args: list[dict[str, str]],
+               target_path: str,
                template_dir: str = DEFAULT_TEMPLATE_DIR):
     super().__init__(model)
     self._template_dir = template_dir
     self.project_name = project_name
     self.project_url = self._find_project_url(project_name)
+    self.target_path = target_path
     self.function_args = function_args
 
     # Load templates.
@@ -676,6 +678,9 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
     requirement = self._get_template(self.requirement_template_file)
     requirement = requirement.replace('{IMPORT_MAPPINGS}', '\n'.join(mappings))
+
+    harness_name = os.path.basename(self.target_path).replace('.java', '')
+    requirement = requirement.replace('{HARNESS_NAME}', harness_name)
 
     return requirement
 

--- a/prompts/template_xml/jvm_requirement.txt
+++ b/prompts/template_xml/jvm_requirement.txt
@@ -9,6 +9,7 @@
 <item>Please avoid using any multithreading or multi-processing approach.</item>
 <item>Please add import statements for necessary classes, except for classes in the java.lang package.</item>
 <item>You must create the object before calling the target method.</item>
+<item>Please use {HARNESS_NAME} as the Java class name.</item>
 <item>Do not create new variables with the same names as existing variables.
 WRONG:
 <code>

--- a/prompts/template_xml/jvm_requirement.txt
+++ b/prompts/template_xml/jvm_requirement.txt
@@ -21,7 +21,7 @@ public static void testing(int test) {
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 // Other imports
 
-public class Fuzz {
+public class {HARNESS_NAME} {
   public static void fuzzerInitialize() {
     // Initializing objects for fuzzing
   }

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -256,7 +256,8 @@ def run(benchmark: Benchmark,
     if benchmark.language == 'jvm':
       # For Java projects
       builder = prompt_builder.DefaultJvmTemplateBuilder(
-          model, benchmark.project, benchmark.params, template_dir)
+          model, benchmark.project, benchmark.params, benchmark.target_path,
+          template_dir)
     else:
       if prompt_builder_to_use == 'CSpecific':
         builder = prompt_builder.CSpecificBuilder(model, benchmark,


### PR DESCRIPTION
This PR includes the needed name in the prompts to allow the LLM model to generate a fuzzing harness with the correct name. This removes the need to replace the name afterwards. This change could avoid errors when the class name is used by other logic in the generated fuzzing harness class which has not been updated.