### PR TITLE
Ask LLM to remove `#include 'non-existent filepath` and suggest alternatives

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -228,6 +228,15 @@ def query_introspector_cfg(project: str) -> dict:
   return _get_data(resp, 'project', {})
 
 
+def query_introspector_source_file_path(project: str, func_sig: str) -> str:
+  """Queries FuzzIntrospector API for file path of |func_sig|."""
+  resp = _query_introspector(INTROSPECTOR_FUNCTION_SOURCE, {
+      'project': project,
+      'function_signature': func_sig
+  })
+  return _get_data(resp, 'filepath', '')
+
+
 def query_introspector_function_source(project: str, func_sig: str) -> str:
   """Queries FuzzIntrospector API for source code of |func_sig|."""
   resp = _query_introspector(INTROSPECTOR_FUNCTION_SOURCE, {

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -473,16 +473,20 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
   function_file = ci.get_target_function_file_path()
   if function_file:
     instruction += (
-        f'If the non-existent {wrong_file} was included for the declaration of'
-        f' <code>{benchmark.function_signature}</code>, you must replace it '
-        f'with the actual file <filepath>{function_file}</filepath>.\n')
+        f'If the non-existent <filepath>{wrong_file}</filepath> was included '
+        f'for the declaration of <code>{benchmark.function_signature}</code>, '
+        'you must replace it with the EXACT path of the actual file <filepath>'
+        f'{function_file}</filepath>. For example:\n'
+        f'<code>\n#include "<function_file>"\n</code>\n')
 
   # Step 2: Suggest similar alternatives.
   similar_headers = ci.get_similar_header_file_paths(wrong_file)
   if similar_headers:
+    statements = '\n'.join(
+        [f'#include "{header}"' for header in similar_headers])
     instruction += (
-        'Otherwise, please consider the following list of header files that '
-        f'might be correct alternatives: {", ".join(similar_headers)}.\n')
+        'Otherwise, consider replacing it with some of the following statements'
+        f'that may be correct alternatives:\n<code>{statements}\n</code>\n')
   return instruction
 
 

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -477,7 +477,7 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
         f'for the declaration of <code>{benchmark.function_signature}</code>, '
         'you must replace it with the EXACT path of the actual file <filepath>'
         f'{function_file}</filepath>. For example:\n'
-        f'<code>\n#include "<function_file>"\n</code>\n')
+        f'<code>\n#include "{function_file}"\n</code>\n')
 
   # Step 2: Suggest similar alternatives.
   similar_headers = ci.get_similar_header_file_paths(wrong_file)

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -475,7 +475,7 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
   # Step 2: Suggest the header/source file of the function under test.
   function_file = ci.get_target_function_file_path()
   if (function_file and
-      '#include "{function_file}"' not in fuzz_target_source_code):
+      f'#include "{function_file}"' not in fuzz_target_source_code):
     instruction += (
         f'If the non-existent <filepath>{wrong_file}</filepath> was included '
         f'for the declaration of <code>{benchmark.function_signature}</code>, '
@@ -483,7 +483,7 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
         f'{function_file}</filepath>. For example:\n'
         f'<code>\n#include "{function_file}"\n</code>\n')
 
-  if '#include "{function_file}"' in fuzz_target_source_code:
+  if f'#include "{function_file}"' in fuzz_target_source_code:
     function_file_base_name = os.path.basename(function_file)
     function_file_prefix = function_file.removesuffix(function_file_base_name)
     instruction += (

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -483,6 +483,17 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
         f'{function_file}</filepath>. For example:\n'
         f'<code>\n#include "{function_file}"\n</code>\n')
 
+  if '#include "{function_file}"' in fuzz_target_source_code:
+    function_file_base_name = os.path.basename(function_file)
+    function_file_prefix = function_file.removesuffix(function_file_base_name)
+    instruction += (
+        'In the generated code, ensure that the path prefix of <code>'
+        f'{function_file_base_name}</code> is consistent with other include '
+        f'statements related to the project({benchmark.project}). For example, '
+        'if another include statement is '
+        f'<code>#include <{benchmark.project}/header.h>\n</code>\n, '
+        f'you must modify the path prefix <code>{function_file_prefix}</code> '
+        f'in <code>\n#include "{function_file}"\n</code>\n to align with it.')
   # Step 2: Suggest similar alternatives.
   similar_headers = ci.get_similar_header_file_paths(wrong_file)
   if similar_headers:

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -411,8 +411,9 @@ def apply_llm_fix(ai_binary: str,
   builder = prompt_builder.DefaultTemplateBuilder(fixer_model)
 
   context = _collect_context(benchmark, errors)
+  instruction = _collect_instructions(benchmark, errors)
   prompt = builder.build_fixer_prompt(benchmark, fuzz_target_source_code,
-                                      error_desc, errors, context)
+                                      error_desc, errors, context, instruction)
   prompt.save(prompt_path)
 
   fixer_model.generate_code(prompt, response_dir)
@@ -426,40 +427,8 @@ def _collect_context(benchmark: benchmarklib.Benchmark,
 
   context = ''
   for error in errors:
-    context += _collect_context_file_not_found(benchmark, error)
     context += _collect_context_no_member(benchmark, error)
 
-  return context
-
-
-def _collect_context_file_not_found(benchmark: benchmarklib.Benchmark,
-                                    error: str) -> str:
-  """Collects the useful context to fix 'file not found' errors."""
-  matched = re.search(FILE_NOT_FOUND_ERROR_REGEX, error)
-  if not matched:
-    return ''
-
-  # Step 1: Say the file does not exist, do not include it.
-  wrong_file = matched.group(1)
-  context = (
-      f'IMPORTANT: DO NOT include the header file {wrong_file} in the generated'
-      'fuzz target again, the file does not exist in the project-under-test.\n')
-
-  ci = context_introspector.ContextRetriever(benchmark)
-  # Step 2: Suggest the header/source file of the function under test.
-  function_file = ci.get_target_function_file_path()
-  if function_file:
-    context += (
-        f'If the non-existent {wrong_file} was included for the declaration of'
-        f' <code>{benchmark.function_signature}</code>, you must replace it '
-        f'with the actual file <filepath>{function_file}</filepath>.\n')
-
-  # Step 2: Suggest similar alternatives.
-  similar_headers = ci.get_similar_header_file_paths(wrong_file)
-  if similar_headers:
-    context += (
-        'Otherwise, please consider the following list of header files that '
-        f'might be correct alternatives: {", ".join(similar_headers)}.\n')
   return context
 
 
@@ -472,6 +441,49 @@ def _collect_context_no_member(benchmark: benchmarklib.Benchmark,
   target_type = matched.group(1)
   ci = context_introspector.ContextRetriever(benchmark)
   return ci.get_type_def(target_type)
+
+
+def _collect_instructions(benchmark: benchmarklib.Benchmark,
+                          errors: list[str]) -> str:
+  """Collects the useful instructions to fix the errors."""
+  if not errors:
+    return ''
+
+  instruction = ''
+  for error in errors:
+    instruction += _collect_instruction_file_not_found(benchmark, error)
+  return instruction
+
+
+def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
+                                        error: str) -> str:
+  """Collects the useful instruction to fix 'file not found' errors."""
+  matched = re.search(FILE_NOT_FOUND_ERROR_REGEX, error)
+  if not matched:
+    return ''
+
+  # Step 1: Say the file does not exist, do not include it.
+  wrong_file = matched.group(1)
+  instruction = (
+      f'IMPORTANT: DO NOT include the header file {wrong_file} in the generated'
+      'fuzz target again, the file does not exist in the project-under-test.\n')
+
+  ci = context_introspector.ContextRetriever(benchmark)
+  # Step 2: Suggest the header/source file of the function under test.
+  function_file = ci.get_target_function_file_path()
+  if function_file:
+    instruction += (
+        f'If the non-existent {wrong_file} was included for the declaration of'
+        f' <code>{benchmark.function_signature}</code>, you must replace it '
+        f'with the actual file <filepath>{function_file}</filepath>.\n')
+
+  # Step 2: Suggest similar alternatives.
+  similar_headers = ci.get_similar_header_file_paths(wrong_file)
+  if similar_headers:
+    instruction += (
+        'Otherwise, please consider the following list of header files that '
+        f'might be correct alternatives: {", ".join(similar_headers)}.\n')
+  return instruction
 
 
 def main():

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -501,7 +501,7 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
         [f'#include "{header}"' for header in similar_headers])
     instruction += (
         'Otherwise, consider replacing it with some of the following statements'
-        f'that may be correct alternatives:\n<code>{statements}\n</code>\n')
+        f'that may be correct alternatives:\n<code>\n{statements}\n</code>\n')
   return instruction
 
 

--- a/prompts/template_xml/fixer_instruction.txt
+++ b/prompts/template_xml/fixer_instruction.txt
@@ -1,0 +1,4 @@
+Below are instructions to assist you in fixing the error.
+<instruction>
+{INSTRUCTION}
+</instruction>

--- a/prompts/template_xml/fixer_problem.txt
+++ b/prompts/template_xml/fixer_problem.txt
@@ -10,6 +10,7 @@ Below is the error to fix:
 </error>
 
 {CONTEXT}
+{INSTRUCTION}
 
 Fix code:
 1. Consider possible solutions for the issues listed above.


### PR DESCRIPTION
LLM insists on including non-existent files, likely because LLM _thinks_ that's necessary (for the function-under-test) or does not know what's the correct alternatives
```
isc_lex_gettoken.c:5:10: fatal error: 'isc/boolean.h' file not found
    5 | #include <isc/boolean.h>
      |          ^~~~~~~~~~~~~~~
```

This PR specifically asks LLM to remove that incorrect statement (and suggest any existent alternatives).