### PR TITLE
Fix regex to parse function name when checking if it is called in the fuzz target

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -138,9 +138,7 @@ class BuilderRunner:
       return func_sig
 
     function_name = match.group(1).strip()
-    if function_name.startswith('operator'):
-      return function_name.removeprefix('operator')
-    return function_name
+    return function_name.removeprefix('operator')
 
   def _contains_target_jvm_method(self, target_path: str) -> bool:
     """Validates if the LLM-generated code contains the target jvm methods."""

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -134,7 +134,13 @@ class BuilderRunner:
     pattern = (r'(?:[a-zA-Z_]\w*::)*([a-zA-Z_]\w*|operator[^(\s]*)(?:\s*<.*>)?'
                r'\s*\(')
     match = re.search(pattern, func_sig)
-    return match.group(1).strip() if match else func_sig
+    if not match:
+      return func_sig
+
+    function_name = match.group(1).strip()
+    if function_name.startswith('operator'):
+      return function_name.removeprefix('operator')
+    return function_name
 
   def _contains_target_jvm_method(self, target_path: str) -> bool:
     """Validates if the LLM-generated code contains the target jvm methods."""

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -131,7 +131,8 @@ class BuilderRunner:
   def _get_minimum_func_name(self, func_sig: str) -> str:
     """Extracts the minimum function name from function signature,
     without name space, return type, params, templates."""
-    pattern = r'(?:[a-zA-Z_]\w*::)*([a-zA-Z_]\w*)(?:\s*<.*>)?\s*\('
+    pattern = (r'(?:[a-zA-Z_]\w*::)*([a-zA-Z_]\w*|operator[^(\s]*)(?:\s*<.*>)?'
+               r'\s*\(')
     match = re.search(pattern, func_sig)
     return match.group(1).strip() if match else func_sig
 


### PR DESCRIPTION
Function `operator` is a special case that can be followed by special chars like `++`.
This PR includes that in the regex.

For example, the following line uses `++`, but was not parsed by the current regex:
```C++
// Iterator<std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<bool, std::__1::allocator<bool> >&> & iter::impl::Compressed<std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<bool, std::__1::allocator<bool> >&>::Iterator<std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<bool, std::__1::allocator<bool> >&>::operator++(Iterator<std::__1::vector<int, std::__1::allocator<int> > &, std::__1::vector<bool, std::__1::allocator<bool> > &> *);
it++;
```