### PR TITLE
More fixes for headers

### DIFF
--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -219,6 +219,20 @@ class ContextRetriever:
 
     return type_def
 
+  def get_same_header_file_paths(self, wrong_file: str) -> list[str]:
+    """Retrieves path of header files with the same name as |wrong_name|."""
+    wrong_file_name = os.path.splitext(os.path.basename(wrong_file))
+    header_list = introspector.query_introspector_header_files(
+        self._benchmark.project)
+
+    candidate_headers = []
+    for header in header_list:
+      correct_file_name = os.path.splitext(os.path.basename(header))
+      if wrong_file_name == correct_file_name:
+        candidate_headers.append(header)
+
+    return candidate_headers[:5]
+
   def get_similar_header_file_paths(self, wrong_file: str) -> list[str]:
     """Retrieves and finds 5 header file names closest to |wrong_name|."""
     header_list = introspector.query_introspector_header_files(

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -176,8 +176,7 @@ class BuilderRunner:
     min_func_name = self._get_minimum_func_name(
         self.benchmark.function_signature)
 
-    pattern = rf'\b{min_func_name}\b'
-    return re.search(pattern, generated_code) is not None
+    return min_func_name in generated_code
 
   def _pre_build_check(self, target_path: str,
                        build_result: BuildResult) -> bool:

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -491,7 +491,7 @@ def _collect_instruction_file_not_found(benchmark: benchmarklib.Benchmark,
     statements = '\n'.join(
         [f'#include "{header}"' for header in same_name_headers])
     instruction += (
-        'Replace the non-existent <filepath>{wrong_file}</filepath> with the '
+        f'Replace the non-existent <filepath>{wrong_file}</filepath> with the '
         'following statement, which share the same file name but exists under '
         'the correct path in the project-under-test:\n'
         f'<code>\n{statements}\n</code>\n')

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -461,6 +461,7 @@ def _collect_instructions(benchmark: benchmarklib.Benchmark, errors: list[str],
                                                        fuzz_target_source_code)
     instruction += _collect_instruction_fdp_in_c_target(
         benchmark, error, fuzz_target_source_code)
+    instruction += _collect_instruction_no_goto(fuzz_target_source_code)
   return instruction
 
 
@@ -544,6 +545,17 @@ def _collect_instruction_fdp_in_c_target(benchmark: benchmarklib.Benchmark,
         'targets.\nAlso, ensure the whole fuzz target must be compatible with '
         'plain C and does not include any C++ specific code or dependencies.\n')
 
+  return ''
+
+
+def _collect_instruction_no_goto(fuzz_target_source_code: str) -> str:
+  """Collects the instruction to avoid using goto."""
+  if 'goto' in fuzz_target_source_code:
+    return (
+        'EXTREMELY IMPORTANT: AVOID USING <code>goto</code>. If you have to '
+        'write code using <code>goto</code>, you MUST MUST also declare all '
+        'variables BEFORE the <code>goto</code>. Never introduce new variables '
+        'after the <code>goto</code>.')
   return ''
 
 

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -465,6 +465,7 @@ def _collect_instructions(benchmark: benchmarklib.Benchmark, errors: list[str],
                                                       fuzz_target_source_code)
   instruction += _collect_instruction_no_goto(fuzz_target_source_code)
   instruction += _collect_instruction_builtin_libs_first(benchmark, errors)
+  instruction += _collect_instruction_extern(benchmark)
 
   return instruction
 
@@ -576,6 +577,23 @@ def _collect_instruction_builtin_libs_first(benchmark: benchmarklib.Benchmark,
         'project-specific libraries that contain declarations before those that'
         'use these declared symbols.')
   return ''
+
+
+def _collect_instruction_extern(benchmark: benchmarklib.Benchmark) -> str:
+  """Collects the instructions to use extern "C" in C++ fuzz targets."""
+  if not benchmark.needs_extern:
+    return ''
+  instruction = (
+      'IMPORTANT: The fuzz target ({FUZZ_TARGET_FILE_NAME}) is written in C++, '
+      'whereas the project-under-test ({PROJECT_NAME}) is written in C. All '
+      'headers, functions, and code from the {PROJECT_NAME} project must be '
+      'consistently wrapped in <code>extern "C"</code> to ensure error-free '
+      'compilation and linkage between C and C++:\n<code>\nextern "C" {\n    //'
+      'Include necessary C headers, source files, functions, and code here.\n}'
+      '\n</code>\n')
+  instruction.replace('{FUZZ_TARGET_FILE_NAME}', benchmark.target_path)
+  instruction.replace('{PROJECT_NAME}', benchmark.project)
+  return instruction
 
 
 def main():

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -146,10 +146,15 @@ class DefaultTemplateBuilder(PromptBuilder):
     """Formats a priming based on the prompt template."""
     priming = self._get_template(self.priming_template_file)
     priming = priming.replace('{LANGUAGE}', target_file_type.value)
+    # TODO(Dongge): Add project name and fuzz target file path.
     if needs_extern:
-      priming += ('\nNote that some code may need to be wrapped with '
-                  '<code>extern "C"</code> because the project under test is '
-                  'written in C but the fuzz target is in C++.\n')
+      priming += (
+          'IMPORTANT: The fuzz target is written in C++, whereas the '
+          'project-under-test is written in C. All headers, functions, and code'
+          'from the project must be consistently wrapped in '
+          '<code>extern "C"</code> to ensure error-free compilation and linkage'
+          'between C and C++:\n<code>\nextern "C" {\n    //Include necessary C '
+          'headers, source files, functions, and code here.\n}\n</code>\n')
     if target_file_type == FileType.CPP:
       type_specific_priming = self._get_template(self.cpp_priming_filler_file)
     else:

--- a/prompts/template_xml/fixer_priming.txt
+++ b/prompts/template_xml/fixer_priming.txt
@@ -3,4 +3,3 @@ Given the following {LANGUAGE} fuzz harness and its build error message, fix the
 If there is undeclared identifier or unknown type name error, fix it by finding and including the related libraries.
 
 MUST RETURN THE FULL CODE, INCLUDING UNCHANGED PARTS.
-EXTREMELY IMPORTANT: AVOID USING <code>goto</code>. If you have to write code using <code>goto</code>, you MUST MUST also declare all variables BEFORE the <code>goto</code>. Never introduce new variables after the <code>goto</code>.


### PR DESCRIPTION
1. Always import built-in libraries first to avoid 'unknown type name' error.
2. Fix header files by replacing them with the one with the same name (but different path).
3. Make `goto` statement optional so that the prompt is more focused.