### PR TITLE
introspector: add api to get header files where a function is likely declared

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -60,6 +60,7 @@ INTROSPECTOR_FUNC_SIG = ''
 INTROSPECTOR_ADDR_TYPE = ''
 INTROSPECTOR_ALL_HEADER_FILES = ''
 INTROSPECTOR_ALL_FUNC_TYPES = ''
+INTROSPECTOR_HEADERS_FOR_FUNC = ''
 INTROSPECTOR_SAMPLE_XREFS = ''
 INTROSPECTOR_ALL_JVM_SOURCE_PATH = ''
 
@@ -84,7 +85,8 @@ def set_introspector_endpoints(endpoint):
       INTROSPECTOR_ORACLE_KEYWORD, INTROSPECTOR_ADDR_TYPE, \
       INTROSPECTOR_ALL_HEADER_FILES, INTROSPECTOR_ALL_FUNC_TYPES, \
       INTROSPECTOR_SAMPLE_XREFS, INTROSPECTOR_ORACLE_EASY_PARAMS, \
-      INTROSPECTOR_ORACLE_ALL_CANDIDATES, INTROSPECTOR_ALL_JVM_SOURCE_PATH
+      INTROSPECTOR_ORACLE_ALL_CANDIDATES, INTROSPECTOR_ALL_JVM_SOURCE_PATH, \
+      INTROSPECTOR_HEADERS_FOR_FUNC
 
   INTROSPECTOR_ENDPOINT = endpoint
   logging.info('Fuzz Introspector endpoint set to %s', INTROSPECTOR_ENDPOINT)
@@ -107,6 +109,8 @@ def set_introspector_endpoints(endpoint):
       f'{INTROSPECTOR_ENDPOINT}/addr-to-recursive-dwarf-info')
   INTROSPECTOR_ALL_HEADER_FILES = f'{INTROSPECTOR_ENDPOINT}/all-header-files'
   INTROSPECTOR_ALL_FUNC_TYPES = f'{INTROSPECTOR_ENDPOINT}/func-debug-types'
+  INTROSPECTOR_HEADERS_FOR_FUNC = (
+      f'{INTROSPECTOR_ENDPOINT}/get-header-files-needed-for-function')
   INTROSPECTOR_SAMPLE_XREFS = (
       f'{INTROSPECTOR_ENDPOINT}/sample-cross-references')
   INTROSPECTOR_ALL_JVM_SOURCE_PATH = (
@@ -293,6 +297,18 @@ def query_introspector_jvm_source_path(project: str) -> List[str]:
   resp = _query_introspector(INTROSPECTOR_ALL_JVM_SOURCE_PATH,
                              {'project': project})
   return _get_data(resp, 'src_path', [])
+
+
+def query_introspector_header_files_to_include(project: str,
+                                                func_sig: str) -> List[str]:
+  """Queries Fuzz Introspector header files where a function is likely
+  declared."""
+  resp = _query_introspector(INTROSPECTOR_HEADERS_FOR_FUNC, {
+      'project': project,
+      'function_signature': func_sig
+  })
+  arg_types = _get_data(resp, 'headers-to-include', [])
+  return arg_types
 
 
 def query_introspector_function_debug_arg_types(project: str,

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -300,7 +300,7 @@ def query_introspector_jvm_source_path(project: str) -> List[str]:
 
 
 def query_introspector_header_files_to_include(project: str,
-                                                func_sig: str) -> List[str]:
+                                               func_sig: str) -> List[str]:
   """Queries Fuzz Introspector header files where a function is likely
   declared."""
   resp = _query_introspector(INTROSPECTOR_HEADERS_FOR_FUNC, {

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -857,9 +857,9 @@ class CSpecificBuilder(PromptBuilder):
                                       function_source)
 
     # Set header inclusion string if there are any headers.
-    headers_to_include = introspector.query_introspector_header_files_to_include(
-        self.benchmark.project,
-        self.benchmark.function_signature)
+    headers_to_include = \
+        introspector.query_introspector_header_files_to_include(
+        self.benchmark.project, self.benchmark.function_signature)
     header_inclusion_string = ''
     if headers_to_include:
       header_inclusion_string = ', '.join(headers_to_include)

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -857,8 +857,9 @@ class CSpecificBuilder(PromptBuilder):
                                       function_source)
 
     # Set header inclusion string if there are any headers.
-    headers_to_include = introspector.query_introspector_header_files(
-        self.benchmark.project)
+    headers_to_include = introspector.query_introspector_header_files_to_include(
+        self.benchmark.project,
+        self.benchmark.function_signature)
     header_inclusion_string = ''
     if headers_to_include:
       header_inclusion_string = ', '.join(headers_to_include)

--- a/prompts/template_xml/c-priming.txt
+++ b/prompts/template_xml/c-priming.txt
@@ -15,7 +15,7 @@ Please wrap all code in <code> tags and you should include nothing else but the 
 
 Make sure the ensure strings passed to the target are null-terminated.
 
-There is one rule that your harness must satisfy: all of the header files in this library are: {TARGET_HEADER_FILES}. Make sure to not include any header files not in this list and you should use the full path to the header file as outlined in the list.
+The function we're fuzzing and corresponding types are included in the following header files: {TARGET_HEADER_FILES}. Please include these files in the target harness and use the full path to the header file as outlined in the list.
 
 {FUNCTION_ARG_TYPES_MSG}
 


### PR DESCRIPTION
Also uses it in the C-targeted prompt. In essence an alternative to having this in the prompt is avoiding having these in the prompt and just including the header files mechanically, but I'll explore that later for now.

This has been tested locally on a myriad of C projects, so suggest leaving the CI experimentation for now (I'll add the ability to apply a given model shortly)