### PR TITLE
JVM: Fix bug on cross reference code retrieval

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -724,10 +724,8 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
     # Query for source code of target method callsites
     xref_source_list = []
-    for xref in introspector.query_introspector_cross_references(
+    for xref_source in introspector.query_introspector_cross_references(
         self.benchmark.project, signature):
-      xref_source = introspector.query_introspector_function_source(
-          self.benchmark.project, xref)
       if xref_source:
         xref_source_list.append(xref_source)
 


### PR DESCRIPTION
This PR fixes a bug in the wrong source code retrieval logic for function cross reference. 