### PR TITLE
JVM: Revamp prompt structure

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -714,7 +714,7 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
       argument_descriptions.append(argument)
 
-    return '\n'.join(argument_descriptions)
+    return '<arguments>' + '\n'.join(argument_descriptions) + '</arguments>'
 
   def _format_source_reference(self, signature: str) -> Tuple[str, str]:
     """Formats the source code reference for this target."""

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -662,11 +662,9 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
        method and format it for the prompts creation.
     """
     if '<init>' in signature:
-      target = self._format_target_constructor(signature)
-    else:
-      target = self._format_target_method(signature)
+      return self._format_target_constructor(signature)
 
-    return target.replace('{EXCEPTIONS}', self._format_exceptions())
+    return self._format_target_method(signature)
 
   def _format_requirement(self, signature: str) -> str:
     """Formats a requirement based on the prompt template."""
@@ -742,6 +740,7 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
                               self._format_requirement(signature))
     problem = problem.replace('{DATA_MAPPING}', self._format_data_filler())
     problem = problem.replace('{ARGUMENTS}', self._format_arguments())
+    problem = problem.replace('{EXCEPTIONS}', self._format_exceptions())
 
     self_source, cross_source = self._format_source_reference(signature)
     problem = problem.replace('{SELF_SOURCE}', self_source)

--- a/prompts/template_xml/jvm_base.txt
+++ b/prompts/template_xml/jvm_base.txt
@@ -4,4 +4,4 @@ The <target> tag contains information of the target method to invoke.
 The <arguments> tag contains information of each of the target method arguments.
 The <exceptions> tag contains a list of exceptions thrown by the target method that you MUST catch.
 The <constructor> tag contains constructor or method call details you MUST use to create the needed object before calling the target method.
-The <requirement> tag contains additional requirements that you MUST follow for this code generation.
+The <requirements> tag contains additional requirements that you MUST follow for this code generation.

--- a/prompts/template_xml/jvm_problem.txt
+++ b/prompts/template_xml/jvm_problem.txt
@@ -1,6 +1,14 @@
 <task>
 Your goal is to write a fuzzing harness for the provided method signature using Jazzer framework from Code Intellengence. It is important that the provided solution compiles and actually calls the function specified by the method signature:
 {TARGET}
+{ARGUMENTS}
+{EXCEPTIONS}
+Here is the source code of the target constructor for reference.
+<code>
+{SELF_SOURCE}
+</code>
+Here is a list of source codes of methods that directly invoke the target consturctor for reference.
+{CROSS_SOURCE}
 {REQUIREMENTS}
 {DATA_MAPPING}
 </task>

--- a/prompts/template_xml/jvm_problem_constructor.txt
+++ b/prompts/template_xml/jvm_problem_constructor.txt
@@ -7,15 +7,4 @@ The constructor signature follows the format of <code>[Full qualified name of th
 For example, for the constructor of class <code>Test</code> of package <code>org.test</code> which takes in a single integer would have the following signature:
 <code>[org.test.Test].<init>(int)</code>
 The target method is belonging to the Java project {PROJECT_NAME} ({PROJECT_URL}).
-Here is the list of arguments of the target constructor with descriptions.
-<arguments>
-{ARGUMENTS}
-</arguments>
-{EXCEPTIONS}
-Here is the source code of the target constructor for reference.
-<code>
-{SELF_SOURCE}
-</code>
-Here is a list of source codes of methods that directly invoke the target consturctor for reference.
-{CROSS_SOURCE}
 </target>

--- a/prompts/template_xml/jvm_problem_method.txt
+++ b/prompts/template_xml/jvm_problem_method.txt
@@ -6,15 +6,4 @@ The method signature follows the format of <code>[Full qualified name of the cla
 For example, for a method <code>test</code> in class <code>Test</code> of package <code>org.test</code> which takes in a single integer would have the following method signature:
 <code>[org.test.Test].test(int)</code>
 The target method is belonging to the Java project {PROJECT_NAME} ({PROJECT_URL}).
-Here is the list of arguments of the target method with descriptions.
-<arguments>
-{ARGUMENTS}
-</arguments>
-{EXCEPTIONS}
-Here is the source code of the target method for reference.
-<code>
-{SELF_SOURCE}
-</code>
-Here is a list of source codes of methods that directly invoke the target method for reference.
-{CROSS_SOURCE}
 </target>


### PR DESCRIPTION
This PR revamps the JVM prompt template structure by grouping and organising different method properties into subtags to allow the LLM model to pick up the necessary information in a non-confusion way. 