### PR TITLE
experimental: refactor to simplify and compartmentalise

### DIFF
--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -26,6 +26,17 @@ import manager
 logger = logging.getLogger(name=__name__)
 
 
+class BuildWorker:
+  """Keeper of data on auto generated builds."""
+
+  def __init__(self):
+    self.build_script: str = ''
+    self.build_suggestion: str = ''
+    self.build_directory: str = ''
+    self.executable_files_build: Dict[str, List[str]] = {}
+    self.base_fuzz_build: bool = False
+
+
 ############################################################
 #### Logic for auto building a given source code folder ####
 ############################################################
@@ -708,7 +719,7 @@ def extract_build_suggestions(
 
 def raw_build_evaluation(
     all_build_scripts: List[Tuple[str, str, AutoBuildContainer]],
-    initial_executable_files: Dict[str, List[str]]) -> Dict[str, Any]:
+    initial_executable_files: Dict[str, List[str]]) -> Dict[str, BuildWorker]:
   """Run each of the build scripts and extract any artifacts build by them."""
   build_results = {}
   for build_script, test_dir, build_suggestion in all_build_scripts:
@@ -727,22 +738,18 @@ def raw_build_evaluation(
     # to running the build.
     binary_files_build = get_all_binary_files_from_folder(test_dir)
 
-    new_binary_files = {
-        'static-libs': [],
-        'dynamic-libs': [],
-        'object-files': []
-    }
-    for key, bfiles in binary_files_build.items():
-      for bfile in bfiles:
-        if bfile not in initial_executable_files[key]:
-          new_binary_files[key].append(bfile)
-
-    logger.info('Static libs found %s', str(new_binary_files))
-
     # binary_files_build['static-libs'])
-    build_results[test_dir] = {
-        'build-script': build_script,
-        'executables-build': binary_files_build,
-        'auto-build-setup': (build_script, test_dir, build_suggestion)
-    }
+    #build_results[test_dir] = {
+    #    'build-script': build_script,
+    #    'executables-build': binary_files_build,
+    #    'auto-build-setup': (build_script, test_dir, build_suggestion)
+    #}
+    build_worker = BuildWorker()
+    build_worker.build_script = build_script
+    build_worker.build_suggestion = build_suggestion
+    build_worker.executable_files_build = binary_files_build
+    build_worker.build_directory = test_dir
+
+    build_results[test_dir] = build_worker
+
   return build_results

--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -39,11 +39,13 @@ class AutoBuildContainer:
 class BuildWorker:
   """Keeper of data on auto generated builds."""
 
-  def __init__(self, build_suggestion: AutoBuildContainer):
+  def __init__(self, build_suggestion: AutoBuildContainer, build_script: str,
+               build_directory: str, executable_files_build: Dict[str,
+                                                                  List[str]]):
     self.build_suggestion: AutoBuildContainer = build_suggestion
-    self.build_script: str = ''
-    self.build_directory: str = ''
-    self.executable_files_build: Dict[str, List[str]] = {}
+    self.build_script: str = build_script
+    self.build_directory: str = build_directory
+    self.executable_files_build: Dict[str, List[str]] = executable_files_build
     self.base_fuzz_build: bool = False
 
 
@@ -738,16 +740,8 @@ def raw_build_evaluation(
     # to running the build.
     binary_files_build = get_all_binary_files_from_folder(test_dir)
 
-    # binary_files_build['static-libs'])
-    #build_results[test_dir] = {
-    #    'build-script': build_script,
-    #    'executables-build': binary_files_build,
-    #    'auto-build-setup': (build_script, test_dir, build_suggestion)
-    #}
-    build_worker = BuildWorker(build_suggestion)
-    build_worker.build_script = build_script
-    build_worker.executable_files_build = binary_files_build
-    build_worker.build_directory = test_dir
+    build_worker = BuildWorker(build_suggestion, build_script, test_dir,
+                               binary_files_build)
 
     build_results[test_dir] = build_worker
 

--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -26,17 +26,6 @@ import manager
 logger = logging.getLogger(name=__name__)
 
 
-class BuildWorker:
-  """Keeper of data on auto generated builds."""
-
-  def __init__(self):
-    self.build_script: str = ''
-    self.build_suggestion: str = ''
-    self.build_directory: str = ''
-    self.executable_files_build: Dict[str, List[str]] = {}
-    self.base_fuzz_build: bool = False
-
-
 ############################################################
 #### Logic for auto building a given source code folder ####
 ############################################################
@@ -45,6 +34,17 @@ class AutoBuildContainer:
   def __init__(self):
     self.list_of_commands = []
     self.heuristic_id = ''
+
+
+class BuildWorker:
+  """Keeper of data on auto generated builds."""
+
+  def __init__(self, build_suggestion: AutoBuildContainer):
+    self.build_suggestion: AutoBuildContainer = build_suggestion
+    self.build_script: str = ''
+    self.build_directory: str = ''
+    self.executable_files_build: Dict[str, List[str]] = {}
+    self.base_fuzz_build: bool = False
 
 
 class AutoBuildBase:
@@ -744,9 +744,8 @@ def raw_build_evaluation(
     #    'executables-build': binary_files_build,
     #    'auto-build-setup': (build_script, test_dir, build_suggestion)
     #}
-    build_worker = BuildWorker()
+    build_worker = BuildWorker(build_suggestion)
     build_worker.build_script = build_script
-    build_worker.build_suggestion = build_suggestion
     build_worker.executable_files_build = binary_files_build
     build_worker.build_directory = test_dir
 

--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -465,9 +465,9 @@ class CMakeScannerOptsParser(AutoBuildBase):
       if option['type'] != 'BOOL':
         continue
       if 'STATIC' in option['name'] and option['default'] != 'ON':
-        cmake_string += '-D%s=ON ' % (option['name'])
+        cmake_string += f'-D{option["name"]}=ON '
       elif option['default'] != 'OFF':
-        cmake_string += '-D%s=OFF ' % (option['name'])
+        cmake_string += f'-D{option["name"]}=OFF '
     return cmake_string
 
 
@@ -527,7 +527,7 @@ class CMakeScanner(AutoBuildBase):
     opt1 = [
         'mkdir fuzz-build',
         'cd fuzz-build',
-        'cmake %s ../' % (' '.join(cmake_opts)),
+        f'cmake {" ".join(cmake_opts)} ../',
         'make V=1 || true',
     ]
     build_container2 = AutoBuildContainer()
@@ -539,7 +539,7 @@ class CMakeScanner(AutoBuildBase):
     opt_static = [
         'mkdir fuzz-build',
         'cd fuzz-build',
-        'cmake %s ../' % (' '.join(cmake_opts)),
+        f'cmake {" ".join(cmake_opts)} ../',
         'sed -i \'s/SHARED/STATIC/g\' ../CMakeLists.txt',
         'make V=1 || true',
     ]
@@ -552,13 +552,13 @@ class CMakeScanner(AutoBuildBase):
     option_values = []
     for option in self.cmake_options:
       if 'BUILD_SHARED_LIBS' == option:
-        option_values.append('-D%s=OFF' % (option))
+        option_values.append(f'-D{option}=OFF')
       elif 'BUILD_STATIC' == option:
-        option_values.append('-D%s=ON' % (option))
+        option_values.append(f'-D{option}=ON')
       elif 'BUILD_SHARED' == option:
-        option_values.append('-D%s=OFF' % (option))
+        option_values.append(f'-D{option}=OFF')
       elif 'ENABLE_STATIC' == option:
-        option_values.append('-D%s=ON' % (option))
+        option_values.append(f'-D{option}=ON')
 
     if len(option_values) > 0:
       option_string = ' '.join(option_values)
@@ -569,7 +569,7 @@ class CMakeScanner(AutoBuildBase):
       bopt = [
           'mkdir fuzz-build',
           'cd fuzz-build',
-          'cmake %s %s ../' % (' '.join(cmake_default_options), option_string),
+          f'cmake {" ".join(cmake_default_options)} {option_string} ../',
           'make V=1',
       ]
       build_container3 = AutoBuildContainer()
@@ -582,15 +582,15 @@ class CMakeScanner(AutoBuildBase):
     option_values = []
     for option in self.cmake_options:
       if 'BUILD_SHARED_LIBS' == option:
-        option_values.append('-D%s=OFF' % (option))
+        option_values.append(f'-D{option}=OFF')
       elif 'BUILD_STATIC' == option:
-        option_values.append('-D%s=ON' % (option))
+        option_values.append(f'-D{option}=ON')
       elif 'BUILD_SHARED' == option:
-        option_values.append('-D%s=OFF' % (option))
+        option_values.append(f'-D{option}=OFF')
       elif 'ENABLE_STATIC' == option:
-        option_values.append('-D%s=ON' % (option))
+        option_values.append(f'-D{option}=ON')
       elif 'BUILD_TESTS' in option:
-        option_values.append('-D%s=ON' % (option))
+        option_values.append(f'-D{option}=ON')
 
     if len(option_values) > 0:
       option_string = ' '.join(option_values)
@@ -601,7 +601,7 @@ class CMakeScanner(AutoBuildBase):
       bopt = [
           'mkdir fuzz-build',
           'cd fuzz-build',
-          'cmake %s %s ../' % (' '.join(cmake_default_options), option_string),
+          f'cmake {" ".join(cmake_default_options)} {option_string} ../',
           'make V=1',
       ]
       build_container4 = AutoBuildContainer()
@@ -677,9 +677,9 @@ def get_all_binary_files_from_folder(path: str) -> Dict[str, List[str]]:
 def wrap_build_script(test_dir: str, build_container: AutoBuildContainer,
                       abspath_of_target: str) -> str:
   build_script = '#!/bin/bash\n'
-  build_script += 'rm -rf /%s\n' % (test_dir)
-  build_script += 'cp -rf %s %s\n' % (abspath_of_target, test_dir)
-  build_script += 'cd %s\n' % (test_dir)
+  build_script += f'rm -rf /{test_dir}\n'
+  build_script += f'cp -rf {abspath_of_target} {test_dir}\n'
+  build_script += f'cd {test_dir}\n'
   for cmd in build_container.list_of_commands:
     build_script += cmd + '\n'
 

--- a/experimental/c-cpp/build_generator.py
+++ b/experimental/c-cpp/build_generator.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import subprocess
 from abc import abstractmethod
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 
 import manager
 
@@ -718,8 +718,8 @@ def extract_build_suggestions(
 
 
 def raw_build_evaluation(
-    all_build_scripts: List[Tuple[str, str, AutoBuildContainer]],
-    initial_executable_files: Dict[str, List[str]]) -> Dict[str, BuildWorker]:
+    all_build_scripts: List[Tuple[str, str, AutoBuildContainer]]
+) -> Dict[str, BuildWorker]:
   """Run each of the build scripts and extract any artifacts build by them."""
   build_results = {}
   for build_script, test_dir, build_suggestion in all_build_scripts:

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -163,7 +163,7 @@ class FuzzHeuristicGeneratorBase:
 
   def log_prompt(self, prompt: str) -> None:
     """Logs the prompt to stdout."""
-    logger.info('-' * 20, ' PROMPT ', '-' * 20, '\n', prompt, '\n', '-' * 48)
+    logger.info('-' * 20 + ' PROMPT ' + '-' * 20 + '\n' + prompt + '\n' + '-' * 48)
 
   def get_header_intrinsics(self):
     """All header files and include directories."""
@@ -216,7 +216,7 @@ class FuzzHeuristicGeneratorBase:
     else:
       raise Exception(f'Did not find a relevant LLM for "{LLM_MODEL}".')
 
-    logger.info('>' * 45, ' Source:')
+    logger.info('>' * 45 + ' Source:')
     logger.info(fuzzer_source)
     logger.info('-' * 65)
     return fuzzer_source
@@ -356,7 +356,7 @@ The most important part of the harness is that it will build and compile correct
 ''' % (self.github_url, func['function_signature'], func_source_code,
        str(headers_to_include), type_constraints, cross_reference_text)
 
-    logger.info('-' * 45, '\n', prompt, '\n', '-' * 45)
+    logger.info('-' * 45 + '\n' + prompt + '\n' + '-' * 45)
 
     fuzzer_source = get_source_from_cache(self.name, func)
     if not fuzzer_source:

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -148,9 +148,10 @@ class FuzzHeuristicGeneratorBase:
 
   def log_prompt(self, prompt: str) -> None:
     """Logs the prompt to stdout."""
-    prompt_out = '-' * 20 + ' PROMPT ' + '-' * 20 + '\n'
-    prompt_out += prompt + '\n'
-    prompt_out += '-' * 48
+    prompt_out = f'{"-"*20} PROMPT {"-"*20}\n{prompt}\n{"-" * 48}'
+    #prompt_out = '-' * 20 + ' PROMPT ' + '-' * 20 + '\n'
+    #prompt_out += prompt + '\n'
+    #prompt_out += '-' * 48
     logger.info(prompt_out)
 
   def get_header_intrinsics(self):
@@ -288,7 +289,7 @@ class FuzzerGenHeuristic6(FuzzHeuristicGeneratorBase):
 
     type_constraints = 'the types of types function are:\n'
     for idx, arg in enumerate(func['debug_function_info']['args']):
-      type_constraints += f'- Argument {idx+1} is of type \"{arg}\"\n'
+      type_constraints += f'- Argument {idx+1} is of type `{arg}`\n'
     type_constraints += (
         'You must make sure the arguments passed to the ' +
         'function match the types of the function. Do this by casting ' +
@@ -343,7 +344,7 @@ The most important part of the harness is that it will build and compile correct
 {cross_reference_text}
 '''
 
-    logger.info('%s%s%s', '-' * 45, '\n' + prompt + '\n', '-' * 45)
+    logger.info('%s%s%s', '-' * 45, f'\n{prompt}\n', '-' * 45)
 
     fuzzer_source = get_source_from_cache(self.name, func)
     if not fuzzer_source:
@@ -410,7 +411,7 @@ Please wrap all code in <code> tags and you should include nothing else but the 
 
 Make sure the ensure strings passed to the target are null-terminated.
 
-There is one rule that your harness must satisfy: all of the header files in this library is {str(headers_to_include)}. Make sure to not include any header files not in this list.
+There is one rule that your harness must satisfy: all of the header files in this library is {headers_to_include}. Make sure to not include any header files not in this list.
 
 Finally, {type_constraints}
 
@@ -478,7 +479,7 @@ Please wrap all code in <code> tags and you should include nothing else but the 
 
 Make sure the ensure strings passed to the target are null-terminated.
 
-There is one rule that your harness must satisfy: all of the header files in this library is {str(headers_to_include)}. Make sure to not include any header files not in this list.
+There is one rule that your harness must satisfy: all of the header files in this library is {headers_to_include}. Make sure to not include any header files not in this list.
 
 Finally, {type_constraints}
 
@@ -774,7 +775,7 @@ def build_empty_fuzzers(build_workers, language):
     logger.info('Test dir: %s :: %s', test_dir,
                 str(build_worker.executable_files_build['refined-static-libs']))
 
-    if len(build_worker.executable_files_build['refined-static-libs']) == 0:
+    if not build_worker.executable_files_build['refined-static-libs']:
       continue
 
     logger.info('Trying to link in an empty fuzzer')
@@ -886,9 +887,8 @@ def run_introspector_on_dir(build_worker, test_dir,
 
 
 def log_fuzzer_source(full_fuzzer_source: str):
-  harness_source_out = '-' * 20 + ' HARNESS SOURCE ' + '-' * 20 + '\n'
-  harness_source_out += full_fuzzer_source + '\n'
-  harness_source_out += '-' * 56
+  harness_source_out = (
+      f'{"-" * 20} HARNESS SOURCE {"-" * 20}\n{full_fuzzer_source}\n{"-" * 56}')
   logger.info(harness_source_out)
 
 
@@ -933,10 +933,9 @@ def generate_harness_intrinsics(
     # Generate a build script for compiling the fuzzer with ASAN.
     final_asan_build_script = results[test_dir].build_script + '\n'
     fuzzer_out = '/src/generated-fuzzer'
-    final_asan_build_script += ' '.join(fuzzer_build_cmd) + ' '
-    final_asan_build_script += fuzzer_intrinsics['build-command-includes']
-    final_asan_build_script += ' -o '
-    final_asan_build_script += fuzzer_out
+    fuzz_cmd = ' '.join(fuzzer_build_cmd) + ' '
+    fuzz_includes = fuzzer_intrinsics["build-command-includes"]
+    final_asan_build_script += f'{fuzz_cmd} {fuzz_includes} -o {fuzzer_out}'
 
     # Wrap all parts we need for building and running the fuzzer.
     harness_builds_to_validate.append({

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -1040,7 +1040,7 @@ def evaluate_heuristic(test_dir, result_to_validate, fuzzer_intrinsics,
 
   # Run the fuzzer and observer error
   if not os.path.isfile(
-      '/src/generated-fuzzer'):  #result_to_validate['fuzzer-out']):
+      '/src/generated-fuzzer'):
     logger.info('No fuzzing harness executable')
     logger.info('Copying [%s] to [%s]', fuzzer_gen_dir,
                 os.path.join(outdir, os.path.basename(fuzzer_gen_dir)))

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -900,8 +900,8 @@ def run_introspector_on_dir(build_results, test_dir,
 
 
 def log_fuzzer_source(full_fuzzer_source: str):
-  logger.info('-' * 20, ' HARNESS SOURCE ', '-' * 20, '\n', full_fuzzer_source,
-              '\n', '-' * 56)
+  logger.info('-' * 20 + ' HARNESS SOURCE ' + '-' * 20 + '\n'+ full_fuzzer_source+
+              '\n' + '-' * 56)
 
 
 def generate_harness_intrinsics(

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -933,9 +933,9 @@ def generate_harness_intrinsics(
     # Generate a build script for compiling the fuzzer with ASAN.
     final_asan_build_script = results[test_dir].build_script + '\n'
     fuzzer_out = '/src/generated-fuzzer'
-    final_asan_build_script += ' '.join(fuzzer_build_cmd)
+    final_asan_build_script += ' '.join(fuzzer_build_cmd) + ' '
     final_asan_build_script += fuzzer_intrinsics['build-command-includes']
-    final_asan_build_script += '-o'
+    final_asan_build_script += ' -o '
     final_asan_build_script += fuzzer_out
 
     # Wrap all parts we need for building and running the fuzzer.

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -822,7 +822,7 @@ def build_empty_fuzzers(build_workers, language):
     build_worker.base_fuzz_build = base_fuzz_build
 
 
-def refine_static_libs(build_results) -> List[str]:
+def refine_static_libs(build_results) -> None:
   """Returns a list of static libraries with substitution of common gtest
   libraries, which should not be linked in the fuzzer builds."""
   for test_dir in build_results:

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -91,21 +91,6 @@ def determine_project_language(path: str) -> str:
   return target_language
 
 
-def get_all_binary_files_from_folder(path: str) -> Dict[str, List[str]]:
-  """Extracts binary artifacts from a list of files, based on file suffix."""
-  all_files = get_all_files_in_path(path, path)
-
-  executable_files = {'static-libs': [], 'dynamic-libs': [], 'object-files': []}
-  for fil in all_files:
-    if fil.endswith('.o'):
-      executable_files['object-files'].append(fil)
-    if fil.endswith('.a'):
-      executable_files['static-libs'].append(fil)
-    if fil.endswith('.so'):
-      executable_files['dynamic-libs'].append(fil)
-  return executable_files
-
-
 def get_all_functions_in_project(introspection_files_found):
   all_functions_in_project = []
   for fi_yaml_file in introspection_files_found:
@@ -1273,9 +1258,6 @@ def auto_generate(github_url,
         f'git clone --recurse-submodules {github_url} {dst_folder}', shell=True)
 
   # Stage 1: Build script generation
-  initial_executable_files = get_all_binary_files_from_folder(
-      target_source_path)
-
   language = determine_project_language(target_source_path)
   logger.info('Target language: %s', language)
   append_to_report(outdir, f'Target language: {language}')
@@ -1293,8 +1275,7 @@ def auto_generate(github_url,
 
   # Check each of the build scripts.
   logger.info('[+] Testing build suggestions')
-  build_results = build_generator.raw_build_evaluation(
-      all_build_scripts, initial_executable_files)
+  build_results = build_generator.raw_build_evaluation(all_build_scripts)
   logger.info('Checking results of %d build generators', len(build_results))
   for test_dir, build_worker in build_results.items():
     build_heuristic = build_worker.build_suggestion.heuristic_id

--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -163,7 +163,8 @@ class FuzzHeuristicGeneratorBase:
 
   def log_prompt(self, prompt: str) -> None:
     """Logs the prompt to stdout."""
-    logger.info('-' * 20 + ' PROMPT ' + '-' * 20 + '\n' + prompt + '\n' + '-' * 48)
+    logger.info('-' * 20 + ' PROMPT ' + '-' * 20 + '\n' + prompt + '\n' +
+                '-' * 48)
 
   def get_header_intrinsics(self):
     """All header files and include directories."""
@@ -806,7 +807,8 @@ def build_empty_fuzzers(build_workers, language):
         fuzz_compiler, '-fsanitize=fuzzer', '-fsanitize=address',
         empty_fuzzer_file
     ]
-    for refined_static_lib in build_worker.executable_files_build['refined-static-libs']:
+    for refined_static_lib in build_worker.executable_files_build[
+        'refined-static-libs']:
       cmd.append(os.path.join(test_dir, refined_static_lib))
 
     logger.info('Command [%s]', ' '.join(cmd))
@@ -836,7 +838,8 @@ def refine_static_libs(build_results) -> List[str]:
           for lib_to_avoid in libs_to_avoid):
         continue
       refined_static_list.append(static_lib)
-    build_worker.executable_files_build['refined-static-libs'] = refined_static_list
+    build_worker.executable_files_build[
+        'refined-static-libs'] = refined_static_list
 
 
 def get_language_defaults(language: str):
@@ -871,7 +874,8 @@ def run_introspector_on_dir(build_worker, test_dir,
   fuzzer_build_cmd = [
       fuzz_compiler, fuzz_flags, '$LIB_FUZZING_ENGINE', empty_fuzzer_file
   ]
-  for refined_static_lib in build_worker.executable_files_build['refined-static-libs']:
+  for refined_static_lib in build_worker.executable_files_build[
+      'refined-static-libs']:
     fuzzer_build_cmd.append('-Wl,--whole-archive')
     fuzzer_build_cmd.append(os.path.join(test_dir, refined_static_lib))
 
@@ -1040,8 +1044,7 @@ def evaluate_heuristic(test_dir, result_to_validate, fuzzer_intrinsics,
     f.write(fuzzer_intrinsics['prompt'])
 
   # Run the fuzzer and observer error
-  if not os.path.isfile(
-      '/src/generated-fuzzer'):
+  if not os.path.isfile('/src/generated-fuzzer'):
     logger.info('No fuzzing harness executable')
     logger.info('Copying [%s] to [%s]', fuzzer_gen_dir,
                 os.path.join(outdir, os.path.basename(fuzzer_gen_dir)))
@@ -1299,14 +1302,11 @@ def auto_generate(github_url,
     append_to_report(
         outdir,
         f'build success: {build_heuristic} :: {test_dir} :: {static_libs}')
-    logger.info('%s : %s : %s',
-                build_heuristic, test_dir,
-                static_libs)
+    logger.info('%s : %s : %s', build_heuristic, test_dir, static_libs)
 
   # For each of the auto generated build scripts identify the
   # static libraries resulting from the build.
-  refine_static_libs(
-      build_results)
+  refine_static_libs(build_results)
 
   # Stage 2: perform program analysis to extract data to be used for
   # harness generation.
@@ -1330,7 +1330,8 @@ def auto_generate(github_url,
   logger.info('Going through %d build results to generate fuzzers',
               len(build_results))
   for test_dir, build_worker in build_results.items():
-    logger.info('Checking build heuristic: %s', build_worker.build_suggestion.heuristic_id)
+    logger.info('Checking build heuristic: %s',
+                build_worker.build_suggestion.heuristic_id)
 
     # Skip if build suggestion did not work with an empty fuzzer.
     if not build_worker.base_fuzz_build:
@@ -1404,7 +1405,6 @@ def auto_generate(github_url,
                            folders_with_results, outdir, github_url, language,
                            introspector_report)
         idx += 1
-
 
   # Show those that succeeded.
   for hp in heuristics_passed:

--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -64,17 +64,17 @@ def setup_worker_project(oss_fuzz_base: str, project_name: str, llm_model: str):
 
   # Build a version of the project
   if silent_global:
-    subprocess.check_call('python3 infra/helper.py build_fuzzers %s' %
-                          (project_name),
-                          shell=True,
-                          cwd=oss_fuzz_base,
-                          stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL)
+    subprocess.check_call(
+        f'python3 infra/helper.py build_fuzzers {project_name}',
+        shell=True,
+        cwd=oss_fuzz_base,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL)
   else:
-    subprocess.check_call('python3 infra/helper.py build_fuzzers %s' %
-                          (project_name),
-                          shell=True,
-                          cwd=oss_fuzz_base)
+    subprocess.check_call(
+        f'python3 infra/helper.py build_fuzzers {project_name}',
+        shell=True,
+        cwd=oss_fuzz_base)
 
 
 def run_coverage_runs(oss_fuzz_base: str, worker_name: str) -> None:
@@ -145,11 +145,11 @@ def run_autogen(github_url,
                 generator_heuristics='all'):
   """Launch auto-gen analysis within OSS-Fuzz container."""
 
-  initiator_cmd = 'python3 /src/manager.py %s -o %s' % (github_url, outdir)
+  initiator_cmd = f'python3 /src/manager.py {github_url} -o {outdir}'
   if disable_autofuzz:
     initiator_cmd += ' --disable-fuzzgen'
-  initiator_cmd += ' --model=%s' % (model)
-  initiator_cmd += ' --targets-per-heuristic=%d' % (targets_per_heuristic)
+  initiator_cmd += f' --model={model}'
+  initiator_cmd += f' --targets-per-heuristic={targets_per_heuristic}'
 
   extra_environment = []
   if model == 'vertex':
@@ -157,7 +157,7 @@ def run_autogen(github_url,
     extra_environment.append('GOOGLE_APPLICATION_CREDENTIALS=/src/creds.json')
   elif model == 'openai':
     extra_environment.append('-e')
-    extra_environment.append('OPENAI_API_KEY=%s' % (openai_api_key))
+    extra_environment.append(f'OPENAI_API_KEY={openai_api_key}')
 
   cmd = [
       'docker',
@@ -174,18 +174,18 @@ def run_autogen(github_url,
       '-e',
       'FUZZING_LANGUAGE=c++',
       '-e',
-      'BUILD_HEURISTICS=%s' % (build_heuristics),
+      f'BUILD_HEURISTICS={build_heuristics}',
       '-e',
-      'GENERATOR_HEURISTICS=%s' % (generator_heuristics),
+      f'GENERATOR_HEURISTICS={generator_heuristics}',
   ] + extra_environment
 
   cmd += [
       '-v',
-      '%s/build/out/%s:/out' % (oss_fuzz_base, worker_project),
+      f'{oss_fuzz_base}/build/out/{worker_project}:/out',
       '-v',
-      '%s/build/work/%s:/work' % (oss_fuzz_base, worker_project),
+      f'{oss_fuzz_base}/build/work/{worker_project}:/work',
       '-t',
-      'gcr.io/oss-fuzz/%s' % (worker_project),
+      f'gcr.io/oss-fuzz/{worker_project}',
       # Command to run inside the container
       initiator_cmd
   ]
@@ -239,7 +239,7 @@ def run_on_targets(target,
 
   outdir = os.path.join('/out/', constants.SHARED_MEMORY_RESULTS_DIR)
   with open('status-log.txt', 'a') as f:
-    f.write("Targeting: %s :: %d\n" % (target, idx))
+    f.write(f'Targeting: {target} :: {idx}\n')
   run_autogen(target,
               outdir,
               oss_fuzz_base,

--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -343,30 +343,32 @@ def setup_logging():
   logging.basicConfig(level=logging.INFO, format=LOG_FMT)
 
 
+def extract_target_repositories(target_input) -> list[str]:
+  if os.path.isfile(target_input):
+    target_repositories = read_targets_file(target_input)
+  else:
+    target_repositories = [target_input]
+  logger.info(target_repositories)
+  return target_repositories
+
+
 def main():
   global silent_global
 
   args = parse_commandline()
+
   setup_logging()
-  target = args.input
-  disable_autofuzz = args.disable_fuzzgen
-
-  if os.path.isfile(target):
-    target_repositories = read_targets_file(target)
-  else:
-    target_repositories = [target]
-  logger.info(target_repositories)
-
+  target_repositories = extract_target_repositories(args.input)
   silent_global = args.silent
 
   use_multithreading = True
   if use_multithreading:
-    run_parallels(os.path.abspath(args.oss_fuzz), target_repositories, disable_autofuzz,
-                  args.targets_per_heuristic, args.model, args.build_heuristics,
-                  args.generator_heuristics)
+    run_parallels(os.path.abspath(args.oss_fuzz), target_repositories,
+                  args.disable_fuzzgen, args.targets_per_heuristic, args.model,
+                  args.build_heuristics, args.generator_heuristics)
   else:
-    run_sequential(os.path.abspath(args.oss_fuzz), target_repositories, disable_autofuzz,
-                   args.targets_per_heuristic, args.model,
+    run_sequential(os.path.abspath(args.oss_fuzz), target_repositories,
+                   args.disable_fuzzgen, args.targets_per_heuristic, args.model,
                    args.build_heuristics, args.generator_heuristics)
 
 

--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -348,7 +348,6 @@ def main():
 
   args = parse_commandline()
   setup_logging()
-  oss_fuzz_base = args.oss_fuzz
   target = args.input
   disable_autofuzz = args.disable_fuzzgen
 
@@ -362,11 +361,11 @@ def main():
 
   use_multithreading = True
   if use_multithreading:
-    run_parallels(oss_fuzz_base, target_repositories, disable_autofuzz,
+    run_parallels(os.path.abspath(args.oss_fuzz), target_repositories, disable_autofuzz,
                   args.targets_per_heuristic, args.model, args.build_heuristics,
                   args.generator_heuristics)
   else:
-    run_sequential(oss_fuzz_base, target_repositories, disable_autofuzz,
+    run_sequential(os.path.abspath(args.oss_fuzz), target_repositories, disable_autofuzz,
                    args.targets_per_heuristic, args.model,
                    args.build_heuristics, args.generator_heuristics)
 


### PR DESCRIPTION
Refactors the from-scratch logic by:
- Adding a container for build workers
- Removing unused code
- Facelifting string formatting since it was added to the CI

Note, in the `manager` and `build_generator` we can't remove the use of `List` and `Dict` since it relies on the Python from OSS-Fuzz, which hasn't migrated to `list` and `dict` yet.

This is working towards https://github.com/google/oss-fuzz-gen/issues/450