### PR TITLE
core: enable use of dedicated oss-fuzz folder

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -75,10 +75,14 @@ def _clone_oss_fuzz_repo():
     print(stderr)
 
 
-def clone_oss_fuzz(temp_repo: bool = True):
+def clone_oss_fuzz(oss_fuzz_dir: str = ''):
   """Clones the OSS-Fuzz repository."""
-  if temp_repo:
+  if not oss_fuzz_dir:
     _set_temp_oss_fuzz_repo()
+  else:
+    global OSS_FUZZ_DIR
+    OSS_FUZZ_DIR=oss_fuzz_dir
+
   if not os.path.exists(OSS_FUZZ_DIR):
     _clone_oss_fuzz_repo()
   # Remove existing targets.

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -81,7 +81,7 @@ def clone_oss_fuzz(oss_fuzz_dir: str = ''):
     _set_temp_oss_fuzz_repo()
   else:
     global OSS_FUZZ_DIR
-    OSS_FUZZ_DIR=oss_fuzz_dir
+    OSS_FUZZ_DIR = oss_fuzz_dir
 
   if not os.path.exists(OSS_FUZZ_DIR):
     _clone_oss_fuzz_repo()

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -218,10 +218,12 @@ def parse_args() -> argparse.Namespace:
                       '--introspector-endpoint',
                       type=str,
                       default=introspector.DEFAULT_INTROSPECTOR_ENDPOINT)
-  parser.add_argument('-of',
-          '--oss-fuzz-dir',
-          help='Path to OSS-Fuzz dir to use. If not set will create temporary directory',
-          default='')
+  parser.add_argument(
+      '-of',
+      '--oss-fuzz-dir',
+      help=
+      'Path to OSS-Fuzz dir to use. If not set will create temporary directory',
+      default='')
   parser.add_argument(
       '-g',
       '--generate-benchmarks',

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -218,6 +218,10 @@ def parse_args() -> argparse.Namespace:
                       '--introspector-endpoint',
                       type=str,
                       default=introspector.DEFAULT_INTROSPECTOR_ENDPOINT)
+  parser.add_argument('-of',
+          '--oss-fuzz-dir',
+          help='Path to OSS-Fuzz dir to use. If not set will create temporary directory',
+          default='')
   parser.add_argument(
       '-g',
       '--generate-benchmarks',
@@ -307,7 +311,7 @@ def main():
   # right API endpoint is used throughout.
   introspector.set_introspector_endpoints(args.introspector_endpoint)
 
-  run_one_experiment.prepare()
+  run_one_experiment.prepare(args.oss_fuzz_dir)
 
   experiment_configs = get_experiment_configs(args)
   experiment_results = []

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -206,9 +206,9 @@ def check_targets(
   return None
 
 
-def prepare() -> None:
+def prepare(oss_fuzz_dir: str) -> None:
   """Prepares the experiment environment."""
-  oss_fuzz_checkout.clone_oss_fuzz(temp_repo=True)
+  oss_fuzz_checkout.clone_oss_fuzz(oss_fuzz_dir)
   oss_fuzz_checkout.postprocess_oss_fuzz()
 
 


### PR DESCRIPTION
This is useful during development purposes where it's convenient being
able to adjust the OSS-Fuzz projects' folders, e.g. to test hypotheses.