### PR TITLE
Filter empty string in comment

### DIFF
--- a/ci/ci_trial_build.py
+++ b/ci/ci_trial_build.py
@@ -69,6 +69,7 @@ def exec_command_from_github(pull_request_number):
   # Set the branch so that the trial_build builds the projects from the PR
   # branch.
   command.extend(['-p', str(pull_request_number)])
+  command = [c for c in command if c]
   logging.info('Command: %s.', command)
   return request_pr_exp.main(command)
 


### PR DESCRIPTION
The comment parser sometimes include empty string as a command line argument, which breaks python's argparser in [`request_pr_exp.py`](https://github.com/google/oss-fuzz-gen/blob/main/ci/request_pr_exp.py).

This PR removes empty strings from the command parsed from the comment.