### PR TITLE
Separate osv-scanner workflows so that the action for scheduled and push will not appear on PRs

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -9,7 +9,7 @@
 # For more examples and options, including how to ignore specific vulnerabilities,
 # see https://google.github.io/osv-scanner/github-action/
 
-name: OSV-Scanner
+name: OSV-Scanner-PR
 
 on:
   pull_request:

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,36 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# A sample workflow which sets up periodic OSV-Scanner scanning for vulnerabilities,
+# in addition to a PR check which fails if new vulnerabilities are introduced.
+#
+# For more examples and options, including how to ignore specific vulnerabilities,
+# see https://google.github.io/osv-scanner/github-action/
+
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  merge_group:
+    branches: [ "main" ]
+
+permissions:
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Read commit contents
+  contents: read
+  # Read permisson for osv-scanner-reusable.
+  actions: read
+
+jobs:
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ba0b4d196d231340e0ae94ae00933c8be0984192" # v1.7.4
+    with:
+      # Example of specifying custom arguments
+      scan-args: |-
+        -r
+        --skip-git
+        ./

--- a/.github/workflows/osv-scanner-scheduled-push.yml
+++ b/.github/workflows/osv-scanner-scheduled-push.yml
@@ -9,13 +9,9 @@
 # For more examples and options, including how to ignore specific vulnerabilities,
 # see https://google.github.io/osv-scanner/github-action/
 
-name: OSV-Scanner
+name: OSV-Scanner-Schedule-Push
 
 on:
-  pull_request:
-    branches: [ "main" ]
-  merge_group:
-    branches: [ "main" ]
   schedule:
     - cron: '29 23 * * 5'
   push:
@@ -30,18 +26,8 @@ permissions:
   actions: read
 
 jobs:
-  scan-scheduled:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+  scan-schedule-push:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@ba0b4d196d231340e0ae94ae00933c8be0984192" # v1.7.4
-    with:
-      # Example of specifying custom arguments
-      scan-args: |-
-        -r
-        --skip-git
-        ./
-  scan-pr:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ba0b4d196d231340e0ae94ae00933c8be0984192" # v1.7.4
     with:
       # Example of specifying custom arguments
       scan-args: |-


### PR DESCRIPTION
Avoid showing irrelevant action on PRs: 
![image](https://github.com/user-attachments/assets/4310213a-7b3d-4be2-bf15-21d56ccb3bb3)
