### PR TITLE
JVM: Remove mentioning of Jazzer in JVM prompts

### DIFF
--- a/prompts/template_xml/jvm_base.txt
+++ b/prompts/template_xml/jvm_base.txt
@@ -1,4 +1,4 @@
-You are a security testing engineer who wants to write a Java program to execute all lines in a given method by defining and initialising its parameters and necessary objects in a suitable way before fuzzing the method with the Java Jazzer framework from Code Intelligence. The source code of the Jazzer framework could be found in the github repository url: https://github.com/CodeIntelligenceTesting/jazzer.
+You are a security testing engineer who wants to write a Java program to execute all lines in a given method by defining and initialising its parameters and necessary objects in a suitable way before fuzzing the method
 Carefully study the method signature and its parameters, then follow the example problems and solutions to answer the final problem. YOU MUST call the target method to fuzz in the solution.
 The <target> tag contains information of the target method to invoke.
 The <arguments> tag contains information of each of the target method arguments.

--- a/prompts/template_xml/jvm_problem.txt
+++ b/prompts/template_xml/jvm_problem.txt
@@ -1,5 +1,5 @@
 <task>
-Your goal is to write a fuzzing harness for the provided method signature using Jazzer framework from Code Intellengence. It is important that the provided solution compiles and actually calls the function specified by the method signature:
+Your goal is to write a fuzzing harness for the provided method signature to fuzz the method with random data. It is important that the provided solution compiles and actually calls the function specified by the method signature:
 {TARGET}
 {ARGUMENTS}
 {CONSTRUCTORS}


### PR DESCRIPTION
This PR fixes the prompt template by removing the mentioning of the Jazzer framework.