### PR TITLE
Rename gen code to query llm

### DIFF
--- a/experimental/manual/prompter.py
+++ b/experimental/manual/prompter.py
@@ -72,4 +72,4 @@ if __name__ == "__main__":
   model = setup_model()
   prompt = construct_prompt()
   os.makedirs(args.response_dir, exist_ok=True)
-  model.generate_code(prompt, response_dir=args.response_dir)
+  model.query_llm(prompt, response_dir=args.response_dir)

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -424,7 +424,7 @@ def apply_llm_fix(ai_binary: str,
                                       error_desc, errors, context, instruction)
   prompt.save(prompt_path)
 
-  fixer_model.generate_code(prompt, response_dir)
+  fixer_model.query_llm(prompt, response_dir)
 
 
 def _collect_context(benchmark: benchmarklib.Benchmark,

--- a/llm_toolkit/crash_triager.py
+++ b/llm_toolkit/crash_triager.py
@@ -107,4 +107,4 @@ def apply_llm_triage(
                                         crash_func)
   prompt.save(prompt_path)
 
-  triage_model.generate_code(prompt, response_dir)
+  triage_model.query_llm(prompt, response_dir)

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -126,9 +126,9 @@ class LLM:
   # ============================== Generation ============================== #
   @abstractmethod
   def query_llm(self,
-                    prompt: prompts.Prompt,
-                    response_dir: str,
-                    log_output: bool = False) -> None:
+                prompt: prompts.Prompt,
+                response_dir: str,
+                log_output: bool = False) -> None:
     """Queries the LLM and stores responses in |response_dir|."""
 
   @abstractmethod
@@ -223,9 +223,9 @@ class GPT(LLM):
 
   # ============================== Generation ============================== #
   def query_llm(self,
-                    prompt: prompts.Prompt,
-                    response_dir: str,
-                    log_output: bool = False) -> None:
+                prompt: prompts.Prompt,
+                response_dir: str,
+                log_output: bool = False) -> None:
     """Queries OpenAI's API and stores response in |response_dir|."""
     if self.ai_binary:
       print(f'OpenAI does not use local AI binary: {self.ai_binary}')
@@ -274,9 +274,9 @@ class GoogleModel(LLM):
 
   # ============================== Generation ============================== #
   def query_llm(self,
-                    prompt: prompts.Prompt,
-                    response_dir: str,
-                    log_output: bool = False) -> None:
+                prompt: prompts.Prompt,
+                response_dir: str,
+                log_output: bool = False) -> None:
     """Queries a Google LLM and stores results in |response_dir|."""
     if not self.ai_binary:
       print(f'Error: This model requires a local AI binary: {self.ai_binary}')
@@ -350,9 +350,9 @@ class VertexAIModel(GoogleModel):
     } for index in range(self.num_samples)]
 
   def query_llm(self,
-                    prompt: prompts.Prompt,
-                    response_dir: str,
-                    log_output: bool = False) -> None:
+                prompt: prompts.Prompt,
+                response_dir: str,
+                log_output: bool = False) -> None:
     del log_output
     if self.ai_binary:
       print(f'VertexAI does not use local AI binary: {self.ai_binary}')

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -129,7 +129,7 @@ class LLM:
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:
-    """Generates fuzz targets to the |response_dir|."""
+    """Queries the LLM and stores responses in |response_dir|."""
 
   @abstractmethod
   def prompt_type(self) -> type[prompts.Prompt]:
@@ -226,7 +226,7 @@ class GPT(LLM):
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:
-    """Generates code with OpenAI's API."""
+    """Queries OpenAI's API and stores response in |response_dir|."""
     if self.ai_binary:
       print(f'OpenAI does not use local AI binary: {self.ai_binary}')
     if self.temperature_list:
@@ -277,7 +277,7 @@ class GoogleModel(LLM):
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:
-    """Generates code with internal LLM."""
+    """Queries a Google LLM and stores results in |response_dir|."""
     if not self.ai_binary:
       print(f'Error: This model requires a local AI binary: {self.ai_binary}')
       sys.exit(1)

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -125,7 +125,7 @@ class LLM:
 
   # ============================== Generation ============================== #
   @abstractmethod
-  def generate_code(self,
+  def query_llm(self,
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:
@@ -222,7 +222,7 @@ class GPT(LLM):
     return prompts.OpenAIPrompt
 
   # ============================== Generation ============================== #
-  def generate_code(self,
+  def query_llm(self,
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:
@@ -273,7 +273,7 @@ class GoogleModel(LLM):
     return int(len(re.split('[^a-zA-Z0-9]+', text)) * 1.5 + 0.5)
 
   # ============================== Generation ============================== #
-  def generate_code(self,
+  def query_llm(self,
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:
@@ -349,7 +349,7 @@ class VertexAIModel(GoogleModel):
             self._max_output_tokens
     } for index in range(self.num_samples)]
 
-  def generate_code(self,
+  def query_llm(self,
                     prompt: prompts.Prompt,
                     response_dir: str,
                     log_output: bool = False) -> None:

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -87,7 +87,7 @@ def generate_targets(benchmark: Benchmark,
   """Generates fuzz target with LLM."""
   print(f'Generating targets for {benchmark.project} '
         f'{benchmark.function_signature} using {model.name}..')
-  model.generate_code(prompt,
+  model.query_llm(prompt,
                       response_dir=work_dirs.raw_targets,
                       log_output=debug)
 

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -87,9 +87,7 @@ def generate_targets(benchmark: Benchmark,
   """Generates fuzz target with LLM."""
   print(f'Generating targets for {benchmark.project} '
         f'{benchmark.function_signature} using {model.name}..')
-  model.query_llm(prompt,
-                      response_dir=work_dirs.raw_targets,
-                      log_output=debug)
+  model.query_llm(prompt, response_dir=work_dirs.raw_targets, log_output=debug)
 
   _, target_ext = os.path.splitext(benchmark.target_path)
   generated_targets = []


### PR DESCRIPTION
The main reason for this is that the `generate_code` does not really generate any code but rather it queries a given LLM using a specified prompt. Since we now have prompts of various sort, I feel it might be a bit misplaced the name. This could also make it a bit more clear which API to use if you're working on using LLMs for tasks other than explicit code generation.

This came up while doing https://github.com/google/oss-fuzz-gen/pull/479 where one consideration was to have the LLM generate a corpus explicit without going a seed-corpus-by-way-of-python generation.

Ref: https://github.com/google/oss-fuzz-gen/issues/482