### PR TITLE
Fully exclude `/usr/` paths.

### DIFF
--- a/experimental/manual/oss_fuzz_vuln_prompt.py
+++ b/experimental/manual/oss_fuzz_vuln_prompt.py
@@ -66,8 +66,7 @@ PROJECTS_DIR = os.path.join('oss-fuzz', 'projects')
 STACK_FRAME_START_REGEX = re.compile(r'\s*#\d+\s+0x[0-9A-Fa-f]+\s+')
 STACK_FRAME_PATH_LINE_REGEX = re.compile(
     r'(?<=\[|\(|\s)([a-zA-Z/.][^\s]*?)\s*(:|@)\s*(\d+)(?=\]$|\)$|:\d+$|$)')
-EXCLUDED_FILE_PATH_SUBSTRINGS = ('/compiler-rt/', '/glibc-',
-                                 '/usr/local/include/')
+EXCLUDED_FILE_PATH_SUBSTRINGS = ('/compiler-rt/', '/glibc-', '/usr/')
 
 
 def get_local_repo_path(repo_url):


### PR DESCRIPTION
Drive-by, following https://github.com/google/oss-fuzz-gen/pull/478#discussion_r1677235224