### PR TITLE
unify logging

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -874,7 +874,7 @@ def _parse_arguments() -> argparse.Namespace:
 set_introspector_endpoints(DEFAULT_INTROSPECTOR_ENDPOINT)
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logger.INFO)
+  logging.basicConfig(level=logging.INFO)
 
   args = _parse_arguments()
   if args.out:

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -195,8 +195,8 @@ def _get_data(resp: Optional[requests.Response], key: str,
     return content
 
   logger.error('Failed to get %s from FI:\n'
-                '%s\n'
-                '%s', key, resp.url, data)
+               '%s\n'
+               '%s', key, resp.url, data)
   return default_value
 
 
@@ -477,7 +477,7 @@ def get_raw_function_name(function: dict, project: str) -> str:
               function.get('raw_function_name', ''))
   if not raw_name:
     logger.error('No raw function name in project: %s for function: %s',
-                  project, function)
+                 project, function)
   return raw_name
 
 
@@ -678,7 +678,7 @@ def populate_benchmarks_using_introspector(project: str, language: str,
 
   target_name = get_target_name(project, harness)
   logger.info('Fuzz target binary found for project %s: %s', project,
-               target_name)
+              target_name)
 
   potential_benchmarks = []
   for function in functions:
@@ -887,7 +887,7 @@ if __name__ == '__main__':
     oss_fuzz_checkout.postprocess_oss_fuzz()
   except subprocess.CalledProcessError as e:
     logger.error('Failed to prepare OSS-Fuzz directory for project %s: %s',
-                  args.project, e)
+                 args.project, e)
   cur_project_language = oss_fuzz_checkout.get_project_language(args.project)
   benchmarks = populate_benchmarks_using_introspector(args.project,
                                                       cur_project_language,

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -33,6 +33,8 @@ from data_prep import project_src
 from experiment import benchmark as benchmarklib
 from experiment import oss_fuzz_checkout
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar('T', str, list, dict, int)  # Generic type.
 
 TIMEOUT = 45
@@ -96,7 +98,6 @@ def set_introspector_endpoints(endpoint):
       INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE
 
   INTROSPECTOR_ENDPOINT = endpoint
-  logging.info('Fuzz Introspector endpoint set to %s', INTROSPECTOR_ENDPOINT)
 
   INTROSPECTOR_CFG = f'{INTROSPECTOR_ENDPOINT}/annotated-cfg'
   INTROSPECTOR_ORACLE_FAR_REACH = (
@@ -139,7 +140,7 @@ def _query_introspector(api: str, params: dict) -> Optional[requests.Response]:
     try:
       resp = requests.get(api, params, timeout=TIMEOUT)
       if not resp.ok:
-        logging.error(
+        logger.error(
             'Failed to get data from FI:\n'
             '%s\n'
             '-----------Response received------------\n'
@@ -150,19 +151,19 @@ def _query_introspector(api: str, params: dict) -> Optional[requests.Response]:
       return resp
     except requests.exceptions.Timeout as err:
       if attempt_num == MAX_RETRY:
-        logging.error(
+        logger.error(
             'Failed to get data from FI due to timeout, max retry exceeded:\n'
             '%s\n'
             'Error: %s', _construct_url(api, params), err)
         break
       delay = 5 * 2**attempt_num + random.randint(1, 10)
-      logging.warning(
+      logger.warning(
           'Failed to get data from FI due to timeout on attempt %d:\n'
           '%s\n'
           'retry in %ds...', attempt_num, _construct_url(api, params), delay)
       time.sleep(delay)
     except requests.exceptions.RequestException as err:
-      logging.error(
+      logger.error(
           'Failed to get data from FI due to unexpected error:\n'
           '%s\n'
           'Error: %s', _construct_url(api, params), err)
@@ -180,7 +181,7 @@ def _get_data(resp: Optional[requests.Response], key: str,
   try:
     data = resp.json()
   except requests.exceptions.InvalidJSONError:
-    logging.error(
+    logger.error(
         'Unable to parse response from FI:\n'
         '%s\n'
         '-----------Response received------------\n'
@@ -193,7 +194,7 @@ def _get_data(resp: Optional[requests.Response], key: str,
   if content:
     return content
 
-  logging.error('Failed to get %s from FI:\n'
+  logger.error('Failed to get %s from FI:\n'
                 '%s\n'
                 '%s', key, resp.url, data)
   return default_value
@@ -243,7 +244,7 @@ def query_introspector_for_targets(project, target_oracle) -> list[Dict]:
   """Queries introspector for target functions."""
   query_func = get_oracle_dict().get(target_oracle, None)
   if not query_func:
-    logging.error('No such oracle "%s"', target_oracle)
+    logger.error('No such oracle "%s"', target_oracle)
     sys.exit(1)
   return query_func(project)
 
@@ -453,7 +454,7 @@ def _get_raw_return_type(function: dict, project: str) -> str:
   """Returns the raw function type."""
   return_type = function.get('return-type') or function.get('return_type', '')
   if not return_type:
-    logging.error(
+    logger.error(
         'Missing return type in project: %s\n'
         '  raw_function_name: %s', project,
         get_raw_function_name(function, project))
@@ -475,7 +476,7 @@ def get_raw_function_name(function: dict, project: str) -> str:
   raw_name = (function.get('raw-function-name') or
               function.get('raw_function_name', ''))
   if not raw_name:
-    logging.error('No raw function name in project: %s for function: %s',
+    logger.error('No raw function name in project: %s for function: %s',
                   project, function)
   return raw_name
 
@@ -485,7 +486,7 @@ def _get_clean_arg_types(function: dict, project: str) -> list[str]:
   raw_arg_types = (function.get('arg-types') or
                    function.get('function_arguments', []))
   if not raw_arg_types:
-    logging.error(
+    logger.error(
         'Missing argument types in project: %s\n'
         '  raw_function_name: %s', project,
         get_raw_function_name(function, project))
@@ -521,7 +522,7 @@ def _get_arg_names(function: dict, project: str, language: str) -> list[str]:
     arg_names = (function.get('arg-names') or
                  function.get('function_argument_names', []))
   if not arg_names:
-    logging.error(
+    logger.error(
         'Missing argument names in project: %s\n'
         '  raw_function_name: %s', project,
         get_raw_function_name(function, project))
@@ -535,7 +536,7 @@ def get_function_signature(function: dict, project: str) -> str:
     # For JVM projects, the full function signature are the raw function name
     return get_raw_function_name(function, project)
   if not function_signature:
-    logging.error(
+    logger.error(
         'Missing function signature in project: %s\n'
         '  raw_function_name: %s', project,
         get_raw_function_name(function, project))
@@ -565,7 +566,7 @@ def _select_top_functions_from_oracle(project: str, limit: int,
   if target_oracle not in target_oracles:
     return OrderedDict()
 
-  logging.info('Extracting functions using oracle %s.', target_oracle)
+  logger.info('Extracting functions using oracle %s.', target_oracle)
   functions = query_introspector_for_targets(project, target_oracle)[:limit]
 
   return OrderedDict((func['function_signature'], func) for func in functions)
@@ -650,7 +651,7 @@ def populate_benchmarks_using_introspector(project: str, language: str,
   functions = _select_functions_from_oracles(project, limit, target_oracles)
 
   if not functions:
-    logging.error('No functions found using the oracles: %s', target_oracles)
+    logger.error('No functions found using the oracles: %s', target_oracles)
     return []
 
   if language == 'jvm':
@@ -671,12 +672,12 @@ def populate_benchmarks_using_introspector(project: str, language: str,
   harnesses, interesting = result
   harness = pick_one(harnesses)
   if not harness:
-    logging.error('No fuzz target found in project %s.', project)
+    logger.error('No fuzz target found in project %s.', project)
     return []
-  logging.info('Fuzz target file found for project %s: %s', project, harness)
+  logger.info('Fuzz target file found for project %s: %s', project, harness)
 
   target_name = get_target_name(project, harness)
-  logging.info('Fuzz target binary found for project %s: %s', project,
+  logger.info('Fuzz target binary found for project %s: %s', project,
                target_name)
 
   potential_benchmarks = []
@@ -699,17 +700,17 @@ def populate_benchmarks_using_introspector(project: str, language: str,
         # stored as <SOURCE_BASE>/a/b/c/d.java
         src_file = f'{filename.replace(".", "/")}.java'
         if src_file not in src_path_list:
-          logging.error('error: %s %s', filename, interesting.keys())
+          logger.error('error: %s %s', filename, interesting.keys())
           continue
     elif filename not in [os.path.basename(i) for i in interesting.keys()]:
       # TODO: Bazel messes up paths to include "/proc/self/cwd/..."
-      logging.error('error: %s %s', filename, interesting.keys())
+      logger.error('error: %s %s', filename, interesting.keys())
       continue
 
     function_signature = get_function_signature(function, project)
     if not function_signature:
       continue
-    logging.info('Function signature to fuzz: %s', function_signature)
+    logger.info('Function signature to fuzz: %s', function_signature)
     potential_benchmarks.append(
         benchmarklib.Benchmark('cli',
                                project,
@@ -728,7 +729,7 @@ def populate_benchmarks_using_introspector(project: str, language: str,
 
     if len(potential_benchmarks) >= (limit * len(target_oracles)):
       break
-  print("Length of potential targets: %d" % (len(potential_benchmarks)))
+  logger.info("Length of potential targets: %d" % (len(potential_benchmarks)))
 
   return potential_benchmarks
 
@@ -761,7 +762,7 @@ def _identify_latest_report(project_name: str):
   if summaries:
     return ('https://storage.googleapis.com/oss-fuzz-introspector/'
             f'{summaries[-1]}')
-  logging.error('Error: %s has no summary.', project_name)
+  logger.error('Error: %s has no summary.', project_name)
   return None
 
 
@@ -799,14 +800,14 @@ def get_project_funcs(project_name: str) -> Dict[str, List[Dict]]:
     from FuzzIntrospector."""
   introspector_json_report = _extract_introspector_report(project_name)
   if introspector_json_report is None:
-    logging.error('No fuzz introspector report is found.')
+    logger.error('No fuzz introspector report is found.')
     return {}
 
   if introspector_json_report.get('analyses') is None:
-    logging.error('Error: introspector_json_report has no "analyses"')
+    logger.error('Error: introspector_json_report has no "analyses"')
     return {}
   if introspector_json_report.get('analyses').get('AnnotatedCFG') is None:
-    logging.error(
+    logger.error(
         'Error: introspector_json_report["analyses"] has no "AnnotatedCFG"')
     return {}
 
@@ -873,7 +874,7 @@ def _parse_arguments() -> argparse.Namespace:
 set_introspector_endpoints(DEFAULT_INTROSPECTOR_ENDPOINT)
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logging.INFO)
+  logging.basicConfig(level=logger.INFO)
 
   args = _parse_arguments()
   if args.out:
@@ -885,7 +886,7 @@ if __name__ == '__main__':
     oss_fuzz_checkout.clone_oss_fuzz()
     oss_fuzz_checkout.postprocess_oss_fuzz()
   except subprocess.CalledProcessError as e:
-    logging.error('Failed to prepare OSS-Fuzz directory for project %s: %s',
+    logger.error('Failed to prepare OSS-Fuzz directory for project %s: %s',
                   args.project, e)
   cur_project_language = oss_fuzz_checkout.get_project_language(args.project)
   benchmarks = populate_benchmarks_using_introspector(args.project,
@@ -895,5 +896,5 @@ if __name__ == '__main__':
   if benchmarks:
     benchmarklib.Benchmark.to_yaml(benchmarks, args.out)
   else:
-    logging.error('Nothing found for %s', args.project)
+    logger.error('Nothing found for %s', args.project)
     sys.exit(1)

--- a/data_prep/parse_training_data.py
+++ b/data_prep/parse_training_data.py
@@ -99,7 +99,7 @@ class Benchmark:
         fixed_code = code_file.read()
       if not all_targets.get(instance):
         logger.warning('Benchmark instance does not exist: %s - %s',
-                        self.benchmark_dir, instance)
+                       self.benchmark_dir, instance)
         continue
       all_targets[instance].append(fixed_code)
     return all_targets
@@ -117,7 +117,7 @@ class Benchmark:
       status_json_path = os.path.join(status_dir, instance, 'result.json')
       if not os.path.isfile(status_json_path):
         logger.info('Missing result JSON of benchmark instance: %s - %s',
-                     self.benchmark, instance)
+                    self.benchmark, instance)
         continue
       with open(status_json_path) as file:
         try:

--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -9,6 +9,8 @@ from typing import Any
 from data_prep import introspector
 from experiment import benchmark as benchmarklib
 
+logger = logging.getLogger(__name__)
+
 COMPLEX_TYPES = ['const', 'enum', 'struct', 'union', 'volatile']
 
 

--- a/data_prep/project_context/context_retriever.py
+++ b/data_prep/project_context/context_retriever.py
@@ -1,8 +1,8 @@
 import json
+import logging
 import os
 import re
 import shutil
-import logging
 import subprocess
 import uuid
 from collections import defaultdict
@@ -311,7 +311,8 @@ class ContextRetriever:
         logger.info(e)
         continue
 
-    logger.info(f'Header location could not be found for {self._function_signature}')
+    logger.info(
+        f'Header location could not be found for {self._function_signature}')
     return ''
 
   def get_type_info(self) -> List[str]:

--- a/data_prep/project_context/context_retriever.py
+++ b/data_prep/project_context/context_retriever.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import shutil
+import logging
 import subprocess
 import uuid
 from collections import defaultdict
@@ -10,6 +11,8 @@ from typing import List, Tuple
 from google.cloud import storage
 
 from experiment import benchmark as benchmarklib
+
+logger = logging.getLogger(__name__)
 
 
 class ContextRetriever:
@@ -210,11 +213,11 @@ class ContextRetriever:
 
     # Only the unqualified type and identifier should exist here.
     if len(tokens) > 2:
-      print(f'Error with extracting type: {tokens}')
+      logger.info(f'Error with extracting type: {tokens}')
       return ''
 
     if len(tokens) == 0:
-      print(f'Type dequalifying failed: {fully_qualified_type}')
+      logger.info(f'Type dequalifying failed: {fully_qualified_type}')
       return ''
 
     dequal_type = tokens[0]
@@ -276,7 +279,7 @@ class ContextRetriever:
           ast_json = json.load(ast_file)
         # Files generated and uploaded are occasionally empty.
         except Exception as e:
-          print(e)
+          logger.info(e)
           continue
 
       ast_nodes = ast_json.get('inner', [])
@@ -305,10 +308,10 @@ class ContextRetriever:
           return header
       # ASTs from the bucket are occasionally empty.
       except Exception as e:
-        print(e)
+        logger.info(e)
         continue
 
-    print(f'Header location could not be found for {self._function_signature}')
+    logger.info(f'Header location could not be found for {self._function_signature}')
     return ''
 
   def get_type_info(self) -> List[str]:

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -163,13 +163,15 @@ def _copy_project_src(project: str,
                       cloud_experiment_bucket: str = ''):
   """Copies /|src| from cloud if bucket is available or from local image."""
   if cloud_experiment_bucket:
-    logger.info(f'Retrieving human-written fuzz targets of {project} from Google '
-          'Cloud Build.')
+    logger.info(
+        f'Retrieving human-written fuzz targets of {project} from Google '
+        'Cloud Build.')
     bucket_dirname = _build_project_on_cloud(project, cloud_experiment_bucket)
     _copy_project_src_from_cloud(bucket_dirname, out, cloud_experiment_bucket)
   else:
-    logger.info(f'Retrieving human-written fuzz targets of {project} from local '
-          'Docker build.')
+    logger.info(
+        f'Retrieving human-written fuzz targets of {project} from local '
+        'Docker build.')
     _build_project_local_docker(project)
     _copy_project_src_from_local(project, out)
 
@@ -374,12 +376,12 @@ def _copy_fuzz_targets(harness_path: str, dest_dir: str, project: str):
   result = sp.run(command, capture_output=True, stdin=sp.DEVNULL, check=True)
   if result.returncode:
     logger.error('Failed to copy harness from %s to %s: %s %s.', harness_path,
-                  dest_dir, result.stdout, result.stderr)
+                 dest_dir, result.stdout, result.stderr)
     raise Exception(f'Failed to copy harness from {harness_path} to {dest_dir}',
                     harness_path, dest_dir)
 
   logger.info('Retrieved fuzz targets from %s:\n  %s', project,
-               '\n  '.join(os.listdir(dest_dir)))
+              '\n  '.join(os.listdir(dest_dir)))
 
 
 def search_source(

--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -26,6 +26,8 @@ from google.cloud import storage
 
 from experiment import benchmark, oss_fuzz_checkout
 
+logger = logging.getLogger(__name__)
+
 SEARCH_IGNORE_DIRS = ['aflplusplus', 'fuzztest', 'honggfuzz', 'libfuzzer']
 SEARCH_EXTS = ['.c', '.cc', '.cpp', '.cxx', '.c++']
 
@@ -92,21 +94,21 @@ def _format_source(src_file: str) -> str:
                     stdin=sp.DEVNULL,
                     timeout=timeout_seconds)
   except sp.TimeoutExpired:
-    logging.debug(
+    logger.debug(
         'Could not format in %d seconds: %s',
         timeout_seconds,
         src_file,
     )
   except Exception as e:
-    logging.debug('Failed to format %s: %s', src_file, e)
+    logger.debug('Failed to format %s: %s', src_file, e)
   else:
     if result.returncode:
-      logging.warning('Failed to format %s:', src_file)
-      logging.warning('STDOUT: %s', result.stdout)
-      logging.warning('STDERR: %s', result.stderr)
+      logger.warning('Failed to format %s:', src_file)
+      logger.warning('STDOUT: %s', result.stdout)
+      logger.warning('STDERR: %s', result.stderr)
   if os.path.isfile(src_file):
     return _read_harness(src_file) or _read_harness(src_file, 'ignore') or ''
-  logging.warning('Failed to find file: %s', src_file)
+  logger.warning('Failed to find file: %s', src_file)
 
   return ''
 
@@ -143,17 +145,17 @@ def _build_project_local_docker(project: str):
   command = [
       'python3', helper_path, 'build_image', '--cache', '--no-pull', project
   ]
-  logging.info('Building project image: %s', ' '.join(command))
+  logger.info('Building project image: %s', ' '.join(command))
   result = sp.run(command,
                   stdout=sp.PIPE,
                   stderr=sp.STDOUT,
                   stdin=sp.DEVNULL,
                   check=False)
   if result.returncode:
-    logging.error('Failed to build OSS-Fuzz image for %s:', project)
-    logging.error('return code %d: %s', result.returncode, result.stdout)
+    logger.error('Failed to build OSS-Fuzz image for %s:', project)
+    logger.error('return code %d: %s', result.returncode, result.stdout)
     raise Exception('Failed to build OSS-Fuzz image for {project}')
-  logging.info('Done building image.')
+  logger.info('Done building image.')
 
 
 def _copy_project_src(project: str,
@@ -161,12 +163,12 @@ def _copy_project_src(project: str,
                       cloud_experiment_bucket: str = ''):
   """Copies /|src| from cloud if bucket is available or from local image."""
   if cloud_experiment_bucket:
-    print(f'Retrieving human-written fuzz targets of {project} from Google '
+    logger.info(f'Retrieving human-written fuzz targets of {project} from Google '
           'Cloud Build.')
     bucket_dirname = _build_project_on_cloud(project, cloud_experiment_bucket)
     _copy_project_src_from_cloud(bucket_dirname, out, cloud_experiment_bucket)
   else:
-    print(f'Retrieving human-written fuzz targets of {project} from local '
+    logger.info(f'Retrieving human-written fuzz targets of {project} from local '
           'Docker build.')
     _build_project_local_docker(project)
     _copy_project_src_from_local(project, out)
@@ -197,9 +199,9 @@ def _build_project_on_cloud(project: str, cloud_experiment_bucket: str) -> str:
                               cwd=oss_fuzz_checkout.OSS_FUZZ_DIR)
   if (cloud_build_result.returncode or
       'failed: step exited with non-zero status' in cloud_build_result.stdout):
-    logging.error('Failed to upload /src/ in OSS-Fuzz image of %s:', project)
-    logging.error('STDOUT: %s', cloud_build_result.stdout)
-    logging.error('STDERR: %s', cloud_build_result.stderr)
+    logger.error('Failed to upload /src/ in OSS-Fuzz image of %s:', project)
+    logger.error('STDOUT: %s', cloud_build_result.stdout)
+    logger.error('STDERR: %s', cloud_build_result.stderr)
     raise Exception(
         f'Failed to run cloud build command: {" ".join(cloud_build_command)}')
 
@@ -226,9 +228,9 @@ def _copy_project_src_from_cloud(bucket_dirname: str, out: str,
 
     # Download the file
     blob.download_to_filename(local_file_path)
-    print(f"Downloaded {blob.name} to {local_file_path}")
+    logger.info(f"Downloaded {blob.name} to {local_file_path}")
     blob.delete()
-    print(f"Deleted {blob.name} from the bucket.")
+    logger.info(f"Deleted {blob.name} from the bucket.")
 
 
 def _copy_project_src_from_local(project: str, out: str):
@@ -262,9 +264,9 @@ def _copy_project_src_from_local(project: str, out: str):
                   stdin=sp.DEVNULL,
                   check=False)
   if result.returncode:
-    logging.error('Failed to run OSS-Fuzz image of %s:', project)
-    logging.error('STDOUT: %s', result.stdout)
-    logging.error('STDERR: %s', result.stderr)
+    logger.error('Failed to run OSS-Fuzz image of %s:', project)
+    logger.error('STDOUT: %s', result.stdout)
+    logger.error('STDERR: %s', result.stderr)
     raise Exception(f'Failed to run docker command: {" ".join(run_container)}')
 
   try:
@@ -274,11 +276,11 @@ def _copy_project_src_from_local(project: str, out: str):
                     stdin=sp.DEVNULL,
                     check=False)
     if result.returncode:
-      logging.error('Failed to copy /src from OSS-Fuzz image of %s:', project)
-      logging.error('STDOUT: %s', result.stdout)
-      logging.error('STDERR: %s', result.stderr)
+      logger.error('Failed to copy /src from OSS-Fuzz image of %s:', project)
+      logger.error('STDOUT: %s', result.stdout)
+      logger.error('STDERR: %s', result.stderr)
       raise Exception(f'Failed to run docker command: {" ".join(copy_src)}')
-    logging.info('Done copying %s /src to %s.', project, out)
+    logger.info('Done copying %s /src to %s.', project, out)
   finally:
     # Shut down the container that was just started.
     result = sp.run(['docker', 'container', 'stop', f'{project}-container'],
@@ -286,9 +288,9 @@ def _copy_project_src_from_local(project: str, out: str):
                     stdin=sp.DEVNULL,
                     check=False)
     if result.returncode:
-      logging.error('Failed to stop container image: %s-container', project)
-      logging.error('STDOUT: %s', result.stdout)
-      logging.error('STDERR: %s', result.stderr)
+      logger.error('Failed to stop container image: %s-container', project)
+      logger.error('STDOUT: %s', result.stdout)
+      logger.error('STDERR: %s', result.stderr)
 
 
 def _identify_fuzz_targets(out: str, interesting_filenames: list[str],
@@ -296,7 +298,7 @@ def _identify_fuzz_targets(out: str, interesting_filenames: list[str],
   """
   Identifies fuzz target file contents and |interesting_filenames| in |out|.
   """
-  logging.debug('len(interesting_filenames): %d', len(interesting_filenames))
+  logger.debug('len(interesting_filenames): %d', len(interesting_filenames))
 
   interesting_filepaths = []
   potential_harnesses = []
@@ -371,12 +373,12 @@ def _copy_fuzz_targets(harness_path: str, dest_dir: str, project: str):
   command = ['cp', harness_path, dest_dir]
   result = sp.run(command, capture_output=True, stdin=sp.DEVNULL, check=True)
   if result.returncode:
-    logging.error('Failed to copy harness from %s to %s: %s %s.', harness_path,
+    logger.error('Failed to copy harness from %s to %s: %s %s.', harness_path,
                   dest_dir, result.stdout, result.stderr)
     raise Exception(f'Failed to copy harness from {harness_path} to {dest_dir}',
                     harness_path, dest_dir)
 
-  logging.info('Retrieved fuzz targets from %s:\n  %s', project,
+  logger.info('Retrieved fuzz targets from %s:\n  %s', project,
                '\n  '.join(os.listdir(dest_dir)))
 
 

--- a/data_prep/project_targets.py
+++ b/data_prep/project_targets.py
@@ -96,7 +96,8 @@ def _bucket_match_target_content_signatures(
     logger.info('Error: No fuzz target functions available.')
     return {}
   if not os.path.isdir(fuzz_target_dir):
-    logger.info('Error: Fuzz target directory does not exist ({fuzz_target_dir})')
+    logger.info(
+        'Error: Fuzz target directory does not exist ({fuzz_target_dir})')
     return {}
 
   target_path_contents = _match_target_path_content(list(target_funcs.keys()),
@@ -145,11 +146,13 @@ def generate_data(project_name: str,
       target_funcs, project_fuzz_target_dir, project_name)
 
   if target_content_signature_dict:
-    logger.info(f'Downloaded human-written fuzz targets of {project_name} from Google'
-          f' Cloud Bucket: {OSS_FUZZ_EXP_BUCKET}.')
+    logger.info(
+        f'Downloaded human-written fuzz targets of {project_name} from Google'
+        f' Cloud Bucket: {OSS_FUZZ_EXP_BUCKET}.')
   else:
-    logger.info(f'Failed to download human-written fuzz target of {project_name} '
-          f'from Google Cloud Bucket: {OSS_FUZZ_EXP_BUCKET}.')
+    logger.info(
+        f'Failed to download human-written fuzz target of {project_name} '
+        f'from Google Cloud Bucket: {OSS_FUZZ_EXP_BUCKET}.')
     logger.info('Will try to build from Google Cloud or local docker image.')
     target_content_signature_dict = _match_target_content_signatures(
         target_funcs, project_name, language, cloud_experiment_bucket)

--- a/data_prep/project_targets.py
+++ b/data_prep/project_targets.py
@@ -19,6 +19,7 @@ for training.
 
 import argparse
 import json
+import logging
 import os
 import re
 import sys
@@ -29,6 +30,8 @@ from google.cloud import storage
 
 from data_prep import introspector, project_src
 from experiment import oss_fuzz_checkout
+
+logger = logging.getLogger(__name__)
 
 OSS_FUZZ_EXP_BUCKET = 'oss-fuzz-llm-public'
 # TODO(dongge): Use tmp dir.
@@ -90,10 +93,10 @@ def _bucket_match_target_content_signatures(
   """Returns a list of dictionary with function signatures as keys and
     its fuzz target content as values."""
   if not target_funcs:
-    print('Error: No fuzz target functions available.')
+    logger.info('Error: No fuzz target functions available.')
     return {}
   if not os.path.isdir(fuzz_target_dir):
-    print('Error: Fuzz target directory does not exist ({fuzz_target_dir})')
+    logger.info('Error: Fuzz target directory does not exist ({fuzz_target_dir})')
     return {}
 
   target_path_contents = _match_target_path_content(list(target_funcs.keys()),
@@ -142,12 +145,12 @@ def generate_data(project_name: str,
       target_funcs, project_fuzz_target_dir, project_name)
 
   if target_content_signature_dict:
-    print(f'Downloaded human-written fuzz targets of {project_name} from Google'
+    logger.info(f'Downloaded human-written fuzz targets of {project_name} from Google'
           f' Cloud Bucket: {OSS_FUZZ_EXP_BUCKET}.')
   else:
-    print(f'Failed to download human-written fuzz target of {project_name} '
+    logger.info(f'Failed to download human-written fuzz target of {project_name} '
           f'from Google Cloud Bucket: {OSS_FUZZ_EXP_BUCKET}.')
-    print('Will try to build from Google Cloud or local docker image.')
+    logger.info('Will try to build from Google Cloud or local docker image.')
     target_content_signature_dict = _match_target_content_signatures(
         target_funcs, project_name, language, cloud_experiment_bucket)
   if not target_content_signature_dict:
@@ -210,7 +213,7 @@ def _match_target_content_signatures(
   """Returns a list of dictionary with function signatures as keys and
     its fuzz target content as values."""
   if not target_funcs:
-    print('Error: No fuzz target functions available.')
+    logger.info('Error: No fuzz target functions available.')
     return {}
 
   source_content = project_src.search_source(
@@ -219,7 +222,7 @@ def _match_target_content_signatures(
       cloud_experiment_bucket=cloud_experiment_bucket)
 
   if not source_content[0]:
-    print(f'Error: No fuzz target found for project {project_name}.')
+    logger.info(f'Error: No fuzz target found for project {project_name}.')
     return {}
 
   target_path_contents = source_content[0]
@@ -326,7 +329,7 @@ def _generate_project_training_data(project_name: str,
     return generate_data(project_name, language, sig_per_target, max_samples,
                          cloud_experiment_bucket)
   except Exception as e:
-    print(f'Project {project_name} failed:\n{e}')
+    logger.info(f'Project {project_name} failed:\n{e}')
     return None
 
 

--- a/data_prep/target_collector.py
+++ b/data_prep/target_collector.py
@@ -20,12 +20,15 @@
 
 import datetime
 import json
+import logging
 import os
 import shutil
 import sys
 from typing import Set
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_introspector_report(project_name, date_str):
@@ -47,7 +50,7 @@ def _get_targets(project_name: str) -> Set[str]:
   introspector_json_report = _extract_introspector_report(
       project_name, yesterday.strftime('%Y%m%d'))
   if introspector_json_report is None:
-    print('Error: No fuzz introspector report is found.')
+    logger.info('Error: No fuzz introspector report is found.')
     return set()
 
   annotated_cfg = introspector_json_report['analyses']['AnnotatedCFG']

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -200,7 +200,7 @@ class BuilderRunner:
            '`LLVMFuzzerTestOneInput`.')
       ]
       logger.info(f'Missing target function: {target_path} does not contain '
-            f'{self.benchmark.function_signature}')
+                  f'{self.benchmark.function_signature}')
 
     return result
 
@@ -258,7 +258,7 @@ class BuilderRunner:
             func_info[func_name].add(line_number)
           else:
             logger.warning('Failed to parse line number from %s in project %s',
-                            func_name, project_name)
+                           func_name, project_name)
           break
         if project_name in file_path:
           func_match = self.FUNC_NAME.search(func_name)
@@ -629,7 +629,8 @@ class BuilderRunner:
             f'Failed to build fuzzer for {generated_project} with {sanitizer}')
         return False
 
-    logger.info(f'Successfully build fuzzer for {generated_project} with {sanitizer}')
+    logger.info(
+        f'Successfully build fuzzer for {generated_project} with {sanitizer}')
     return True
 
   def get_coverage_local(
@@ -669,8 +670,8 @@ class BuilderRunner:
              check=True)
     except sp.CalledProcessError as e:
       logger.info(f'Failed to generate coverage for {generated_project}:\n'
-            f'{e.stdout}\n'
-            f'{e.stderr}')
+                  f'{e.stdout}\n'
+                  f'{e.stderr}')
       return None, None
 
     if self.benchmark.language == 'jvm':
@@ -744,8 +745,8 @@ class CloudBuilderRunner(BuilderRunner):
 
         if not delay or attempt_id == CLOUD_EXP_MAX_ATTEMPT:
           logger.error('Failed to evaluate %s on cloud, attempt %d:\n%s\n%s',
-                        os.path.realpath(target_path), attempt_id, stdout,
-                        stderr)
+                       os.path.realpath(target_path), attempt_id, stdout,
+                       stderr)
           break
 
         logger.warning(
@@ -835,11 +836,11 @@ class CloudBuilderRunner(BuilderRunner):
       blob = bucket.blob(build_log_name)
       if blob.exists():
         logger.info('Downloading cloud build log of %s: %s to %s',
-                     os.path.realpath(target_path), build_log_name, f)
+                    os.path.realpath(target_path), build_log_name, f)
         blob.download_to_file(f)
       else:
         logger.warning('Cannot find cloud build log of %s: %s',
-                        os.path.realpath(target_path), build_log_name)
+                       os.path.realpath(target_path), build_log_name)
 
     # Ignored for JVM project since JVM project does not generate err.log
     if language != 'jvm':
@@ -849,11 +850,11 @@ class CloudBuilderRunner(BuilderRunner):
         blob = bucket.blob(err_log_name)
         if blob.exists():
           logger.info('Downloading jcc error log of %s: %s to %s',
-                       os.path.realpath(target_path), err_log_name, f)
+                      os.path.realpath(target_path), err_log_name, f)
           blob.download_to_file(f)
         else:
           logger.warning('Cannot find jcc error log of %s: %s',
-                          os.path.realpath(target_path), err_log_name)
+                         os.path.realpath(target_path), err_log_name)
 
     with open(self.work_dirs.run_logs_target(generated_target_name, iteration),
               'wb') as f:
@@ -861,11 +862,11 @@ class CloudBuilderRunner(BuilderRunner):
       if blob.exists():
         build_result.succeeded = True
         logger.info('Downloading cloud run log of %s: %s to %s',
-                     os.path.realpath(target_path), run_log_name, f)
+                    os.path.realpath(target_path), run_log_name, f)
         blob.download_to_file(f)
       else:
         logger.warning('Cannot find cloud run log of %s: %s',
-                        os.path.realpath(target_path), run_log_name)
+                       os.path.realpath(target_path), run_log_name)
 
     if not build_result.succeeded:
       errors = code_fixer.extract_error_message(
@@ -873,10 +874,10 @@ class CloudBuilderRunner(BuilderRunner):
           os.path.basename(self.benchmark.target_path))
       build_result.errors = errors
       logger.info('Cloud evaluation of %s indicates a failure: %s',
-                   os.path.realpath(target_path), errors)
+                  os.path.realpath(target_path), errors)
       return build_result, None
     logger.info('Cloud evaluation of %s indicates a success.',
-                 os.path.realpath(target_path))
+                os.path.realpath(target_path))
 
     corpus_dir = self.work_dirs.corpus(generated_target_name)
     with open(os.path.join(corpus_dir, 'corpus.zip'), 'wb') as f:

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -38,6 +38,8 @@ from llm_toolkit import code_fixer
 from llm_toolkit.crash_triager import TriageResult
 from llm_toolkit.models import DefaultModel
 
+logger = logging.getLogger(__name__)
+
 # The directory in the oss-fuzz image
 JCC_DIR = '/usr/local/bin'
 
@@ -197,7 +199,7 @@ class BuilderRunner:
            f'`{self.benchmark.function_signature}` INSIDE FUNCTION '
            '`LLVMFuzzerTestOneInput`.')
       ]
-      print(f'Missing target function: {target_path} does not contain '
+      logger.info(f'Missing target function: {target_path} does not contain '
             f'{self.benchmark.function_signature}')
 
     return result
@@ -255,7 +257,7 @@ class BuilderRunner:
             line_number = int(line_match.group(1))
             func_info[func_name].add(line_number)
           else:
-            logging.warning('Failed to parse line number from %s in project %s',
+            logger.warning('Failed to parse line number from %s in project %s',
                             func_name, project_name)
           break
         if project_name in file_path:
@@ -266,7 +268,7 @@ class BuilderRunner:
             line_number = int(line_match.group(1))
             func_info[func_name].add(line_number)
           else:
-            logging.warning(
+            logger.warning(
                 'Failed to parse function name from %s in project %s',
                 func_name, project_name)
 
@@ -312,7 +314,7 @@ class BuilderRunner:
       lines = fuzzlog.split('\n')
     except MemoryError as e:
       # Some logs from abnormal fuzz targets are too large to be parsed.
-      logging.error('%s is too large to parse: %s', log_handle.name, e)
+      logger.error('%s is too large to parse: %s', log_handle.name, e)
       return ParseResult(0, 0, False, '',
                          SemanticCheckResult(SemanticCheckResult.LOG_MESS_UP))
 
@@ -440,7 +442,7 @@ class BuilderRunner:
       return self.build_and_run_local(generated_project, target_path, iteration,
                                       build_result, language)
     except Exception as err:
-      logging.warning(
+      logger.warning(
           'Error occurred when building and running fuzz target locally'
           '(attempt %d) %s: %s', iteration, err, traceback.format_exc())
       raise err
@@ -466,7 +468,7 @@ class BuilderRunner:
                          'err.log'),
             self.work_dirs.error_logs_target(benchmark_target_name, iteration))
       except FileNotFoundError as e:
-        logging.error('Cannot get err.log for %s: %s', generated_project, e)
+        logger.error('Cannot get err.log for %s: %s', generated_project, e)
 
     if not build_result.succeeded:
       errors = code_fixer.extract_error_message(benchmark_log_path,
@@ -502,7 +504,7 @@ class BuilderRunner:
     """Runs a target in the fixed target directory."""
     # If target name is not overridden, use the basename of the target path
     # in the Dockerfile.
-    print(f'Running {generated_project}')
+    logger.info(f'Running {generated_project}')
     corpus_dir = self.work_dirs.corpus(benchmark_target_name)
     command = [
         'python3', 'infra/helper.py', 'run_fuzzer', '--corpus-dir', corpus_dir,
@@ -520,20 +522,20 @@ class BuilderRunner:
       try:
         proc.wait(timeout=self.run_timeout + 5)
       except sp.TimeoutExpired:
-        print(f'{generated_project} timed out during fuzzing.')
+        logger.info(f'{generated_project} timed out during fuzzing.')
         # Try continuing and parsing the logs even in case of timeout.
 
     if proc.returncode != 0:
-      print(f'********** Failed to run {generated_project}. **********')
+      logger.info(f'********** Failed to run {generated_project}. **********')
     else:
-      print(f'Successfully run {generated_project}.')
+      logger.info(f'Successfully run {generated_project}.')
 
   def build_target_local(self,
                          generated_project: str,
                          log_path: str,
                          sanitizer: str = 'address') -> bool:
     """Builds a target with OSS-Fuzz."""
-    print(f'Building {generated_project} with {sanitizer}')
+    logger.info(f'Building {generated_project} with {sanitizer}')
     command = [
         'docker', 'build', '-t', f'gcr.io/oss-fuzz/{generated_project}',
         os.path.join(oss_fuzz_checkout.OSS_FUZZ_DIR, 'projects',
@@ -548,7 +550,7 @@ class BuilderRunner:
                stderr=sp.STDOUT,
                check=True)
       except sp.CalledProcessError:
-        print(f'Failed to build image for {generated_project}')
+        logger.info(f'Failed to build image for {generated_project}')
         return False
 
     outdir = get_build_artifact_dir(generated_project, 'out')
@@ -623,11 +625,11 @@ class BuilderRunner:
                stderr=sp.STDOUT,
                check=True)
       except sp.CalledProcessError:
-        print(
+        logger.info(
             f'Failed to build fuzzer for {generated_project} with {sanitizer}')
         return False
 
-    print(f'Successfully build fuzzer for {generated_project} with {sanitizer}')
+    logger.info(f'Successfully build fuzzer for {generated_project} with {sanitizer}')
     return True
 
   def get_coverage_local(
@@ -641,7 +643,7 @@ class BuilderRunner:
                                              log_path,
                                              sanitizer='coverage')
     if not built_coverage:
-      print(f'Failed to make coverage build for {generated_project}')
+      logger.info(f'Failed to make coverage build for {generated_project}')
       return None, None
 
     corpus_dir = self.work_dirs.corpus(benchmark_target_name)
@@ -666,7 +668,7 @@ class BuilderRunner:
              stdin=sp.DEVNULL,
              check=True)
     except sp.CalledProcessError as e:
-      print(f'Failed to generate coverage for {generated_project}:\n'
+      logger.info(f'Failed to generate coverage for {generated_project}:\n'
             f'{e.stdout}\n'
             f'{e.stderr}')
       return None, None
@@ -741,12 +743,12 @@ class CloudBuilderRunner(BuilderRunner):
                       if err in stdout + stderr), 0)
 
         if not delay or attempt_id == CLOUD_EXP_MAX_ATTEMPT:
-          logging.error('Failed to evaluate %s on cloud, attempt %d:\n%s\n%s',
+          logger.error('Failed to evaluate %s on cloud, attempt %d:\n%s\n%s',
                         os.path.realpath(target_path), attempt_id, stdout,
                         stderr)
           break
 
-        logging.warning(
+        logger.warning(
             'Failed to evaluate %s on cloud, attempt %d, retry in %ds:\n'
             '%s\n%s', os.path.realpath(target_path), attempt_id, delay, stdout,
             stderr)
@@ -767,7 +769,7 @@ class CloudBuilderRunner(BuilderRunner):
       return self.build_and_run_cloud(generated_project, target_path, iteration,
                                       build_result, language)
     except Exception as err:
-      logging.warning(
+      logger.warning(
           'Error occurred when building and running fuzz target on cloud'
           '(attempt %d) %s: %s', iteration, err, traceback.format_exc())
       traceback.print_exc()
@@ -778,7 +780,7 @@ class CloudBuilderRunner(BuilderRunner):
       build_result: BuildResult,
       language: str) -> tuple[BuildResult, Optional[RunResult]]:
     """Builds and runs the fuzz target locally for fuzzing."""
-    logging.info('Evaluating %s on cloud.', os.path.realpath(target_path))
+    logger.info('Evaluating %s on cloud.', os.path.realpath(target_path))
 
     project_name = self.benchmark.project
 
@@ -819,7 +821,7 @@ class CloudBuilderRunner(BuilderRunner):
         cwd=oss_fuzz_checkout.OSS_FUZZ_DIR):
       return build_result, None
 
-    logging.info('Evaluated %s on cloud.', os.path.realpath(target_path))
+    logger.info('Evaluated %s on cloud.', os.path.realpath(target_path))
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(self.experiment_bucket)
@@ -832,11 +834,11 @@ class CloudBuilderRunner(BuilderRunner):
         'wb') as f:
       blob = bucket.blob(build_log_name)
       if blob.exists():
-        logging.info('Downloading cloud build log of %s: %s to %s',
+        logger.info('Downloading cloud build log of %s: %s to %s',
                      os.path.realpath(target_path), build_log_name, f)
         blob.download_to_file(f)
       else:
-        logging.warning('Cannot find cloud build log of %s: %s',
+        logger.warning('Cannot find cloud build log of %s: %s',
                         os.path.realpath(target_path), build_log_name)
 
     # Ignored for JVM project since JVM project does not generate err.log
@@ -846,11 +848,11 @@ class CloudBuilderRunner(BuilderRunner):
           'wb') as f:
         blob = bucket.blob(err_log_name)
         if blob.exists():
-          logging.info('Downloading jcc error log of %s: %s to %s',
+          logger.info('Downloading jcc error log of %s: %s to %s',
                        os.path.realpath(target_path), err_log_name, f)
           blob.download_to_file(f)
         else:
-          logging.warning('Cannot find jcc error log of %s: %s',
+          logger.warning('Cannot find jcc error log of %s: %s',
                           os.path.realpath(target_path), err_log_name)
 
     with open(self.work_dirs.run_logs_target(generated_target_name, iteration),
@@ -858,11 +860,11 @@ class CloudBuilderRunner(BuilderRunner):
       blob = bucket.blob(run_log_name)
       if blob.exists():
         build_result.succeeded = True
-        logging.info('Downloading cloud run log of %s: %s to %s',
+        logger.info('Downloading cloud run log of %s: %s to %s',
                      os.path.realpath(target_path), run_log_name, f)
         blob.download_to_file(f)
       else:
-        logging.warning('Cannot find cloud run log of %s: %s',
+        logger.warning('Cannot find cloud run log of %s: %s',
                         os.path.realpath(target_path), run_log_name)
 
     if not build_result.succeeded:
@@ -870,10 +872,10 @@ class CloudBuilderRunner(BuilderRunner):
           self.work_dirs.build_logs_target(generated_target_name, iteration),
           os.path.basename(self.benchmark.target_path))
       build_result.errors = errors
-      logging.info('Cloud evaluation of %s indicates a failure: %s',
+      logger.info('Cloud evaluation of %s indicates a failure: %s',
                    os.path.realpath(target_path), errors)
       return build_result, None
-    logging.info('Cloud evaluation of %s indicates a success.',
+    logger.info('Cloud evaluation of %s indicates a success.',
                  os.path.realpath(target_path))
 
     corpus_dir = self.work_dirs.corpus(generated_target_name)

--- a/experiment/fuzz_target_error.py
+++ b/experiment/fuzz_target_error.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+
 class SemanticCheckResult:
   """Fuzz target semantic check results."""
   NOT_APPLICABLE = '-'

--- a/experiment/fuzz_target_error.py
+++ b/experiment/fuzz_target_error.py
@@ -18,6 +18,7 @@ import logging
 import re
 from typing import Optional
 
+logger = logging.getLogger(__name__)
 
 class SemanticCheckResult:
   """Fuzz target semantic check results."""

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -153,7 +153,7 @@ def get_project_language(project: str) -> str:
                                    'project.yaml')
   if not os.path.isfile(project_yaml_path):
     logger.warning('Failed to find the project yaml of %s, assuming it is C++',
-                    project)
+                   project)
     return 'C++'
 
   with open(project_yaml_path, 'r') as benchmark_file:

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -24,6 +24,8 @@ import tempfile
 
 import yaml
 
+logger = logging.getLogger(__name__)
+
 BUILD_DIR: str = 'build'
 GLOBAL_TEMP_DIR: str = ''
 # Assume OSS-Fuzz is at repo root dir by default.
@@ -41,9 +43,9 @@ def _remove_temp_oss_fuzz_repo():
   try:
     shutil.rmtree(OSS_FUZZ_DIR)
   except PermissionError as e:
-    logging.warning('No permission to remove %s: %s', OSS_FUZZ_DIR, e)
+    logger.warning('No permission to remove %s: %s', OSS_FUZZ_DIR, e)
   except FileNotFoundError as e:
-    logging.warning('No OSS-Fuzz directory %s: %s', OSS_FUZZ_DIR, e)
+    logger.warning('No OSS-Fuzz directory %s: %s', OSS_FUZZ_DIR, e)
 
 
 def _set_temp_oss_fuzz_repo():
@@ -71,8 +73,8 @@ def _clone_oss_fuzz_repo():
                   stdin=sp.DEVNULL)
   stdout, stderr = proc.communicate()
   if proc.returncode != 0:
-    print(stdout)
-    print(stderr)
+    logger.info(stdout)
+    logger.info(stderr)
 
 
 def clone_oss_fuzz(oss_fuzz_dir: str = ''):
@@ -126,9 +128,9 @@ def postprocess_oss_fuzz() -> None:
                   stdin=sp.DEVNULL,
                   capture_output=True)
   if result.returncode:
-    print(f'Failed to postprocess OSS-Fuzz ({OSS_FUZZ_DIR})')
-    print('stdout: ', result.stdout)
-    print('stderr: ', result.stderr)
+    logger.info(f'Failed to postprocess OSS-Fuzz ({OSS_FUZZ_DIR})')
+    logger.info('stdout: ', result.stdout)
+    logger.info('stderr: ', result.stderr)
 
 
 def list_c_cpp_projects() -> list[str]:
@@ -150,7 +152,7 @@ def get_project_language(project: str) -> str:
   project_yaml_path = os.path.join(OSS_FUZZ_DIR, 'projects', project,
                                    'project.yaml')
   if not os.path.isfile(project_yaml_path):
-    logging.warning('Failed to find the project yaml of %s, assuming it is C++',
+    logger.warning('Failed to find the project yaml of %s, assuming it is C++',
                     project)
     return 'C++'
 
@@ -164,7 +166,7 @@ def get_project_repository(project: str) -> str:
   project_yaml_path = os.path.join(OSS_FUZZ_DIR, 'projects', project,
                                    'project.yaml')
   if not os.path.isfile(project_yaml_path):
-    logging.warning(
+    logger.warning(
         'Failed to find the project yaml of %s, return empty repository',
         project)
     return ''

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -24,6 +24,8 @@ from typing import BinaryIO, List, Optional
 
 import chardet
 
+logger = logging.getLogger(__name__)
+
 # No spaces at the beginning, and ends with a ":".
 FUNCTION_PATTERN = re.compile(r'^([^\s].*):$')
 LINE_PATTERN = re.compile(r'^\s*\d+\|\s*([\d\.a-zA-Z]+)\|(.*)')
@@ -166,7 +168,7 @@ class Textcov:
       result = chardet.detect(raw_data)
       encoding = result['encoding']
       if encoding is None:
-        logging.warning('Failed to decode.')
+        logger.warning('Failed to decode.')
         raise UnicodeDecodeError("chardet", raw_data, 0, len(raw_data),
                                  "Cannot detect encoding")
 
@@ -190,7 +192,7 @@ class Textcov:
     try:
       demangled = demangle(cls._read_file_with_fallback(file_handle))
     except Exception as e:
-      logging.warning('Decoding failure: %s', e)
+      logger.warning('Decoding failure: %s', e)
       demangled = ''
     demangled = _discard_fuzz_target_lines(demangled)
 

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -27,6 +27,8 @@ from llm_toolkit import models
 from llm_toolkit import output_parser as parser
 from llm_toolkit import prompt_builder
 
+logger = logging.getLogger(__name__)
+
 ERROR_LINES = 20
 NO_MEMBER_ERROR_REGEX = r"error: no member named '.*' in '([^':]*):?.*'"
 FILE_NOT_FOUND_ERROR_REGEX = r"fatal error: '([^']*)' file not found"
@@ -284,7 +286,7 @@ def extract_error_message(log_path: str,
         for line in log_lines[error_lines_range[0]:error_lines_range[1] + 1])
 
   if not errors:
-    logging.warning('Failed to parse error message from %s.', log_path)
+    logger.warning('Failed to parse error message from %s.', log_path)
   return group_error_messages(errors)
 
 
@@ -377,7 +379,7 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
     fixed_code_candidates.append([fixed_code_path, fixed_code])
 
   if not fixed_code_candidates:
-    print(f'LLM did not generate rawoutput for {prompt_path}.')
+    logger.info(f'LLM did not generate rawoutput for {prompt_path}.')
     return
 
   # TODO(Dongge): Use the common vote:
@@ -390,7 +392,7 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
   # code.
   preferred_fix_path, preferred_fix_code = max(fixed_code_candidates,
                                                key=lambda x: len(x[1]))
-  print(f'Will use the longest fix: {os.path.relpath(preferred_fix_path)}.')
+  logger.info(f'Will use the longest fix: {os.path.relpath(preferred_fix_path)}.')
   preferred_fix_name, _ = os.path.splitext(preferred_fix_path)
   fixed_target_path = os.path.join(response_dir,
                                    f'{preferred_fix_name}{target_ext}')

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -392,7 +392,8 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
   # code.
   preferred_fix_path, preferred_fix_code = max(fixed_code_candidates,
                                                key=lambda x: len(x[1]))
-  logger.info(f'Will use the longest fix: {os.path.relpath(preferred_fix_path)}.')
+  logger.info(
+      f'Will use the longest fix: {os.path.relpath(preferred_fix_path)}.')
   preferred_fix_name, _ = os.path.splitext(preferred_fix_path)
   fixed_target_path = os.path.join(response_dir,
                                    f'{preferred_fix_name}{target_ext}')

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -232,7 +232,8 @@ class GPT(LLM):
     if self.ai_binary:
       logger.info(f'OpenAI does not use local AI binary: {self.ai_binary}')
     if self.temperature_list:
-      logger.info(f'OpenAI does not allow temperature list: {self.temperature_list}')
+      logger.info(
+          f'OpenAI does not allow temperature list: {self.temperature_list}')
 
     client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
 
@@ -281,11 +282,12 @@ class GoogleModel(LLM):
                 log_output: bool = False) -> None:
     """Queries a Google LLM and stores results in |response_dir|."""
     if not self.ai_binary:
-      logger.info(f'Error: This model requires a local AI binary: {self.ai_binary}')
+      logger.info(
+          f'Error: This model requires a local AI binary: {self.ai_binary}')
       sys.exit(1)
     if self.temperature_list:
       logger.info('AI Binary does not implement temperature list: '
-            f'{self.temperature_list}')
+                  f'{self.temperature_list}')
 
     with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
       f.write(prompt.get())

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -37,6 +37,8 @@ from vertexai.preview.language_models import CodeGenerationModel
 
 from llm_toolkit import prompts
 
+logger = logging.getLogger(__name__)
+
 # Model hyper-parameters.
 MAX_TOKENS: int = 2000
 NUM_SAMPLES: int = 1
@@ -204,7 +206,7 @@ class GPT(LLM):
     try:
       encoder = tiktoken.encoding_for_model(self.name)
     except KeyError:
-      print(f'Could not get a tiktoken encoding for {self.name}.')
+      logger.info(f'Could not get a tiktoken encoding for {self.name}.')
       encoder = tiktoken.get_encoding('cl100k_base')
 
     num_tokens = 0
@@ -228,9 +230,9 @@ class GPT(LLM):
                 log_output: bool = False) -> None:
     """Queries OpenAI's API and stores response in |response_dir|."""
     if self.ai_binary:
-      print(f'OpenAI does not use local AI binary: {self.ai_binary}')
+      logger.info(f'OpenAI does not use local AI binary: {self.ai_binary}')
     if self.temperature_list:
-      print(f'OpenAI does not allow temperature list: {self.temperature_list}')
+      logger.info(f'OpenAI does not allow temperature list: {self.temperature_list}')
 
     client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
 
@@ -242,7 +244,7 @@ class GPT(LLM):
         openai.OpenAIError)
     # TODO: Add a default value for completion.
     if log_output:
-      print(completion)
+      logger.info(completion)
     for index, choice in enumerate(completion.choices):  # type: ignore
       content = choice.message.content
       self._save_output(index, content, response_dir)
@@ -279,10 +281,10 @@ class GoogleModel(LLM):
                 log_output: bool = False) -> None:
     """Queries a Google LLM and stores results in |response_dir|."""
     if not self.ai_binary:
-      print(f'Error: This model requires a local AI binary: {self.ai_binary}')
+      logger.info(f'Error: This model requires a local AI binary: {self.ai_binary}')
       sys.exit(1)
     if self.temperature_list:
-      print('AI Binary does not implement temperature list: '
+      logger.info('AI Binary does not implement temperature list: '
             f'{self.temperature_list}')
 
     with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
@@ -310,9 +312,9 @@ class GoogleModel(LLM):
       stdout, stderr = proc.communicate()
 
       if proc.returncode != 0:
-        print(f'Failed to generate targets with prompt {prompt.get()}')
-        print(f'stdout: {stdout}')
-        print(f'stderr: {stderr}')
+        logger.info(f'Failed to generate targets with prompt {prompt.get()}')
+        logger.info(f'stdout: {stdout}')
+        logger.info(f'stderr: {stderr}')
     finally:
       os.unlink(prompt_path)
 
@@ -355,7 +357,7 @@ class VertexAIModel(GoogleModel):
                 log_output: bool = False) -> None:
     del log_output
     if self.ai_binary:
-      print(f'VertexAI does not use local AI binary: {self.ai_binary}')
+      logger.info(f'VertexAI does not use local AI binary: {self.ai_binary}')
 
     model = self.get_model()
     parameters_list = self._prepare_parameters()

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -31,6 +31,8 @@ from experiment.benchmark import Benchmark, FileType
 from experiment.fuzz_target_error import SemanticCheckResult
 from llm_toolkit import models, prompts
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_TEMPLATE_DIR: str = 'prompts/template_xml/'
 
 # TODO(Dongge): Refactor this tot avoid hard-coding.
@@ -392,7 +394,7 @@ class DefaultTemplateBuilder(PromptBuilder):
                     .replace('</error>\n', '')
 
     # Log warning for an unexpected empty error message.
-    logging.warning(
+    logger.warning(
         'Unexpected empty error message in fix prompt for error_desc: %s',
         str(error_desc))
     return problem.replace('{ERROR_MESSAGES}', error_message)
@@ -455,7 +457,7 @@ class DefaultTemplateBuilder(PromptBuilder):
       if prompt_size + func_code_token_num >= self._model.context_window:
         # The estimation is inaccurate, if an example's size equals to
         # the limit, it's safer to not include the example.
-        logging.warning('Breaking because adding this function code \
+        logger.warning('Breaking because adding this function code \
               would exceed context window')
         break
       prompt_size += func_code_token_num
@@ -467,7 +469,7 @@ class DefaultTemplateBuilder(PromptBuilder):
       return problem.replace('{PROJECT_FUNCTION_CODE}',
                              project_function_code.strip())
 
-    logging.warning(
+    logger.warning(
         'Empty project function code in triage prompt for project: %s, \
           function name: %s', benchmark.project, benchmark.function_name)
 
@@ -496,7 +498,7 @@ class DefaultTemplateBuilder(PromptBuilder):
     lines = driver_code.split('\n')
 
     if target_line > len(lines):
-      logging.warning(
+      logger.warning(
           'Driver target line exceed maxium limit in Project: %s, \
                       try to use whole driver code in trigae prompt', project)
       return driver_code
@@ -531,7 +533,7 @@ class DefaultTemplateBuilder(PromptBuilder):
           output_lines.update(range(start, end + 1))
       return '\n'.join(result)
 
-    logging.warning('Failed to slice Project: %s Function: %s at Lines: %s',
+    logger.warning('Failed to slice Project: %s Function: %s at Lines: %s',
                     project, func_name, target_lines)
     return ''
 
@@ -585,7 +587,7 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     except:
       pass
 
-    print(f'Cannot retrieve project url of project {project_name}')
+    logger.info(f'Cannot retrieve project url of project {project_name}')
     return ''
 
   def _find_template(self, template_dir: str, template_name: str) -> str:

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -534,7 +534,7 @@ class DefaultTemplateBuilder(PromptBuilder):
       return '\n'.join(result)
 
     logger.warning('Failed to slice Project: %s Function: %s at Lines: %s',
-                    project, func_name, target_lines)
+                   project, func_name, target_lines)
     return ''
 
 

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -103,8 +103,9 @@ def get_experiment_configs(
     |args| setting."""
   benchmark_yamls = []
   if args.benchmark_yaml:
-    logger.info(f'A benchmark yaml file ({args.benchmark_yaml}) is provided. '
-          f'Will use it and ignore the files in {args.benchmarks_directory}.')
+    logger.info(
+        f'A benchmark yaml file ({args.benchmark_yaml}) is provided. '
+        f'Will use it and ignore the files in {args.benchmarks_directory}.')
     benchmark_yamls = [args.benchmark_yaml]
   else:
     if args.generate_benchmarks:
@@ -223,7 +224,11 @@ def parse_args() -> argparse.Namespace:
                       '--introspector-endpoint',
                       type=str,
                       default=introspector.DEFAULT_INTROSPECTOR_ENDPOINT)
-  parser.add_argument('-lo', '--log-level', help='Sets the logging level. Options available: [{LOG_LEVELS}]', default='info')
+  parser.add_argument(
+      '-lo',
+      '--log-level',
+      help='Sets the logging level. Options available: [{LOG_LEVELS}]',
+      default='info')
   parser.add_argument(
       '-of',
       '--oss-fuzz-dir',
@@ -298,8 +303,8 @@ def parse_args() -> argparse.Namespace:
 def _print_experiment_result(result: Result):
   """Prints the |result| of a single experiment."""
   logger.info(f'\n**** Finished benchmark {result.benchmark.project}, '
-        f'{result.benchmark.function_signature} ****\n'
-        f'{result.result}')
+              f'{result.benchmark.function_signature} ****\n'
+              f'{result.result}')
 
 
 def _print_experiment_results(results: list[Result]):
@@ -307,8 +312,9 @@ def _print_experiment_results(results: list[Result]):
   logger.info('\n\n**** FINAL RESULTS: ****\n\n')
   for result in results:
     logger.info('=' * 80)
-    logger.info(f'*{result.benchmark.project}, {result.benchmark.function_signature}*'
-          f'\n{result.result}\n')
+    logger.info(
+        f'*{result.benchmark.project}, {result.benchmark.function_signature}*'
+        f'\n{result.result}\n')
 
 
 def _setup_logging(verbose: str = 'info') -> None:
@@ -320,8 +326,8 @@ def _setup_logging(verbose: str = 'info') -> None:
       level=log_level,
       format=LOG_FMT,
       datefmt='%Y-%m-%d %H:%M:%S',
-  )    
-      
+  )
+
 
 def main():
   args = parse_args()

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -150,7 +150,7 @@ def run_experiments(benchmark: benchmarklib.Benchmark,
         prompt_builder_to_use=args.prompt_builder)
     return Result(benchmark, result)
   except Exception as e:
-    logger.info('Exception while running experiment:', e, file=sys.stderr)
+    logger.error('Exception while running experiment: %s', str(e))
     traceback.print_exc()
     return Result(benchmark, f'Exception while running experiment: {e}')
 

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -29,6 +29,8 @@ from experiment import oss_fuzz_checkout
 from experiment.workdir import WorkDirs
 from llm_toolkit import models, prompt_builder
 
+logger = logging.getLogger(__name__)
+
 # WARN: Avoid large NUM_EXP for local experiments.
 # NUM_EXP controls the number of experiments in parallel, while each experiment
 # will evaluate {run_one_experiment.NUM_EVA, default 3} fuzz targets in
@@ -45,6 +47,9 @@ BENCHMARK_ROOT: str = './benchmark-sets'
 BENCHMARK_DIR: str = f'{BENCHMARK_ROOT}/comparison'
 RESULTS_DIR: str = run_one_experiment.RESULTS_DIR
 GENERATED_BENCHMARK: str = 'generated-benchmark-'
+
+LOG_LEVELS = {'debug', 'info'}
+LOG_FMT = '%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s'
 
 
 class Result:
@@ -71,9 +76,9 @@ def get_next_generated_benchmarks_dir() -> str:
 
 def generate_benchmarks(args: argparse.Namespace) -> None:
   """Generates benchmarks, write to filesystem and set args benchmark dir."""
-  logging.info('Generating benchmarks.')
+  logger.info('Generating benchmarks.')
   benchmark_dir = get_next_generated_benchmarks_dir()
-  logging.info('Setting benchmark directory to %s.', benchmark_dir)
+  logger.info('Setting benchmark directory to %s.', benchmark_dir)
   os.makedirs(benchmark_dir)
   args.benchmarks_directory = benchmark_dir
   benchmark_oracles = [
@@ -98,7 +103,7 @@ def get_experiment_configs(
     |args| setting."""
   benchmark_yamls = []
   if args.benchmark_yaml:
-    print(f'A benchmark yaml file ({args.benchmark_yaml}) is provided. '
+    logger.info(f'A benchmark yaml file ({args.benchmark_yaml}) is provided. '
           f'Will use it and ignore the files in {args.benchmarks_directory}.')
     benchmark_yamls = [args.benchmark_yaml]
   else:
@@ -144,7 +149,7 @@ def run_experiments(benchmark: benchmarklib.Benchmark,
         prompt_builder_to_use=args.prompt_builder)
     return Result(benchmark, result)
   except Exception as e:
-    print('Exception while running experiment:', e, file=sys.stderr)
+    logger.info('Exception while running experiment:', e, file=sys.stderr)
     traceback.print_exc()
     return Result(benchmark, f'Exception while running experiment: {e}')
 
@@ -218,6 +223,7 @@ def parse_args() -> argparse.Namespace:
                       '--introspector-endpoint',
                       type=str,
                       default=introspector.DEFAULT_INTROSPECTOR_ENDPOINT)
+  parser.add_argument('-lo', '--log-level', help='Sets the logging level. Options available: [{LOG_LEVELS}]', default='info')
   parser.add_argument(
       '-of',
       '--oss-fuzz-dir',
@@ -291,23 +297,36 @@ def parse_args() -> argparse.Namespace:
 
 def _print_experiment_result(result: Result):
   """Prints the |result| of a single experiment."""
-  print(f'\n**** Finished benchmark {result.benchmark.project}, '
+  logger.info(f'\n**** Finished benchmark {result.benchmark.project}, '
         f'{result.benchmark.function_signature} ****\n'
         f'{result.result}')
 
 
 def _print_experiment_results(results: list[Result]):
   """Prints the |results| of multiple experiments."""
-  print('\n\n**** FINAL RESULTS: ****\n\n')
+  logger.info('\n\n**** FINAL RESULTS: ****\n\n')
   for result in results:
-    print('=' * 80)
-    print(f'*{result.benchmark.project}, {result.benchmark.function_signature}*'
+    logger.info('=' * 80)
+    logger.info(f'*{result.benchmark.project}, {result.benchmark.function_signature}*'
           f'\n{result.result}\n')
 
 
+def _setup_logging(verbose: str = 'info') -> None:
+  if verbose == "debug":
+    log_level = logging.DEBUG
+  else:
+    log_level = logging.INFO
+  logging.basicConfig(
+      level=log_level,
+      format=LOG_FMT,
+      datefmt='%Y-%m-%d %H:%M:%S',
+  )    
+      
+
 def main():
-  logging.basicConfig(level=logging.INFO)
   args = parse_args()
+  _setup_logging(args.log_level)
+  logger.info('Starting experiments')
 
   # Set introspector endpoint before performing any operations to ensure the
   # right API endpoint is used throughout.
@@ -318,7 +337,7 @@ def main():
   experiment_configs = get_experiment_configs(args)
   experiment_results = []
 
-  print(f'Running {NUM_EXP} experiment(s) in parallel.')
+  logger.info(f'Running {NUM_EXP} experiment(s) in parallel.')
   if NUM_EXP == 1:
     for config in experiment_configs:
       result = run_experiments(*config)

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -31,6 +31,8 @@ from experiment.benchmark import Benchmark
 from experiment.workdir import WorkDirs
 from llm_toolkit import models, output_parser, prompt_builder, prompts
 
+logger = logging.getLogger(__name__)
+
 # WARN: Avoid high value for NUM_EVA for local experiments.
 # NUM_EVA controls the number of fuzz targets to evaluate in parallel by each
 # experiment, while {run_all_experiments.NUM_EXP, default 2} experiments will
@@ -85,7 +87,7 @@ def generate_targets(benchmark: Benchmark,
                      builder: prompt_builder.PromptBuilder,
                      debug: bool = DEBUG) -> list[str]:
   """Generates fuzz target with LLM."""
-  print(f'Generating targets for {benchmark.project} '
+  logger.info(f'Generating targets for {benchmark.project} '
         f'{benchmark.function_signature} using {model.name}..')
   model.query_llm(prompt, response_dir=work_dirs.raw_targets, log_output=debug)
 
@@ -105,9 +107,10 @@ def generate_targets(benchmark: Benchmark,
 
   if generated_targets:
     targets_relpath = map(os.path.relpath, generated_targets)
-    print('Generated:\n', '\n '.join(targets_relpath))
+    targets_relpath_str = '\n '.join(targets_relpath)
+    logger.info(f'Generated:\n {targets_relpath_str}')
   else:
-    print(f'Failed to generate targets: {generated_targets}')
+    logger.info(f'Failed to generate targets: {generated_targets}')
   return generated_targets
 
 
@@ -191,7 +194,7 @@ def check_targets(
     for i, target_stat in enumerate(
         p.starmap(evaluator.check_target, ai_target_pairs)):
       if target_stat is None:
-        logging.error('This should never happen: Error evaluating target: %s',
+        logger.error('This should never happen: Error evaluating target: %s',
                       generated_targets[i])
         target_stat = exp_evaluator.Result()
 
@@ -200,7 +203,7 @@ def check_targets(
   if len(target_stats) > 0:
     return aggregate_results(target_stats, generated_targets)
 
-  print('No targets to check.')
+  logger.info('No targets to check.')
   return None
 
 
@@ -225,7 +228,6 @@ def run(benchmark: Benchmark,
         prompt_builder_to_use: str = 'DEFAULT') -> Optional[AggregatedResult]:
   """Generates code via LLM, and evaluates them."""
   model.cloud_setup()
-  logging.basicConfig(level=logging.INFO)
 
   if example_pair is None:
     example_pair = prompt_builder.EXAMPLES[benchmark.language]

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -88,7 +88,7 @@ def generate_targets(benchmark: Benchmark,
                      debug: bool = DEBUG) -> list[str]:
   """Generates fuzz target with LLM."""
   logger.info(f'Generating targets for {benchmark.project} '
-        f'{benchmark.function_signature} using {model.name}..')
+              f'{benchmark.function_signature} using {model.name}..')
   model.query_llm(prompt, response_dir=work_dirs.raw_targets, log_output=debug)
 
   _, target_ext = os.path.splitext(benchmark.target_path)
@@ -195,7 +195,7 @@ def check_targets(
         p.starmap(evaluator.check_target, ai_target_pairs)):
       if target_stat is None:
         logger.error('This should never happen: Error evaluating target: %s',
-                      generated_targets[i])
+                     generated_targets[i])
         target_stat = exp_evaluator.Result()
 
       target_stats.append((i, target_stat))


### PR DESCRIPTION
We use logging in multiple formats:

- logging.info/debug/..
- print(
- write to files

It's fairly inconsistent. So am unifying it in a more Pythonic way. The format also makes it easier to track performance of the tool as we can find bottlenecks by looking at the logs.