### PR TITLE
JVM: Fix exception description in prompt

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -623,8 +623,11 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
   def _format_exceptions(self) -> str:
     """Formats the exception thrown from this method or constructor."""
     if self.benchmark.exceptions:
-      return '<exceptions>' + '\n'.join(
-          self.benchmark.exceptions) + '</exceptions>'
+      exception_str_list = [
+        f'<exception>{exp}</exception>' for exp in self.benchmark.exceptions
+      ]
+      return '<exceptions>\n' + '\n'.join(
+          exception_str_list) + '\n</exceptions>'
 
     return ''
 

--- a/prompts/template_xml/jvm_requirement.txt
+++ b/prompts/template_xml/jvm_requirement.txt
@@ -9,6 +9,7 @@
 <item>Please avoid using any multithreading or multi-processing approach.</item>
 <item>Please add import statements for necessary classes, except for classes in the java.lang package.</item>
 <item>You must create the object before calling the target method.</item>
+<item>You must catch java.lang.UnsupportOperationException.</item>
 <item>Please use {HARNESS_NAME} as the Java class name.</item>
 <item>{STATIC_OR_INSTANCE}</item>
 <item>Do not create new variables with the same names as existing variables.


### PR DESCRIPTION
This PR fixes the exceptions information shown in the JVM prompt to allow LLM to read correct exception information that is needed to catch in the generated harnesses.