### PR TITLE
JVM: Fix multiple bugs in JVM coverage calculation

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -158,13 +158,12 @@ class BuilderRunner:
     arg_count = len(signature.split('(')[1].split(')')[0].split(','))
 
     if '<init>' in name:
-      # JVM constructor name <init> does not exist in result code
-      # Retrieve the class name to locate a constructor call
-      class_name = signature[1:].split('].')[0].split('.')[-1]
-      name = f'new {class_name}'
+      # Always return true for Java constructors because it is not possible
+      # to match all possible ways to call the constructors
+      return True
 
     pattern = r'(%s\(%s\))' % (name, ','.join([base_arg_regex] * arg_count))
-    match = re.search(pattern, ''.join(code.splitlines()))
+    match = re.search(pattern, ''.join(code.splitlines()).replace(' ', ''))
 
     return bool(match)
 

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -93,7 +93,7 @@ def load_existing_textcov(project: str) -> textcov.Textcov:
     if not blob.name.endswith('.covreport'):
       continue
 
-   logger.info(f'Loading existing textcov from {blob.name}')
+    logger.info(f'Loading existing textcov from {blob.name}')
     with blob.open('rb') as f:
       existing_textcov.merge(textcov.Textcov.from_file(f))
 

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -65,8 +65,7 @@ class Result:
     return dataclasses.asdict(self)
 
 
-def load_existing_textcov(project: str,
-                          language: str = 'c++') -> textcov.Textcov:
+def load_existing_textcov(project: str) -> textcov.Textcov:
   """Loads existing textcovs."""
   storage_client = storage.Client.create_anonymous_client()
   bucket = storage_client.bucket(OSS_FUZZ_COVERAGE_BUCKET)
@@ -88,20 +87,38 @@ def load_existing_textcov(project: str,
   # Download and merge them.
   existing_textcov = textcov.Textcov()
   for blob in blobs:
-    if language == 'jvm':
-      if blob.name != 'jacoco.xml':
-        continue
-      print(f'Loading existing textcov from {blob.name}')
-      existing_textcov.merge(textcov.Textcov.from_jvm_file(blob))
-    else:
-      if not blob.name.endswith('.covreport'):
-        continue
+    if not blob.name.endswith('.covreport'):
+      continue
 
-      print(f'Loading existing textcov from {blob.name}')
-      with blob.open('rb') as f:
-        existing_textcov.merge(textcov.Textcov.from_file(f))
+    print(f'Loading existing textcov from {blob.name}')
+    with blob.open('rb') as f:
+      existing_textcov.merge(textcov.Textcov.from_file(f))
 
   return existing_textcov
+
+
+def load_existing_jvm_textcov(project: str) -> textcov.Textcov:
+  """Loads existing textcovs for JVM project."""
+  storage_client = storage.Client.create_anonymous_client()
+  bucket = storage_client.bucket(OSS_FUZZ_COVERAGE_BUCKET)
+  blobs = storage_client.list_blobs(bucket,
+                                    prefix=f'{project}/reports/',
+                                    delimiter='/')
+  # Iterate through all blobs first to get the prefixes (i.e. "subdirectories").
+  for blob in blobs:
+    continue
+
+  if not blobs.prefixes:  # type: ignore
+    # No existing coverage reports.
+    raise RuntimeError(f'No existing coverage reports for {project}')
+
+  latest_dir = sorted(blobs.prefixes)[-1]  # type: ignore
+  blob = bucket.blob(f'{latest_dir}linux/jacoco.xml')
+  print(f'Loading existing jacoco.xml textcov from {blob.name}')
+  with blob.open() as f:
+    return textcov.Textcov.from_jvm_file(f)
+
+  return textcov.Textcov()
 
 
 def load_existing_coverage_summary(project: str) -> dict:
@@ -442,5 +459,7 @@ class Evaluator:
 
   def _load_existing_textcov(self) -> textcov.Textcov:
     """Loads existing textcovs."""
-    return load_existing_textcov(self.benchmark.project,
-                                 self.benchmark.language)
+    if self.benchmark.language == 'jvm':
+      return load_existing_jvm_textcov(self.benchmark.project)
+
+    return load_existing_textcov(self.benchmark.project)

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -127,7 +127,7 @@ class Function:
     if language == 'jvm':
       total_line = len(self.lines)
       self.lines = {}
-      new_covered_lines = other.covered_lines - self.covered_lines
+      new_covered_lines = self.covered_lines - other.covered_lines
       for i in range(total_line):
         line = f'Line{i}'
         if i >= new_covered_lines:
@@ -348,6 +348,7 @@ class Textcov:
     arg = ''
     start = False
     next_arg = ''
+    array_count = 0
     for c in desc:
       if c == '(':
         continue
@@ -363,16 +364,26 @@ class Textcov:
       else:
         if c == 'L':
           start = True
-          args.append(next_arg)
+          if next_arg:
+            if array_count > 0:
+              next_arg = f'{next_arg}{"[]" * array_count}'
+              array_count = 0
+            args.append(next_arg)
           arg = ''
           next_arg = ''
-        elif c in ['[', ']']:
-          next_arg = next_arg + c
+        elif c == '[':
+          array_count += 1
         else:
           if c in JVM_CLASS_MAPPING:
-            args.append(next_arg)
+            if next_arg:
+              if array_count > 0:
+                next_arg = f'{next_arg}{"[]" * array_count}'
+                array_count = 0
+              args.append(next_arg)
             next_arg = JVM_CLASS_MAPPING[c]
 
     if next_arg:
+      if array_count > 0:
+        next_arg = f'{next_arg}{"[]" * array_count}'
       args.append(next_arg)
     return args

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -260,7 +260,7 @@ class Textcov:
         if textcov.is_fuzzer_class(item):
           continue
 
-        # Get line covgerage information for this class
+        # Get line coverage information for this class
         coverage = line_coverage_dict[item.attrib['sourcefilename']]
 
         # Get class name and skip fuzzing and testing classes
@@ -277,7 +277,7 @@ class Textcov:
       method_dict = method_item.attrib
       method_name = method_dict['name']
 
-      # Deteremine start index in coverage list
+      # Determine start index in coverage list
       start_line = int(method_dict['line'])
       start_index = -1
       for count, item in enumerate(coverage):
@@ -285,7 +285,7 @@ class Textcov:
           start_index = count
           break
 
-      # Coverage information failed to retrieve, skipping this method
+      # Failed to retrieve coverage information, skipping this method
       if start_index == -1:
         continue
 

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -237,7 +237,7 @@ class Textcov:
     jacoco_report = ET.parse(file_handle)
 
     # Process source file information
-    line_coverage_dict = dict()
+    line_coverage_dict = {}
     for item in jacoco_report.iter():
       if item.tag == 'sourcefile':
         line_coverage = []
@@ -271,7 +271,7 @@ class Textcov:
             if method_item.attrib['name'] not in JVM_SKIPPED_METHOD:
               class_method_items.append((class_name, method_item, coverage))
 
-    for class_name, method_item in class_method_items:
+    for class_name, method_item, coverage in class_method_items:
       method_dict = method_item.attrib
       method_name = method_dict['name']
 
@@ -296,14 +296,15 @@ class Textcov:
 
       # Retrieve line coverage information
       total_line = 0
-      covered_line = 0
       for cov_data in method_item:
         if cov_data.attrib['type'] == 'LINE':
-          covered_line = int(cov_data.attrib['covered'])
           total_line = int(cov_data.attrib['covered']) + int(
               cov_data.attrib['missed'])
 
       for count in range(start_index, start_index + total_line):
+        if count >= len(coverage):
+          # Fail safe
+          break
         line_no, is_reached = coverage[count]
         line = f'Line{line_no}'
         if is_reached:

--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -125,15 +125,11 @@ class Function:
     """Subtract covered lines."""
 
     if language == 'jvm':
-      total_line = len(self.lines)
-      self.lines = {}
-      new_covered_lines = self.covered_lines - other.covered_lines
-      for i in range(total_line):
-        line = f'Line{i}'
-        if i >= new_covered_lines:
-          self.lines[line] = Line(contents=line, hit_count=0)
-        else:
-          self.lines[line] = Line(contents=line, hit_count=1)
+      for line_no in self.lines:
+        line = self.lines[line_no]
+        other_line = other.lines.get(line_no)
+        if other_line and other_line.hit_count > 0:
+          self.lines[line_no].hit_count = 0
     else:
       # For our analysis purposes, we completely delete any lines that are
       # hit by the other, rather than subtracting hitcounts.
@@ -240,12 +236,30 @@ class Textcov:
     textcov.language = 'jvm'
     jacoco_report = ET.parse(file_handle)
 
+    # Process source file information
+    line_coverage_dict = dict()
+    for item in jacoco_report.iter():
+      if item.tag == 'sourcefile':
+        line_coverage = []
+        for line_item in item:
+          if line_item.tag == 'line':
+            line_no = int(line_item.attrib['nr'])
+            if line_item.attrib['mi'] == '0':
+              line_coverage.append((line_no, True))
+            else:
+              line_coverage.append((line_no, False))
+        line_coverage_dict[item.attrib['name']] = line_coverage
+
+    # Process methods
     class_method_items = []
     for item in jacoco_report.iter():
       if item.tag == 'class':
         # Skip fuzzer classes
         if textcov.is_fuzzer_class(item):
           continue
+
+        # Get line covgerage information for this class
+        coverage = line_coverage_dict[item.attrib['sourcefilename']]
 
         # Get class name and skip fuzzing and testing classes
         class_name = item.attrib['name'].replace('/', '.')
@@ -255,11 +269,23 @@ class Textcov:
         for method_item in item:
           if method_item.tag == 'method':
             if method_item.attrib['name'] not in JVM_SKIPPED_METHOD:
-              class_method_items.append((class_name, method_item))
+              class_method_items.append((class_name, method_item, coverage))
 
     for class_name, method_item in class_method_items:
       method_dict = method_item.attrib
       method_name = method_dict['name']
+
+      # Deteremine start index in coverage list
+      start_line = int(method_dict['line'])
+      start_index = -1
+      for count, item in enumerate(coverage):
+        if item[0] == start_line:
+          start_index = count
+          break
+
+      # Coverage information failed to retrieve, skipping this method
+      if start_index == -1:
+        continue
 
       # Process all arguments type from shortern Java Class naming
       args = textcov.determine_jvm_arguments_type(method_dict['desc'])
@@ -276,12 +302,14 @@ class Textcov:
           covered_line = int(cov_data.attrib['covered'])
           total_line = int(cov_data.attrib['covered']) + int(
               cov_data.attrib['missed'])
-      for i in range(total_line):
-        line = f'Line{i}'
-        if i >= covered_line:
-          current_method.lines[line] = Line(contents=line, hit_count=0)
-        else:
+
+      for count in range(start_index, start_index + total_line):
+        line_no, is_reached = coverage[count]
+        line = f'Line{line_no}'
+        if is_reached:
           current_method.lines[line] = Line(contents=line, hit_count=1)
+        else:
+          current_method.lines[line] = Line(contents=line, hit_count=0)
 
       textcov.functions[full_method_name] = current_method
 


### PR DESCRIPTION
This PR fixes multiple bugs that cause problems in calculating line coverage diff for the JVM projects.
The bugs are listed below.
1. The path to finding the existing coverage report (jacoco.xml) is wrong, making the logic always compare with an empty report when calculating for line coverage diff. This PR adds a new functions to retrieve and parse the existing coverage report correctly.
2. The interpretation logic for the JVM coverage report on array-type arguments or empty arguments is wrong, resulting in a non-matching method name when merging the coverage report. This PR fixes the java name and argument interpretation to get a correct method signature as identifiers when combining and subtracting coverage reports.
3. The subtraction of that line diff values between the existing coverage report and the new coverage report is reversed, making the calculation wrong. This PR fixes that.
4. The pre-check process of builder_runner.py will check if the target method exists in the generated harness before building it. The checking is done by the _contains_target_jvm_method() function. In Java source code, a single method call could contain an unlimited amount of space and could also split into multiple lines. The current checking logic fails to discover if spaces or line feeds exist within a method invocation. This PR fixes that by pre-processing the code to remove line feed and space before processing to correctly discover if the target method is being called or not.
5. Since constructors of classes are some of our targets and there are too many ways to invoke them, the current logic in _contains_target_jvm_method() fails to discover existing constructor invocation and causes false negative cases. This PR skip the pre-check for the constructor target of the JVM project to avoid those false negative cases.
6. JVM coverage information is mapped towards random line name but not the correct line number information. This PR fixes that by modifying the logic of the from_jvm_file method to correctly interpret the jacoco.xml report.
7. Subtraction of coverage report only done by comparing the line coverage count from the coverage reports without checking if different lines has been covered and result in same covered line count. This PR fixes the logic of those functions to calculate the coverage gain correctly.