### PR TITLE
cleanup some benchmark related code

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -713,20 +713,21 @@ def populate_benchmarks_using_introspector(project: str, language: str,
       continue
     logger.info('Function signature to fuzz: %s', function_signature)
     potential_benchmarks.append(
-        benchmarklib.Benchmark(benchmark_id = 'cli',
-                               project = project,
-                               language = language,
-                               function_signature = function_signature,
-                               function_name = get_raw_function_name(function, project),
-                               return_type = _get_clean_return_type(function, project),
-                               params = _group_function_params(
-                                   _get_clean_arg_types(function, project),
-                                   _get_arg_names(function, project, language)),
-                               exceptions = _get_exceptions(function),
-                               is_jvm_static = _is_jvm_static(function),
-                               target_path = harness,
-                               preferred_target_name=target_name,
-                               function_dict=function))
+        benchmarklib.Benchmark(
+            benchmark_id='cli',
+            project=project,
+            language=language,
+            function_signature=function_signature,
+            function_name=get_raw_function_name(function, project),
+            return_type=_get_clean_return_type(function, project),
+            params=_group_function_params(
+                _get_clean_arg_types(function, project),
+                _get_arg_names(function, project, language)),
+            exceptions=_get_exceptions(function),
+            is_jvm_static=_is_jvm_static(function),
+            target_path=harness,
+            preferred_target_name=target_name,
+            function_dict=function))
 
     if len(potential_benchmarks) >= (limit * len(target_oracles)):
       break

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -65,6 +65,7 @@ INTROSPECTOR_FUNC_SIG = ''
 INTROSPECTOR_ADDR_TYPE = ''
 INTROSPECTOR_ALL_HEADER_FILES = ''
 INTROSPECTOR_ALL_FUNC_TYPES = ''
+
 INTROSPECTOR_HEADERS_FOR_FUNC = ''
 INTROSPECTOR_SAMPLE_XREFS = ''
 INTROSPECTOR_ALL_JVM_SOURCE_PATH = ''
@@ -712,19 +713,19 @@ def populate_benchmarks_using_introspector(project: str, language: str,
       continue
     logger.info('Function signature to fuzz: %s', function_signature)
     potential_benchmarks.append(
-        benchmarklib.Benchmark('cli',
-                               project,
-                               language,
-                               function_signature,
-                               get_raw_function_name(function, project),
-                               _get_clean_return_type(function, project),
-                               _group_function_params(
+        benchmarklib.Benchmark(benchmark_id = 'cli',
+                               project = project,
+                               language = language,
+                               function_signature = function_signature,
+                               function_name = get_raw_function_name(function, project),
+                               return_type = _get_clean_return_type(function, project),
+                               params = _group_function_params(
                                    _get_clean_arg_types(function, project),
                                    _get_arg_names(function, project, language)),
-                               _get_exceptions(function),
-                               _is_jvm_static(function),
-                               harness,
-                               target_name,
+                               exceptions = _get_exceptions(function),
+                               is_jvm_static = _is_jvm_static(function),
+                               target_path = harness,
+                               preferred_target_name=target_name,
                                function_dict=function))
 
     if len(potential_benchmarks) >= (limit * len(target_oracles)):

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -112,7 +112,7 @@ class DefaultTemplateBuilder(PromptBuilder):
 
   def __init__(self,
                model: models.LLM,
-               benchmark: Benchmark,
+               benchmark: Optional[Benchmark] = None,
                template_dir: str = DEFAULT_TEMPLATE_DIR):
     super().__init__(model)
     self._template_dir = template_dir
@@ -286,7 +286,10 @@ class DefaultTemplateBuilder(PromptBuilder):
             project_example_content: Optional[list[list[str]]] = None,
             project_context_content: Optional[dict] = None) -> prompts.Prompt:
     """Constructs a prompt using the templates in |self| and saves it."""
-    priming = self._format_priming(self.benchmark.file_type, self.benchmark.needs_extern)
+    if not self.benchmark:
+      return self._prompt
+    priming = self._format_priming(self.benchmark.file_type,
+                                   self.benchmark.needs_extern)
     final_problem = self.format_problem(self.benchmark.function_signature)
     final_problem += (f'You MUST call <code>\n'
                       f'{self.benchmark.function_signature}\n'


### PR DESCRIPTION
While working on https://github.com/google/oss-fuzz-gen/issues/494 I
need to adjust a few things wrt. Benchmarks, as the test-to-harness
logic doesn't fit the benchmark abstraction entirely. This commit is a
step towards simplifying some of the code around benchmarks. I also
removed some code that was no longer used, e.g. `manual_fix` in
`run_one_experiment.py`.