### PR TITLE
data_prep: Fix bugs in introspector query

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -622,7 +622,8 @@ def _select_functions_from_oracles(project: str, limit: int,
                                                         target_oracle,
                                                         target_oracles)
       all_functions.update(tmp_functions)
-      return list(all_functions.values())[:limit]
+
+    return list(all_functions.values())[:limit]
 
   # Selection rule: Prioritize on far-reach-low-coverage, but include one of
   # optimal-targets, easy-params-far-reach if any.


### PR DESCRIPTION
There is a wrong indentation in the _select_functions_from_oracles function. This wrong indentation causes the function to always return a function list from the first oracle in the provided `target_oracles` list only. This PR fixes the indentation bug.