### PR TITLE
c-specific builder: fix typo in post_process_generated_code

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1118,7 +1118,7 @@ class CSpecificBuilder(PromptBuilder):
     """Builds a triager prompt."""
     return self._prompt
 
-  def post_proces_generated_code(self, generated_code: str) -> str:
+  def post_process_generated_code(self, generated_code: str) -> str:
     """Adds specific C headers we always want in the harnesses."""
     # TODO: explore if we can make this more precise, by only adding headers
     # if needed.


### PR DESCRIPTION
The function misses an `s` causing the logic to be the default, which is not as intend. This fixes the name so the post processing logic is called.