### PR TITLE
Set back temperature to 0.4

### DIFF
--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -31,7 +31,7 @@ spec:
         # Modify the follow command to customize one-off experiments.
         # For benchmark sets that need more disk, increase the results volume
         # size too.
-        command: ["/bin/bash", "report/docker_run.sh", "${GKE_EXP_BENCHMARK}", "${GKE_EXP_NAME}", "${GKE_EXP_FUZZING_TIMEOUT}", "ofg-pr", "${GKE_EXP_LLM}", "${GKE_EXP_DELAY}", "${GKE_EXP_LOCAL_INTROSPECTOR}", "${GKE_EXP_NUM_SAMPLES}", "${GKE_EXP_LLM_FIX_LIMIT}"]
+        command: ["/bin/bash", "report/docker_run.sh", "${GKE_EXP_BENCHMARK}", "${GKE_EXP_NAME}", "${GKE_EXP_FUZZING_TIMEOUT}", "ofg-pr", "${GKE_EXP_LLM}", "${GKE_EXP_DELAY}", "${GKE_EXP_LOCAL_INTROSPECTOR}", "${GKE_EXP_NUM_SAMPLES}", "${GKE_EXP_LLM_FIX_LIMIT}", "${GKE_EXP_VARY_TEMPERATURE}"]
         resources:
           requests:
             cpu: ${GKE_EXP_REQ_CPU}

--- a/ci/request_pr_exp.py
+++ b/ci/request_pr_exp.py
@@ -43,6 +43,7 @@ REQUEST_CPU = 6
 REQUEST_MEM = 30
 NUM_SAMPLES = 2
 NUM_FIXES = 2
+VARY_TEMPERATURE = True
 
 PR_LINK_PREFIX = 'https://github.com/google/oss-fuzz-gen/pull'
 JOB_LINK_PREFIX = ('https://console.cloud.google.com/kubernetes/job/'
@@ -142,13 +143,20 @@ def _parse_args(cmd) -> argparse.Namespace:
       '--num-samples',
       type=int,
       default=NUM_SAMPLES,
-      help='The number of samples to request from LLM, default: {NUM_SAMPLES}')
+      help=f'The number of samples to request from LLM, default: {NUM_SAMPLES}')
   parser.add_argument(
       '-nf',
       '--llm-fix-limit',
       type=int,
       default=NUM_FIXES,
-      help='The number of fixes to request from LLM, default: {NUM_FIXES}')
+      help=f'The number of fixes to request from LLM, default: {NUM_FIXES}')
+  parser.add_argument(
+      '-vt',
+      '--vary-temperature',
+      type=bool,
+      default=VARY_TEMPERATURE,
+      help=('Use different temperatures for each sample, default: '
+            f'{VARY_TEMPERATURE}'))
   args = parser.parse_args(cmd)
 
   assert os.path.isfile(
@@ -273,6 +281,7 @@ def _fill_template(args: argparse.Namespace) -> str:
     exp_env_vars['GKE_EXP_LOCAL_INTROSPECTOR'] = 'true'
   exp_env_vars['GKE_EXP_NUM_SAMPLES'] = f'{args.num_samples}'
   exp_env_vars['GKE_EXP_LLM_FIX_LIMIT'] = f'{args.llm_fix_limit}'
+  exp_env_vars['GKE_EXP_VARY_TEMPERATURE'] = f'{args.vary_temperature}'
 
   with open(args.gke_template, 'r') as file:
     yaml_template = file.read()

--- a/ci/request_pr_exp.py
+++ b/ci/request_pr_exp.py
@@ -281,7 +281,7 @@ def _fill_template(args: argparse.Namespace) -> str:
     exp_env_vars['GKE_EXP_LOCAL_INTROSPECTOR'] = 'true'
   exp_env_vars['GKE_EXP_NUM_SAMPLES'] = f'{args.num_samples}'
   exp_env_vars['GKE_EXP_LLM_FIX_LIMIT'] = f'{args.llm_fix_limit}'
-  exp_env_vars['GKE_EXP_VARY_TEMPERATURE'] = f'{args.vary_temperature}'
+  exp_env_vars['GKE_EXP_VARY_TEMPERATURE'] = f'{args.vary_temperature}'.lower()
 
   with open(args.gke_template, 'r') as file:
     yaml_template = file.read()

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -646,15 +646,13 @@ def _collect_instruction_extern(benchmark: benchmarklib.Benchmark) -> str:
   if not benchmark.needs_extern:
     return ''
   instruction = (
-      'IMPORTANT: The fuzz target ({FUZZ_TARGET_FILE_NAME}) is written in C++, '
-      'whereas the project-under-test ({PROJECT_NAME}) is written in C. All '
-      'headers, functions, and code from the {PROJECT_NAME} project must be '
-      'consistently wrapped in <code>extern "C"</code> to ensure error-free '
+      f'IMPORTANT: The fuzz target ({benchmark.target_path}) is written in C++,'
+      ' whereas the project-under-test ({PROJECT_NAME}) is written in C. All '
+      f'headers, functions, and code from the {benchmark.project} project must '
+      'be consistently wrapped in <code>extern "C"</code> to ensure error-free '
       'compilation and linkage between C and C++:\n<code>\nextern "C" {\n    //'
       'Include necessary C headers, source files, functions, and code here.\n}'
       '\n</code>\n')
-  instruction.replace('{FUZZ_TARGET_FILE_NAME}', benchmark.target_path)
-  instruction.replace('{PROJECT_NAME}', benchmark.project)
   return instruction
 
 

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -471,6 +471,7 @@ class GeminiModel(VertexAIModel):
             threshold=generative_models.HarmBlockThreshold.BLOCK_ONLY_HIGH,
         ),
     ]
+    logger.info('%s generating response with config: %s', model.name, config)
     return model.generate_content(prompt,
                                   generation_config=config,
                                   safety_settings=safety_config).text

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -419,9 +419,8 @@ class VertexAIModel(GoogleModel):
     """Prepares the parameter dictionary for LLM query."""
     return [{
         'temperature':
-            self.temperature_list[index % len(self.temperature_list)] if
-            (self.temperature_list and
-             len(self.temperature_list) > index) else self.temperature,
+            self.temperature_list[index % len(self.temperature_list)]
+            if self.temperature_list else self.temperature,
         'max_output_tokens':
             self._max_output_tokens
     } for index in range(self.num_samples)]

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -471,7 +471,7 @@ class GeminiModel(VertexAIModel):
             threshold=generative_models.HarmBlockThreshold.BLOCK_ONLY_HIGH,
         ),
     ]
-    logger.info('%s generating response with config: %s', model.name, config)
+    logger.info('%s generating response with config: %s', self.name, config)
     return model.generate_content(prompt,
                                   generation_config=config,
                                   safety_settings=safety_config).text

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -152,6 +152,7 @@ $PYTHON run_all_experiments.py \
   --delay "${DELAY:?}" \
   --context \
   --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
+  --temperature-list "${VARY_TEMPERATURE[@]}" \
   --model "$MODEL"
 
 export ret_val=$?

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -118,7 +118,7 @@ fi
 
 if [[ "$VARY_TEMPERATURE" = "true" ]]
 then
-    VARY_TEMPERATURE=(1.0 2.0 0.0 0.5 1.5):
+    VARY_TEMPERATURE=(1.0 2.0 0.0 0.5 1.5)
 else
     VARY_TEMPERATURE=()
 fi

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -118,7 +118,7 @@ fi
 
 if [[ "$VARY_TEMPERATURE" = "true" ]]
 then
-    VARY_TEMPERATURE=(0.0 0.2 0.5 1.0 2.0)
+    VARY_TEMPERATURE=(0.0 0.1 0.2 0.3 0.4)
 else
     VARY_TEMPERATURE=()
 fi

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -118,7 +118,7 @@ fi
 
 if [[ "$VARY_TEMPERATURE" = "true" ]]
 then
-    VARY_TEMPERATURE=(1.0 2.0 0.0 0.5 1.5)
+    VARY_TEMPERATURE=(0.0 0.2 0.5 1.0 2.0)
 else
     VARY_TEMPERATURE=()
 fi

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -50,7 +50,7 @@ DEBUG: bool = False
 NUM_SAMPLES = 2
 MAX_TOKENS: int = 4096
 RUN_TIMEOUT: int = 30
-TEMPERATURE: float = 1
+TEMPERATURE: float = 0.4
 
 RESULTS_DIR = './results'
 


### PR DESCRIPTION
This PR:
1. Sets back the default temperature to 0.4.
2. Continues #448 to allow different temperatures for fuzz target samples.

 I will re-run a full exp to validate their effect.

The recent [08-03 report](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-08-03-weekly-all/) contains regressions due to model inadequacies, such as:
```c++
fuzz/parse.cc:13:21: error: calling 'parse_url<url>' with incomplete return type 'url'
   13 |   ada::url result = ada::parser::parse_url(url, base_url);
```

This is likely because we [increased the temperature](https://github.com/google/oss-fuzz-gen/pull/448/files#diff-0d648b28bb6b85213eb0ff1c3954edd4b710ff8b219eb7dc89b294108dfedb3eL52-R52). Maybe code generation needs to be more strict and less random?

Also #448  did not pass `VARY_TEMPERATURE` to `run_all_experiments.py`, this PR fixes that and support it in PR experiments.