### PR TITLE
JVM: Revamp JVM specific properties retrieval for prompt generation

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -297,15 +297,17 @@ def query_introspector_function_line(project: str, func_sig: str) -> list:
   return [_get_data(resp, 'src_begin', 0), _get_data(resp, 'src_end', 0)]
 
 
-def query_introspector_function_props(project: str, func_sig: str) -> tuple:
+def query_introspector_function_props(project: str, func_sig: str) -> dict:
   """Queries FuzzIntrospector API for additional properties of |func_sig|."""
   resp = _query_introspector(INTROSPECTOR_JVM_PROPERTIES, {
       'project': project,
       'function_signature': func_sig
   })
-  return (_get_data(resp, 'exceptions',
-                    []), _get_data(resp, 'is-jvm-static',
-                                   False), _get_data(resp, 'need-close', False))
+  return {
+      'exceptions': _get_data(resp, 'exceptions', []),
+      'is-jvm-static': _get_data(resp, 'is-jvm-static', False),
+      'need-close': _get_data(resp, 'need-close', False)
+  }
 
 
 def query_introspector_source_code(project: str, filepath: str, begin_line: int,

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -303,11 +303,9 @@ def query_introspector_function_props(project: str, func_sig: str) -> tuple:
       'project': project,
       'function_signature': func_sig
   })
-  return (
-      _get_data(resp, 'exceptions', []),
-      _get_data(resp, 'is-jvm-static', False),
-      _get_data(resp, 'need-close', False)
-  )
+  return (_get_data(resp, 'exceptions',
+                    []), _get_data(resp, 'is-jvm-static',
+                                   False), _get_data(resp, 'need-close', False))
 
 
 def query_introspector_source_code(project: str, filepath: str, begin_line: int,
@@ -715,8 +713,6 @@ def populate_benchmarks_using_test_migration(
                                function_name='test-file',
                                return_type='test',
                                params=[],
-                               exceptions=[],
-                               is_jvm_static=False,
                                target_path=harness,
                                preferred_target_name='',
                                is_test_benchmark=True,

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -71,6 +71,7 @@ INTROSPECTOR_HEADERS_FOR_FUNC = ''
 INTROSPECTOR_SAMPLE_XREFS = ''
 INTROSPECTOR_ALL_JVM_SOURCE_PATH = ''
 INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE = ''
+INTROSPECTOR_JVM_PROPERTIES = ''
 
 
 def get_oracle_dict() -> Dict[str, Any]:
@@ -99,7 +100,7 @@ def set_introspector_endpoints(endpoint):
       INTROSPECTOR_ALL_JVM_SOURCE_PATH, INTROSPECTOR_ORACLE_OPTIMAL, \
       INTROSPECTOR_HEADERS_FOR_FUNC, \
       INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE, \
-      INTROSPECTOR_ORACLE_ALL_TESTS
+      INTROSPECTOR_ORACLE_ALL_TESTS, INTROSPECTOR_JVM_PROPERTIES
 
   INTROSPECTOR_ENDPOINT = endpoint
 
@@ -131,6 +132,7 @@ def set_introspector_endpoints(endpoint):
   INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE = (
       f'{INTROSPECTOR_ENDPOINT}/function-with-matching-return-type')
   INTROSPECTOR_ORACLE_ALL_TESTS = f'{INTROSPECTOR_ENDPOINT}/project-tests'
+  INTROSPECTOR_JVM_PROPERTIES = f'{INTROSPECTOR_ENDPOINT}/jvm-method-properties'
 
 
 def _construct_url(api: str, params: dict) -> str:
@@ -293,6 +295,19 @@ def query_introspector_function_line(project: str, func_sig: str) -> list:
       'function_signature': func_sig
   })
   return [_get_data(resp, 'src_begin', 0), _get_data(resp, 'src_end', 0)]
+
+
+def query_introspector_function_props(project: str, func_sig: str) -> tuple:
+  """Queries FuzzIntrospector API for additional properties of |func_sig|."""
+  resp = _query_introspector(INTROSPECTOR_JVM_PROPERTIES, {
+      'project': project,
+      'function_signature': func_sig
+  })
+  return (
+      _get_data(resp, 'exceptions', []),
+      _get_data(resp, 'is-jvm-static', False),
+      _get_data(resp, 'need-close', False)
+  )
 
 
 def query_introspector_source_code(project: str, filepath: str, begin_line: int,
@@ -511,16 +526,6 @@ def _get_arg_count(function: dict) -> int:
   raw_arg_types = (function.get('arg-types') or
                    function.get('function_arguments', []))
   return len(raw_arg_types)
-
-
-def _get_exceptions(function: dict) -> List[str]:
-  """Returns the exception list of this function."""
-  return function.get('exceptions', [])
-
-
-def _is_jvm_static(function: dict) -> bool:
-  """Returns the static property of this function for JVM project."""
-  return function.get('is_static', False)
 
 
 def _get_arg_names(function: dict, project: str, language: str) -> list[str]:
@@ -808,8 +813,6 @@ def populate_benchmarks_using_introspector(project: str, language: str,
             params=_group_function_params(
                 _get_clean_arg_types(function, project),
                 _get_arg_names(function, project, language), language),
-            exceptions=_get_exceptions(function),
-            is_jvm_static=_is_jvm_static(function),
             target_path=harness,
             preferred_target_name=target_name,
             function_dict=function))

--- a/experiment/benchmark.py
+++ b/experiment/benchmark.py
@@ -64,8 +64,6 @@ class Benchmark:
           'name': b.function_name,
           'return_type': b.return_type,
           'params': b.params,
-          'exceptions': b.exceptions,
-          'is_jvm_static': b.is_jvm_static,
       } for b in benchmarks]
 
     with open(os.path.join(outdir, f'{benchmarks[0].project}.yaml'),
@@ -106,8 +104,6 @@ class Benchmark:
                 '',
                 '',
                 [],
-                [],
-                False,
                 data['target_path'],
                 data.get('target_name', ''),
                 is_test_benchmark=True,
@@ -132,8 +128,6 @@ class Benchmark:
                 function.get('name'),
                 function.get('return_type'),
                 function.get('params'),
-                function.get('exceptions', []),
-                function.get('is_jvm_static', False),
                 data['target_path'],
                 data.get('target_name'),
                 use_project_examples=use_project_examples,
@@ -152,8 +146,6 @@ class Benchmark:
                function_name: str,
                return_type: str,
                params: list[dict[str, str]],
-               exceptions: list[str],
-               is_jvm_static: bool,
                target_path: str,
                preferred_target_name: Optional[str] = None,
                use_project_examples=True,
@@ -170,8 +162,6 @@ class Benchmark:
     self.function_name = function_name
     self.return_type = return_type
     self.params = params
-    self.exceptions = exceptions
-    self.is_jvm_static = is_jvm_static
     self.function_dict = function_dict
     self.target_path = target_path
     self._preferred_target_name = preferred_target_name

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -553,7 +553,9 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     # Retrieve additional properties for the target method
     temp_properties = introspector.query_introspector_function_props(
         self.benchmark.project, self.benchmark.function_signature)
-    self.exceptions, self.is_jvm_static, self.need_close = temp_properties
+    self.exceptions = temp_properties.get('exceptions', [])
+    self.is_jvm_static = temp_properties.get('is-jvm-static', False)
+    self.need_close = temp_properties.get('need_close', False)
 
     # Load templates.
     self.base_template_file = self._find_template(template_dir, 'jvm_base.txt')

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -551,7 +551,9 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     self.project_url = self._find_project_url(self.benchmark.project)
 
     # Retrieve additional properties for the target method
-    self.exceptions, self.is_jvm_static, self.need_close = introspector.query_introspector_function_props(self.benchmark.project, self.benchmark.function_signature)
+    temp_properties = introspector.query_introspector_function_props(
+        self.benchmark.project, self.benchmark.function_signature)
+    self.exceptions, self.is_jvm_static, self.need_close = temp_properties
 
     # Load templates.
     self.base_template_file = self._find_template(template_dir, 'jvm_base.txt')
@@ -768,7 +770,8 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
 
     close_statement = ''
     if self.need_close:
-      close_statement = ('<item>You MUST invoke the close method of the '
+      close_statement = (
+          '<item>You MUST invoke the close method of the '
           f'{class_name} objects in the finally block after the target method '
           'is invoked.</item>')
 
@@ -810,10 +813,12 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
     ctrs = introspector.query_introspector_matching_function_constructor_type(
         self.benchmark.project, self.benchmark.return_type, False)
     for ctr in ctrs:
-      constructor_sig = ctr.get('function_signature')
+      constructor_sig = ctr.get('function_signature', '')
       if constructor_sig:
         constructors.append(f'<signature>{constructor_sig}</signature>')
-        self.exceptions.update(introspector.query_introspector_function_props(ctr.get('project'), constructor_sig)[0])
+        self.exceptions.update(
+            introspector.query_introspector_function_props(
+                ctr.get('project', ''), constructor_sig)[0])
 
     if constructors:
       ctr_str = '\n'.join(constructors)
@@ -824,10 +829,12 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
         self.benchmark.project, self.benchmark.return_type, True)
     for func in funcs:
       is_static = func.get('is_static', False)
-      function_sig = func.get('function_signature')
+      function_sig = func.get('function_signature', '')
       if not function_sig:
         continue
-      self.exceptions.update(introspector.query_introspector_function_props(func.get('project'), function_sig)[0])
+      self.exceptions.update(
+          introspector.query_introspector_function_props(
+              func.get('project', ''), function_sig)[0])
       if is_static:
         functions.append(f'<item><signature>{function_sig}</signature></item>')
       else:

--- a/prompts/template_xml/jvm_requirement.txt
+++ b/prompts/template_xml/jvm_requirement.txt
@@ -8,10 +8,12 @@
 <item>NEVER use the @FuzzTest annotation for specifying the fuzzing method.</item>
 <item>Please avoid using any multithreading or multi-processing approach.</item>
 <item>Please add import statements for necessary classes, except for classes in the java.lang package.</item>
-<item>You must create the object before calling the target method.</item>
-<item>You must catch java.lang.UnsupportOperationException.</item>
+<item>You MUST create the object before calling the target method.</item>
+<item>You MUST catch java.lang.RuntimeException.</item>
 <item>Please use {HARNESS_NAME} as the Java class name.</item>
 <item>{STATIC_OR_INSTANCE}</item>
+{NEED_CLOSE}
+<item>You MUST invoke the close method of any resource class objects that implements the java.lang.AutoCloseable interface in the finally block after the target method is invoked.</item>
 <item>Do not create new variables with the same names as existing variables.
 WRONG:
 <code>


### PR DESCRIPTION
There are some properties in the benchmarks that only exist for JVM projects. In the current logic, these properties are being added to the benchmark class and only JVM projects will use them. This PR reduces the size of benchmarks by removing these properties from the benchmarks. Instead, these properties are lively queries from the introspector new API without the need to store them in the benchmark objects. 
In addition to the two properties (exceptions and is_jvm_static) for JVM projects, a third property is also added to indicate if the target method is a resource-type object (implements AutoClosable) that needs to be closed after use. This helps to reduce possible OOM in generated fuzzing harnesses because of memory leaks from unclosed resource objects. This is the replacement of the work originally shown in #528.