### PR TITLE
Benchmark: removed unnecessary keys in benchmark

### DIFF
--- a/benchmark-sets/all/abseil-cpp.yaml
+++ b/benchmark-sets/all/abseil-cpp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_115BinaryToDecimal13RunConversionENS_7uint128EiNS_11FunctionRefIFvS2_EEEENKUlNS_4SpanIjEEE_clES8_"
+- "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_115BinaryToDecimal13RunConversionENS_7uint128EiNS_11FunctionRefIFvS2_EEEENKUlNS_4SpanIjEEE_clES8_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void absl::str_format_internal::(anonymous namespace)::BinaryToDecimal::operator()(const void *, Span<unsigned int>)"
-- "exceptions": []
-  "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_124FractionalDigitGenerator13RunConversionENS_7uint128EiNS_11FunctionRefIFvS2_EEEENKUlNS_4SpanIjEEE_clES8_"
+- "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_124FractionalDigitGenerator13RunConversionENS_7uint128EiNS_11FunctionRefIFvS2_EEEENKUlNS_4SpanIjEEE_clES8_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void absl::str_format_internal::(anonymous namespace)::FractionalDigitGenerator::operator()(const void *, Span<unsigned int>)"
-- "exceptions": []
-  "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_122FormatFPositiveExpSlowENS_7uint128EiRKNS1_11FormatStateEENK3$_0clENS1_15BinaryToDecimalE"
+- "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_122FormatFPositiveExpSlowENS_7uint128EiRKNS1_11FormatStateEENK3$_0clENS1_15BinaryToDecimalE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void absl::str_format_internal::(anonymous namespace)::operator()(const void *, BinaryToDecimal)"
-- "exceptions": []
-  "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_122FormatFNegativeExpSlowENS_7uint128EiRKNS1_11FormatStateEENK3$_0clENS1_24FractionalDigitGeneratorE"
+- "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_122FormatFNegativeExpSlowENS_7uint128EiRKNS1_11FormatStateEENK3$_0clENS1_24FractionalDigitGeneratorE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void absl::str_format_internal::(anonymous namespace)::operator()(const void *, FractionalDigitGenerator)"
-- "exceptions": []
-  "name": "_ZNK4absl11string_view13find_first_ofEPKcm"
+- "name": "_ZNK4absl11string_view13find_first_ofEPKcm"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/ada-url.yaml
+++ b/benchmark-sets/all/ada-url.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3ada6parser9parse_urlINS_3urlEEET_NSt3__117basic_string_viewIcNS4_11char_traitsIcEEEEPKS3_"
+- "name": "_ZN3ada6parser9parse_urlINS_3urlEEET_NSt3__117basic_string_viewIcNS4_11char_traitsIcEEEEPKS3_"
   "params":
   - "name": "user_input"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct url ada::url ada::parser::parse_url<ada::parse_url<ada::url>(string_view, const struct url *)"
-- "exceptions": []
-  "name": "ada_can_parse_with_base"
+- "name": "ada_can_parse_with_base"
   "params":
   - "name": "input"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "size_t"
   "return_type": "bool"
   "signature": "bool ada_can_parse_with_base(const char *, size_t, const char *, size_t)"
-- "exceptions": []
-  "name": "ada_idna_to_ascii"
+- "name": "ada_idna_to_ascii"
   "params":
   - "name": "input"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "struct ada_owned_string ada_idna_to_ascii(const char *, size_t)"
-- "exceptions": []
-  "name": "ada_parse_with_base"
+- "name": "ada_parse_with_base"
   "params":
   - "name": "input"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "ada_url ada_parse_with_base(const char *, size_t, const char *, size_t)"
-- "exceptions": []
-  "name": "_ZN3ada6parser9parse_urlINS_14url_aggregatorEEET_NSt3__117basic_string_viewIcNS4_11char_traitsIcEEEEPKS3_"
+- "name": "_ZN3ada6parser9parse_urlINS_14url_aggregatorEEET_NSt3__117basic_string_viewIcNS4_11char_traitsIcEEEEPKS3_"
   "params":
   - "name": "user_input"
     "type": "bool "

--- a/benchmark-sets/all/arduinojson.yaml
+++ b/benchmark-sets/all/arduinojson.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN11ArduinoJson8V710HB426detail11VariantSlotdlEPvS3_"
+- "name": "_ZN11ArduinoJson8V710HB426detail11VariantSlotdlEPvS3_"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/aspell.yaml
+++ b/benchmark-sets/all/aspell.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7acommon17MDInfoListofLists5clearEPNS_6ConfigE"
+- "name": "_ZN7acommon17MDInfoListofLists5clearEPNS_6ConfigE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void acommon::MDInfoListofLists::clear(Config *)"
-- "exceptions": []
-  "name": "_ZN7acommon6Config6removeERKNS_10ParmStringE"
+- "name": "_ZN7acommon6Config6removeERKNS_10ParmStringE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "PosibErr<void> acommon::Config::remove(ParmStr)"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_111SuggestImpl7suggestEPKc"
+- "name": "_ZN12_GLOBAL__N_111SuggestImpl7suggestEPKc"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/astc-encoder.yaml
+++ b/benchmark-sets/all/astc-encoder.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_Z22is_legal_2d_block_sizejj"
+- "name": "_Z22is_legal_2d_block_sizejj"
   "params":
   - "name": "xdim"
     "type": "int"
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool is_legal_2d_block_size(unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "_Z22is_legal_3d_block_sizejjj"
+- "name": "_Z22is_legal_3d_block_sizejjj"
   "params":
   - "name": "xdim"
     "type": "int"
@@ -19,8 +17,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool is_legal_3d_block_size(unsigned int, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "_Z10encode_ise12quant_methodjPKhPhj"
+- "name": "_Z10encode_ise12quant_methodjPKhPhj"
   "params":
   - "name": "quant_level"
     "type": "int"
@@ -34,8 +31,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void encode_ise(DW_TAG_enumeration_typequant_method, unsigned int, const uint8_t *, uint8_t *, unsigned int)"
-- "exceptions": []
-  "name": "_Z20symbolic_to_physicalRK21block_size_descriptorRK25symbolic_compressed_blockPh"
+- "name": "_Z20symbolic_to_physicalRK21block_size_descriptorRK25symbolic_compressed_blockPh"
   "params":
   - "name": "bsd"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void symbolic_to_physical(const struct block_size_descriptor &, const struct symbolic_compressed_block &, uint8_t *)"
-- "exceptions": []
-  "name": "_ZNK25symbolic_compressed_block20get_color_quant_modeEv"
+- "name": "_ZNK25symbolic_compressed_block20get_color_quant_modeEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/augeas.yaml
+++ b/benchmark-sets/all/augeas.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "transform_save"
+- "name": "transform_save"
   "params":
   - "name": "aug"
     "type": "bool "
@@ -12,15 +11,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int transform_save(struct augeas *, struct tree *, const char *, struct tree *)"
-- "exceptions": []
-  "name": "aug_save"
+- "name": "aug_save"
   "params":
   - "name": "aug"
     "type": "bool "
   "return_type": "int"
   "signature": "int aug_save(struct augeas *)"
-- "exceptions": []
-  "name": "aug_load_file"
+- "name": "aug_load_file"
   "params":
   - "name": "aug"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int aug_load_file(struct augeas *, const char *)"
-- "exceptions": []
-  "name": "aug_text_retrieve"
+- "name": "aug_text_retrieve"
   "params":
   - "name": "aug"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int aug_text_retrieve(struct augeas *, const char *, const char *, const char *, const char *)"
-- "exceptions": []
-  "name": "aug_preview"
+- "name": "aug_preview"
   "params":
   - "name": "aug"
     "type": "bool "

--- a/benchmark-sets/all/avahi.yaml
+++ b/benchmark-sets/all/avahi.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "avahi_string_list_new"
+- "name": "avahi_string_list_new"
   "params":
   - "name": "txt"
     "type": "bool "
   "return_type": "void"
   "signature": "AvahiStringList * avahi_string_list_new(const char *, void)"
-- "exceptions": []
-  "name": "avahi_string_list_add_vprintf"
+- "name": "avahi_string_list_add_vprintf"
   "params":
   - "name": "l"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "AvahiStringList * avahi_string_list_add_vprintf(AvahiStringList *, const char *, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "avahi_string_list_add_printf"
+- "name": "avahi_string_list_add_printf"
   "params":
   - "name": "l"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "AvahiStringList * avahi_string_list_add_printf(AvahiStringList *, const char *, void)"
-- "exceptions": []
-  "name": "avahi_dns_packet_new_reply"
+- "name": "avahi_dns_packet_new_reply"
   "params":
   - "name": "p"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "AvahiDnsPacket * avahi_dns_packet_new_reply(AvahiDnsPacket *, unsigned int, int, int)"
-- "exceptions": []
-  "name": "avahi_string_list_add_pair"
+- "name": "avahi_string_list_add_pair"
   "params":
   - "name": "l"
     "type": "bool "

--- a/benchmark-sets/all/bind9.yaml
+++ b/benchmark-sets/all/bind9.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "dns_view_freezezones"
+- "name": "dns_view_freezezones"
   "params":
   - "name": "view"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "isc_result_t dns_view_freezezones(dns_view_t *, bool)"
-- "exceptions": []
-  "name": "dns_view_asyncload"
+- "name": "dns_view_asyncload"
   "params":
   - "name": "view"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "isc_result_t dns_view_asyncload(dns_view_t *, bool, dns_zt_callback_t *, void *)"
-- "exceptions": []
-  "name": "dns_zt_asyncload"
+- "name": "dns_zt_asyncload"
   "params":
   - "name": "zt"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "isc_result_t dns_zt_asyncload(dns_zt_t *, bool, dns_zt_callback_t *, void *)"
-- "exceptions": []
-  "name": "dns_zt_freezezones"
+- "name": "dns_zt_freezezones"
   "params":
   - "name": "zt"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "isc_result_t dns_zt_freezezones(dns_zt_t *, dns_view_t *, bool)"
-- "exceptions": []
-  "name": "dns__rbtdb_addrdataset"
+- "name": "dns__rbtdb_addrdataset"
   "params":
   - "name": "db"
     "type": "bool "

--- a/benchmark-sets/all/bitcoin-core.yaml
+++ b/benchmark-sets/all/bitcoin-core.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6wallet12_GLOBAL__N_116WalletLoaderImpl12createWalletERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS3_IcS5_16secure_allocatorIcEEEmRNS2_6vectorI13bilingual_strNS6_ISH_EEEE"
+- "name": "_ZN6wallet12_GLOBAL__N_116WalletLoaderImpl12createWalletERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS3_IcS5_16secure_allocatorIcEEEmRNS2_6vectorI13bilingual_strNS6_ISH_EEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Result<std::__1::unique_ptr<interfaces::Wallet, std::__1::default_delete<interfaces::Wallet> > > wallet::(anonymous namespace)::WalletLoaderImpl::createWallet(const string &, const SecureString &, uint64_t, vector<bilingual_str, std::__1::allocator<bilingual_str> > &)"
-- "exceptions": []
-  "name": "_ZZN6walletL13migratewalletEvENK3$_0clERK10RPCHelpManRK14JSONRPCRequest"
+- "name": "_ZZN6walletL13migratewalletEvENK3$_0clERK10RPCHelpManRK14JSONRPCRequest"
   "params":
   - "name": "this"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "UniValue wallet::operator()(const void *, const RPCHelpMan &, const JSONRPCRequest &)"
-- "exceptions": []
-  "name": "_ZN6wallet12_GLOBAL__N_116WalletLoaderImpl13migrateWalletERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS3_IcS5_16secure_allocatorIcEEE"
+- "name": "_ZN6wallet12_GLOBAL__N_116WalletLoaderImpl13migrateWalletERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS3_IcS5_16secure_allocatorIcEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Result<interfaces::WalletMigrationResult> wallet::(anonymous namespace)::WalletLoaderImpl::migrateWallet(const string &, const SecureString &)"
-- "exceptions": []
-  "name": "_ZN6wallet25MigrateLegacyToDescriptorERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEERKNS1_IcS3_16secure_allocatorIcEEERNS_13WalletContextE"
+- "name": "_ZN6wallet25MigrateLegacyToDescriptorERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEERKNS1_IcS3_16secure_allocatorIcEEERNS_13WalletContextE"
   "params":
   - "name": "wallet_name"
     "type": "bool "

--- a/benchmark-sets/all/bluez.yaml
+++ b/benchmark-sets/all/bluez.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "g_obex_put_req"
+- "name": "g_obex_put_req"
   "params":
   - "name": "obex"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "guint g_obex_put_req(GObex *, GObexDataProducer, GObexFunc, gpointer, GError **, guint, void)"
-- "exceptions": []
-  "name": "g_obex_new"
+- "name": "g_obex_new"
   "params":
   - "name": "io"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "GObex * g_obex_new(GIOChannel *, GObexTransportType, gssize, gssize)"
-- "exceptions": []
-  "name": "g_obex_get_req"
+- "name": "g_obex_get_req"
   "params":
   - "name": "obex"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "guint g_obex_get_req(GObex *, GObexDataConsumer, GObexFunc, gpointer, GError **, guint, void)"
-- "exceptions": []
-  "name": "g_obex_get_req_pkt"
+- "name": "g_obex_get_req_pkt"
   "params":
   - "name": "obex"
     "type": "bool "
@@ -63,8 +59,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "guint g_obex_get_req_pkt(GObex *, GObexPacket *, GObexDataConsumer, GObexFunc, gpointer, GError **)"
-- "exceptions": []
-  "name": "g_obex_put_req_pkt"
+- "name": "g_obex_put_req_pkt"
   "params":
   - "name": "obex"
     "type": "bool "

--- a/benchmark-sets/all/boringssl.yaml
+++ b/benchmark-sets/all/boringssl.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "X509_verify_cert"
+- "name": "X509_verify_cert"
   "params":
   - "name": "ctx"
     "type": "bool "
   "return_type": "int"
   "signature": "int X509_verify_cert(X509_STORE_CTX *)"
-- "exceptions": []
-  "name": "_ZN4bssl20ssl_client_handshakeEPNS_13SSL_HANDSHAKEE"
+- "name": "_ZN4bssl20ssl_client_handshakeEPNS_13SSL_HANDSHAKEE"
   "params":
   - "name": "hs"
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typessl_hs_wait_t bssl::ssl_client_handshake(struct SSL_HANDSHAKE *)"
-- "exceptions": []
-  "name": "_ZN4bssl9CheckOCSPENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEES4_S4_lNS0_8optionalIlEEPNS_16OCSPVerifyResult14ResponseStatusE"
+- "name": "_ZN4bssl9CheckOCSPENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEES4_S4_lNS0_8optionalIlEEPNS_16OCSPVerifyResult14ResponseStatusE"
   "params":
   - "name": "raw_response"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeOCSPRevocationStatus bssl::CheckOCSP(string_view, string_view, string_view, int64_t, optional<long>, DW_TAG_enumeration_typeResponseStatus *)"
-- "exceptions": []
-  "name": "_ZN4bssl9CheckOCSPENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEPKNS_17ParsedCertificateES7_lNS0_8optionalIlEEPNS_16OCSPVerifyResult14ResponseStatusE"
+- "name": "_ZN4bssl9CheckOCSPENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEPKNS_17ParsedCertificateES7_lNS0_8optionalIlEEPNS_16OCSPVerifyResult14ResponseStatusE"
   "params":
   - "name": "raw_response"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeOCSPRevocationStatus bssl::CheckOCSP(string_view, const ParsedCertificate *, const ParsedCertificate *, int64_t, optional<long>, DW_TAG_enumeration_typeResponseStatus *)"
-- "exceptions": []
-  "name": "_ZN4bssl12_GLOBAL__N_19CheckOCSPENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEES5_PKNS_17ParsedCertificateES5_S8_lNS1_8optionalIlEEPNS_16OCSPVerifyResult14ResponseStatusE"
+- "name": "_ZN4bssl12_GLOBAL__N_19CheckOCSPENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEES5_PKNS_17ParsedCertificateES5_S8_lNS1_8optionalIlEEPNS_16OCSPVerifyResult14ResponseStatusE"
   "params":
   - "name": "raw_response"
     "type": "bool "

--- a/benchmark-sets/all/brotli.yaml
+++ b/benchmark-sets/all/brotli.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "BrotliDecoderAttachDictionary"
+- "name": "BrotliDecoderAttachDictionary"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,15 +11,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int BrotliDecoderAttachDictionary(BrotliDecoderStateInternal *, BrotliSharedDictionaryType, size_t, const uint8_t *)"
-- "exceptions": []
-  "name": "BrotliDecoderIsFinished"
+- "name": "BrotliDecoderIsFinished"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "int BrotliDecoderIsFinished(const BrotliDecoderStateInternal *)"
-- "exceptions": []
-  "name": "BrotliSafeReadBits32Slow"
+- "name": "BrotliSafeReadBits32Slow"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int BrotliSafeReadBits32Slow(const BrotliBitReader *, uint64_t, uint64_t *)"
-- "exceptions": []
-  "name": "BrotliDecoderDecompress"
+- "name": "BrotliDecoderDecompress"
   "params":
   - "name": ""
     "type": "size_t"
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "BrotliDecoderResult BrotliDecoderDecompress(size_t, const uint8_t *, size_t *, uint8_t *)"
-- "exceptions": []
-  "name": "BrotliDecoderTakeOutput"
+- "name": "BrotliDecoderTakeOutput"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/brpc.yaml
+++ b/benchmark-sets/all/brpc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4brpc6policy19ConsulNamingService16RunNamingServiceEPKcPNS_20NamingServiceActionsE"
+- "name": "_ZN4brpc6policy19ConsulNamingService16RunNamingServiceEPKcPNS_20NamingServiceActionsE"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int brpc::policy::ConsulNamingService::RunNamingService(const char *, NamingServiceActions *)"
-- "exceptions": []
-  "name": "_ZN4brpc6policy19ConsulNamingService10GetServersEPKcPSt6vectorINS_10ServerNodeESaIS5_EE"
+- "name": "_ZN4brpc6policy19ConsulNamingService10GetServersEPKcPSt6vectorINS_10ServerNodeESaIS5_EE"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int brpc::policy::ConsulNamingService::GetServers(const char *, vector<brpc::ServerNode, std::allocator<brpc::ServerNode> > *)"
-- "exceptions": []
-  "name": "_ZN4brpc6policy15DiscoveryClient8RegisterERKNS0_22DiscoveryRegisterParamE"
+- "name": "_ZN4brpc6policy15DiscoveryClient8RegisterERKNS0_22DiscoveryRegisterParamE"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,15 +27,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int brpc::policy::DiscoveryClient::Register(const struct DiscoveryRegisterParam &)"
-- "exceptions": []
-  "name": "_ZN4brpc6policy15DiscoveryClient13PeriodicRenewEPv"
+- "name": "_ZN4brpc6policy15DiscoveryClient13PeriodicRenewEPv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void * brpc::policy::DiscoveryClient::PeriodicRenew(void *)"
-- "exceptions": []
-  "name": "_ZN4brpc6policy15DiscoveryClient10DoRegisterEv"
+- "name": "_ZN4brpc6policy15DiscoveryClient10DoRegisterEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/brunsli.yaml
+++ b/benchmark-sets/all/brunsli.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7brunsli14ComponentStateC2Ev"
+- "name": "_ZN7brunsli14ComponentStateC2Ev"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void brunsli::ComponentState::ComponentState(struct ComponentState *)"
-- "exceptions": []
-  "name": "_ZN36BrunsliDecodeStreamingFuzzEmpty_Test8TestBodyEv"
+- "name": "_ZN36BrunsliDecodeStreamingFuzzEmpty_Test8TestBodyEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void BrunsliDecodeStreamingFuzzEmpty_Test::TestBody()"
-- "exceptions": []
-  "name": "_ZN7brunsli37BrunsliEstimateDecoderPeakMemoryUsageEPKhm"
+- "name": "_ZN7brunsli37BrunsliEstimateDecoderPeakMemoryUsageEPKhm"
   "params":
   - "name": ""
     "type": "bool "
@@ -22,15 +19,13 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "size_t brunsli::BrunsliEstimateDecoderPeakMemoryUsage(const uint8_t *, const size_t)"
-- "exceptions": []
-  "name": "_ZN27BrunsliDecodeFuzzEmpty_Test8TestBodyEv"
+- "name": "_ZN27BrunsliDecodeFuzzEmpty_Test8TestBodyEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void BrunsliDecodeFuzzEmpty_Test::TestBody()"
-- "exceptions": []
-  "name": "_ZN7brunsli14BrunsliDecoder6DecodeEPmPPKhS1_PPh"
+- "name": "_ZN7brunsli14BrunsliDecoder6DecodeEPmPPKhS1_PPh"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/c-ares.yaml
+++ b/benchmark-sets/all/c-ares.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ares_getnameinfo"
+- "name": "ares_getnameinfo"
   "params":
   - "name": "channel"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void ares_getnameinfo(ares_channel_t *, const struct sockaddr *, ares_socklen_t, int, ares_nameinfo_callback, void *)"
-- "exceptions": []
-  "name": "ares_dup"
+- "name": "ares_dup"
   "params":
   - "name": "dest"
     "type": "bool "
@@ -25,15 +23,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ares_dup(ares_channel_t **, const ares_channel_t *)"
-- "exceptions": []
-  "name": "ares_init"
+- "name": "ares_init"
   "params":
   - "name": "channelptr"
     "type": "bool "
   "return_type": "int"
   "signature": "int ares_init(ares_channel_t **)"
-- "exceptions": []
-  "name": "ares_getaddrinfo"
+- "name": "ares_getaddrinfo"
   "params":
   - "name": "channel"
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void ares_getaddrinfo(ares_channel_t *, const char *, const char *, const struct ares_addrinfo_hints *, ares_addrinfo_callback, void *)"
-- "exceptions": []
-  "name": "ares_init_options"
+- "name": "ares_init_options"
   "params":
   - "name": "channelptr"
     "type": "bool "

--- a/benchmark-sets/all/c-blosc.yaml
+++ b/benchmark-sets/all/c-blosc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ZSTD_generateSequences"
+- "name": "ZSTD_generateSequences"
   "params":
   - "name": ""
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "size_t ZSTD_generateSequences(ZSTD_CCtx *, ZSTD_Sequence *, size_t, const void *, size_t)"
-- "exceptions": []
-  "name": "ZSTD_endStream"
+- "name": "ZSTD_endStream"
   "params":
   - "name": ""
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t ZSTD_endStream(ZSTD_CStream *, ZSTD_outBuffer *)"
-- "exceptions": []
-  "name": "ZSTD_compress2"
+- "name": "ZSTD_compress2"
   "params":
   - "name": ""
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "size_t ZSTD_compress2(ZSTD_CCtx *, void *, size_t, const void *, size_t)"
-- "exceptions": []
-  "name": "ZSTD_decompressStream_simpleArgs"
+- "name": "ZSTD_decompressStream_simpleArgs"
   "params":
   - "name": ""
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t ZSTD_decompressStream_simpleArgs(ZSTD_DCtx *, void *, size_t, size_t *, const void *, size_t, size_t *)"
-- "exceptions": []
-  "name": "ZSTD_compressStream"
+- "name": "ZSTD_compressStream"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/capnproto.yaml
+++ b/benchmark-sets/all/capnproto.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN5capnp1_22initDynamicTestMessageENS_13DynamicStruct7BuilderE"
+- "name": "_ZN5capnp1_22initDynamicTestMessageENS_13DynamicStruct7BuilderE"
   "params":
   - "name": "builder"
     "type": "bool "
   "return_type": "void"
   "signature": "void capnp::_::initDynamicTestMessage(Builder)"
-- "exceptions": []
-  "name": "_ZN5capnp1_23checkDynamicTestMessageENS_13DynamicStruct7BuilderE"
+- "name": "_ZN5capnp1_23checkDynamicTestMessageENS_13DynamicStruct7BuilderE"
   "params":
   - "name": "builder"
     "type": "bool "
   "return_type": "void"
   "signature": "void capnp::_::checkDynamicTestMessage(Builder)"
-- "exceptions": []
-  "name": "_ZN5capnp13DynamicStruct7Builder3setEN2kj9StringPtrERKNS_12DynamicValue6ReaderE"
+- "name": "_ZN5capnp13DynamicStruct7Builder3setEN2kj9StringPtrERKNS_12DynamicValue6ReaderE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void capnp::DynamicStruct::Builder::set(StringPtr, const Reader &)"
-- "exceptions": []
-  "name": "_ZN5capnp13DynamicStruct7Builder5adoptEN2kj9StringPtrEONS_6OrphanINS_12DynamicValueEEE"
+- "name": "_ZN5capnp13DynamicStruct7Builder5adoptEN2kj9StringPtrEONS_6OrphanINS_12DynamicValueEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void capnp::DynamicStruct::Builder::adopt(StringPtr, DW_TAG_rvalue_reference_typeOrphan<capnp::DynamicValue>)"
-- "exceptions": []
-  "name": "_ZN5capnp13DynamicStruct7Builder5adoptENS_12StructSchema5FieldEONS_6OrphanINS_12DynamicValueEEE"
+- "name": "_ZN5capnp13DynamicStruct7Builder5adoptENS_12StructSchema5FieldEONS_6OrphanINS_12DynamicValueEEE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/capstone.yaml
+++ b/benchmark-sets/all/capstone.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "BPF_getInstruction"
+- "name": "BPF_getInstruction"
   "params":
   - "name": "ud"
     "type": "size_t"
@@ -18,8 +17,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool BPF_getInstruction(csh, const uint8_t *, size_t, MCInst *, uint16_t *, uint64_t, void *)"
-- "exceptions": []
-  "name": "LoongArch_printer"
+- "name": "LoongArch_printer"
   "params":
   - "name": "MI"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void LoongArch_printer(MCInst *, SStream *, void *)"
-- "exceptions": []
-  "name": "PPC_getInstruction"
+- "name": "PPC_getInstruction"
   "params":
   - "name": "ud"
     "type": "size_t"
@@ -48,8 +45,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool PPC_getInstruction(csh, const uint8_t *, size_t, MCInst *, uint16_t *, uint64_t, void *)"
-- "exceptions": []
-  "name": "ARM_getInstruction"
+- "name": "ARM_getInstruction"
   "params":
   - "name": "ud"
     "type": "size_t"
@@ -67,8 +63,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool ARM_getInstruction(csh, const uint8_t *, size_t, MCInst *, uint16_t *, uint64_t, void *)"
-- "exceptions": []
-  "name": "AArch64_printer"
+- "name": "AArch64_printer"
   "params":
   - "name": "MI"
     "type": "bool "

--- a/benchmark-sets/all/casync.yaml
+++ b/benchmark-sets/all/casync.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "var_tmp_dir"
+- "name": "var_tmp_dir"
   "params":
   - "name": "ret"
     "type": "bool "
   "return_type": "int"
   "signature": "int var_tmp_dir(const char **)"
-- "exceptions": []
-  "name": "tmp_dir"
+- "name": "tmp_dir"
   "params":
   - "name": "ret"
     "type": "bool "
   "return_type": "int"
   "signature": "int tmp_dir(const char **)"
-- "exceptions": []
-  "name": "tempfn_random"
+- "name": "tempfn_random"
   "params":
   - "name": "p"
     "type": "bool "
@@ -22,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int tempfn_random(const char *, char **)"
-- "exceptions": []
-  "name": "compressor_encode"
+- "name": "compressor_encode"
   "params":
   - "name": "c"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int compressor_encode(CompressorContext *, bool, void *, size_t, size_t *)"
-- "exceptions": []
-  "name": "xopendirat"
+- "name": "xopendirat"
   "params":
   - "name": "fd"
     "type": "int"

--- a/benchmark-sets/all/cctz.yaml
+++ b/benchmark-sets/all/cctz.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4cctz15fixed_time_zoneERKNSt3__16chrono8durationIlNS0_5ratioILl1ELl1EEEEE"
+- "name": "_ZN4cctz15fixed_time_zoneERKNSt3__16chrono8durationIlNS0_5ratioILl1ELl1EEEEE"
   "params":
   - "name": "offset"
     "type": "bool "
   "return_type": "void"
   "signature": "time_zone cctz::fixed_time_zone(const seconds &)"
-- "exceptions": []
-  "name": "_ZZN4cctz12TimeZoneInfo4LoadERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEENK3$_0clES9_"
+- "name": "_ZZN4cctz12TimeZoneInfo4LoadERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEENK3$_0clES9_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "unique_ptr<cctz::ZoneInfoSource, std::__1::default_delete<cctz::ZoneInfoSource> > cctz::TimeZoneInfo::operator()(const void *, const string &)"
-- "exceptions": []
-  "name": "_ZNK4cctz9time_zone11descriptionEv"
+- "name": "_ZNK4cctz9time_zone11descriptionEv"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "string cctz::time_zone::description()"
-- "exceptions": []
-  "name": "_ZNK4cctz9time_zone7versionEv"
+- "name": "_ZNK4cctz9time_zone7versionEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/civetweb.yaml
+++ b/benchmark-sets/all/civetweb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mg_send_file_body"
+- "name": "mg_send_file_body"
   "params":
   - "name": "conn"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mg_send_file_body(struct mg_connection *, const char *)"
-- "exceptions": []
-  "name": "mg_send_file"
+- "name": "mg_send_file"
   "params":
   - "name": "conn"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void mg_send_file(struct mg_connection *, const char *)"
-- "exceptions": []
-  "name": "mg_send_mime_file"
+- "name": "mg_send_mime_file"
   "params":
   - "name": "conn"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void mg_send_mime_file(struct mg_connection *, const char *, const char *)"
-- "exceptions": []
-  "name": "mg_handle_form_request"
+- "name": "mg_handle_form_request"
   "params":
   - "name": "conn"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mg_handle_form_request(struct mg_connection *, struct mg_form_data_handler *)"
-- "exceptions": []
-  "name": "mg_send_mime_file2"
+- "name": "mg_send_mime_file2"
   "params":
   - "name": "conn"
     "type": "bool "

--- a/benchmark-sets/all/cjson.yaml
+++ b/benchmark-sets/all/cjson.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "cJSON_ReplaceItemInObjectCaseSensitive"
+- "name": "cJSON_ReplaceItemInObjectCaseSensitive"
   "params":
   - "name": "object"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "cJSON_bool cJSON_ReplaceItemInObjectCaseSensitive(cJSON *, const char *, cJSON *)"
-- "exceptions": []
-  "name": "cJSON_ParseWithLength"
+- "name": "cJSON_ParseWithLength"
   "params":
   - "name": "value"
     "type": "bool "
@@ -19,15 +17,13 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "cJSON * cJSON_ParseWithLength(const char *, size_t)"
-- "exceptions": []
-  "name": "cJSON_Parse"
+- "name": "cJSON_Parse"
   "params":
   - "name": "value"
     "type": "bool "
   "return_type": "void"
   "signature": "cJSON * cJSON_Parse(const char *)"
-- "exceptions": []
-  "name": "cJSON_PrintPreallocated"
+- "name": "cJSON_PrintPreallocated"
   "params":
   - "name": "item"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "cJSON_bool cJSON_PrintPreallocated(cJSON *, char *, const int, const cJSON_bool)"
-- "exceptions": []
-  "name": "cJSON_Compare"
+- "name": "cJSON_Compare"
   "params":
   - "name": "a"
     "type": "bool "

--- a/benchmark-sets/all/clamav.yaml
+++ b/benchmark-sets/all/clamav.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "cl_scandesc"
+- "name": "cl_scandesc"
   "params":
   - "name": ""
     "type": "int"
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "cl_error_t cl_scandesc(int, const char *, const char **, unsigned long *, const struct cl_engine *, struct cl_scan_options *)"
-- "exceptions": []
-  "name": "Lzma2Decode"
+- "name": "Lzma2Decode"
   "params":
   - "name": ""
     "type": "bool "
@@ -37,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "SRes Lzma2Decode(Byte *, SizeT *, const Byte *, SizeT *, Byte, ELzmaFinishMode, ELzmaStatus *, ISzAlloc *)"
-- "exceptions": []
-  "name": "cli_matchregex"
+- "name": "cli_matchregex"
   "params":
   - "name": ""
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cli_matchregex(const char *, const char *)"
-- "exceptions": []
-  "name": "qtmd_decompress"
+- "name": "qtmd_decompress"
   "params":
   - "name": ""
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int qtmd_decompress(struct qtmd_stream *, off_t)"
-- "exceptions": []
-  "name": "cl_cvdverify"
+- "name": "cl_cvdverify"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/clib.yaml
+++ b/benchmark-sets/all/clib.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "clib_package_install"
+- "name": "clib_package_install"
   "params":
   - "name": "pkg"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int clib_package_install(clib_package_t *, const char *, int)"
-- "exceptions": []
-  "name": "clib_package_install_dependencies"
+- "name": "clib_package_install_dependencies"
   "params":
   - "name": "pkg"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int clib_package_install_dependencies(clib_package_t *, const char *, int)"
-- "exceptions": []
-  "name": "clib_package_install_development"
+- "name": "clib_package_install_development"
   "params":
   - "name": "pkg"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int clib_package_install_development(clib_package_t *, const char *, int)"
-- "exceptions": []
-  "name": "clib_package_install_executable"
+- "name": "clib_package_install_executable"
   "params":
   - "name": "pkg"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int clib_package_install_executable(clib_package_t *, const char *, int)"
-- "exceptions": []
-  "name": "clib_package_new_from_slug"
+- "name": "clib_package_new_from_slug"
   "params":
   - "name": "slug"
     "type": "bool "

--- a/benchmark-sets/all/cmake.yaml
+++ b/benchmark-sets/all/cmake.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "XML_ParserCreateNS"
+- "name": "XML_ParserCreateNS"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "char"
   "return_type": "void"
   "signature": "XML_Parser XML_ParserCreateNS(const XML_Char *, XML_Char)"
-- "exceptions": []
-  "name": "XmlInitUnknownEncoding"
+- "name": "XmlInitUnknownEncoding"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "ENCODING * XmlInitUnknownEncoding(void *, int *, CONVERTER, void *)"
-- "exceptions": []
-  "name": "XML_ExternalEntityParserCreate"
+- "name": "XML_ExternalEntityParserCreate"
   "params":
   - "name": ""
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "XML_Parser XML_ExternalEntityParserCreate(XML_Parser, const XML_Char *, const XML_Char *)"
-- "exceptions": []
-  "name": "XML_ParserReset"
+- "name": "XML_ParserReset"
   "params":
   - "name": ""
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "char"
   "signature": "XML_Bool XML_ParserReset(XML_Parser, const XML_Char *)"
-- "exceptions": []
-  "name": "XML_SetBase"
+- "name": "XML_SetBase"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/cmark.yaml
+++ b/benchmark-sets/all/cmark.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "cmark_node_check"
+- "name": "cmark_node_check"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cmark_node_check(cmark_node *, FILE *)"
-- "exceptions": []
-  "name": "cmark_node_replace"
+- "name": "cmark_node_replace"
   "params":
   - "name": ""
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cmark_node_replace(cmark_node *, cmark_node *)"
-- "exceptions": []
-  "name": "cmark_node_append_child"
+- "name": "cmark_node_append_child"
   "params":
   - "name": ""
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cmark_node_append_child(cmark_node *, cmark_node *)"
-- "exceptions": []
-  "name": "cmark_node_insert_after"
+- "name": "cmark_node_insert_after"
   "params":
   - "name": ""
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cmark_node_insert_after(cmark_node *, cmark_node *)"
-- "exceptions": []
-  "name": "cmark_node_prepend_child"
+- "name": "cmark_node_prepend_child"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/coturn.yaml
+++ b/benchmark-sets/all/coturn.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "stun_set_allocate_response_str"
+- "name": "stun_set_allocate_response_str"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -28,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int stun_set_allocate_response_str(uint8_t *, size_t *, stun_tid *, const ioa_addr *, const ioa_addr *, const ioa_addr *, uint32_t, uint32_t, int, const uint8_t *, uint64_t, char *)"
-- "exceptions": []
-  "name": "stun_set_binding_response"
+- "name": "stun_set_binding_response"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -43,8 +41,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int stun_set_binding_response(stun_buffer *, stun_tid *, const ioa_addr *, int, const uint8_t *)"
-- "exceptions": []
-  "name": "stun_set_channel_bind_request"
+- "name": "stun_set_channel_bind_request"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -54,8 +51,7 @@
     "type": "short"
   "return_type": "short"
   "signature": "uint16_t stun_set_channel_bind_request(stun_buffer *, const ioa_addr *, uint16_t)"
-- "exceptions": []
-  "name": "stun_set_allocate_response"
+- "name": "stun_set_allocate_response"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -81,8 +77,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int stun_set_allocate_response(stun_buffer *, stun_tid *, const ioa_addr *, const ioa_addr *, const ioa_addr *, uint32_t, uint32_t, int, const uint8_t *, uint64_t, char *)"
-- "exceptions": []
-  "name": "stun_set_binding_response_str"
+- "name": "stun_set_binding_response_str"
   "params":
   - "name": "buf"
     "type": "bool "

--- a/benchmark-sets/all/cpp-httplib.yaml
+++ b/benchmark-sets/all/cpp-httplib.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZN7httplib6Server7routingERNS_7RequestERNS_8ResponseERNS_6StreamEENKUlNSt3__18functionIFbPKcmEEEE_clESC_"
+- "name": "_ZZN7httplib6Server7routingERNS_7RequestERNS_8ResponseERNS_6StreamEENKUlNSt3__18functionIFbPKcmEEEE_clESC_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool httplib::Server::operator()(const void *, ContentReceiver)"
-- "exceptions": []
-  "name": "_ZZN7httplib6detail21process_server_socketIZNS_6Server24process_and_close_socketEiEUlRNS_6StreamEbRbE_EEbRKNSt3__16atomicIiEEimlllllT_ENKUlbS5_E_clEbS5_"
+- "name": "_ZZN7httplib6detail21process_server_socketIZNS_6Server24process_and_close_socketEiEUlRNS_6StreamEbRbE_EEbRKNSt3__16atomicIiEEimlllllT_ENKUlbS5_E_clEbS5_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool httplib::detail::process_server_socket<httplib::Server::operator()(const void *, bool, bool &)"
-- "exceptions": []
-  "name": "_ZN7httplib6Server24process_and_close_socketEi"
+- "name": "_ZN7httplib6Server24process_and_close_socketEi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool httplib::Server::process_and_close_socket(socket_t)"
-- "exceptions": []
-  "name": "_ZZN7httplib6Server7routingERNS_7RequestERNS_8ResponseERNS_6StreamEENKUlNSt3__18functionIFbRKNS_17MultipartFormDataEEEENS8_IFbPKcmEEEE_clESD_SH_"
+- "name": "_ZZN7httplib6Server7routingERNS_7RequestERNS_8ResponseERNS_6StreamEENKUlNSt3__18functionIFbRKNS_17MultipartFormDataEEEENS8_IFbPKcmEEEE_clESD_SH_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool httplib::Server::operator()(const void *, MultipartContentHeader, ContentReceiver)"
-- "exceptions": []
-  "name": "_ZZN7httplib6Server24process_and_close_socketEiENKUlRNS_6StreamEbRbE_clES2_bS3_"
+- "name": "_ZZN7httplib6Server24process_and_close_socketEiENKUlRNS_6StreamEbRbE_clES2_bS3_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/cppcheck.yaml
+++ b/benchmark-sets/all/cppcheck.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_Z16getProgramMemoryPK5TokenS1_RKN9ValueFlow5ValueERK8Settings"
+- "name": "_Z16getProgramMemoryPK5TokenS1_RKN9ValueFlow5ValueERK8Settings"
   "params":
   - "name": "tok"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct ProgramMemory getProgramMemory(const Token *, const Token *, const Value &, const Settings &)"
-- "exceptions": []
-  "name": "_ZN8CppCheck5checkERK15FileWithDetails"
+- "name": "_ZN8CppCheck5checkERK15FileWithDetails"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "unsigned int CppCheck::check(const FileWithDetails &)"
-- "exceptions": []
-  "name": "_ZN10CheckOther9runChecksERK9TokenizerP11ErrorLogger"
+- "name": "_ZN10CheckOther9runChecksERK9TokenizerP11ErrorLogger"
   "params":
   - "name": "this"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void CheckOther::runChecks(const Tokenizer &, ErrorLogger *)"
-- "exceptions": []
-  "name": "_ZN8CppCheck5checkERK12FileSettings"
+- "name": "_ZN8CppCheck5checkERK12FileSettings"
   "params":
   - "name": "this"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "unsigned int CppCheck::check(const struct FileSettings &)"
-- "exceptions": []
-  "name": "_ZN8CppCheck10checkClangERK15FileWithDetails"
+- "name": "_ZN8CppCheck10checkClangERK15FileWithDetails"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/cpuinfo.yaml
+++ b/benchmark-sets/all/cpuinfo.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "cpuinfo_linux_get_processor_cur_frequency"
+- "name": "cpuinfo_linux_get_processor_cur_frequency"
   "params":
   - "name": "processor"
     "type": "int"
   "return_type": "int"
   "signature": "uint32_t cpuinfo_linux_get_processor_cur_frequency(uint32_t)"
-- "exceptions": []
-  "name": "cpuinfo_linux_get_processor_max_frequency"
+- "name": "cpuinfo_linux_get_processor_max_frequency"
   "params":
   - "name": "processor"
     "type": "int"
   "return_type": "int"
   "signature": "uint32_t cpuinfo_linux_get_processor_max_frequency(uint32_t)"
-- "exceptions": []
-  "name": "cpuinfo_linux_get_processor_package_id"
+- "name": "cpuinfo_linux_get_processor_package_id"
   "params":
   - "name": "processor"
     "type": "int"
@@ -22,15 +19,13 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool cpuinfo_linux_get_processor_package_id(uint32_t, DW_TAG_restrict_typeuint32_t *)"
-- "exceptions": []
-  "name": "cpuinfo_linux_get_processor_min_frequency"
+- "name": "cpuinfo_linux_get_processor_min_frequency"
   "params":
   - "name": "processor"
     "type": "int"
   "return_type": "int"
   "signature": "uint32_t cpuinfo_linux_get_processor_min_frequency(uint32_t)"
-- "exceptions": []
-  "name": "cpuinfo_linux_get_processor_core_id"
+- "name": "cpuinfo_linux_get_processor_core_id"
   "params":
   - "name": "processor"
     "type": "int"

--- a/benchmark-sets/all/croaring.yaml
+++ b/benchmark-sets/all/croaring.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "roaring_bitmap_or_many"
+- "name": "roaring_bitmap_or_many"
   "params":
   - "name": ""
     "type": "size_t"
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "roaring_bitmap_t * roaring_bitmap_or_many(size_t, const roaring_bitmap_t **)"
-- "exceptions": []
-  "name": "roaring_bitmap_lazy_xor_inplace"
+- "name": "roaring_bitmap_lazy_xor_inplace"
   "params":
   - "name": ""
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *, const roaring_bitmap_t *)"
-- "exceptions": []
-  "name": "roaring_bitmap_add_offset"
+- "name": "roaring_bitmap_add_offset"
   "params":
   - "name": ""
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "roaring_bitmap_t * roaring_bitmap_add_offset(const roaring_bitmap_t *, int64_t)"
-- "exceptions": []
-  "name": "roaring_bitmap_xor_many"
+- "name": "roaring_bitmap_xor_many"
   "params":
   - "name": ""
     "type": "size_t"
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "roaring_bitmap_t * roaring_bitmap_xor_many(size_t, const roaring_bitmap_t **)"
-- "exceptions": []
-  "name": "roaring_bitmap_lazy_or"
+- "name": "roaring_bitmap_lazy_or"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/crow.yaml
+++ b/benchmark-sets/all/crow.yaml
@@ -1,34 +1,29 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4crow10HTTPParserINS_10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEEEE11process_urlEv"
+- "name": "_ZN4crow10HTTPParserINS_10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEEEE11process_urlEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void crow::HTTPParser<crow::Connection<crow::SocketAdaptor, crow::Crow<>> >::process_url(struct HTTPParser<crow::Connection<crow::SocketAdaptor, crow::Crow<> > > *)"
-- "exceptions": []
-  "name": "_ZN4crow10HTTPParserINS_10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEEEE15process_messageEv"
+- "name": "_ZN4crow10HTTPParserINS_10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEEEE15process_messageEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void crow::HTTPParser<crow::Connection<crow::SocketAdaptor, crow::Crow<>> >::process_message(struct HTTPParser<crow::Connection<crow::SocketAdaptor, crow::Crow<> > > *)"
-- "exceptions": []
-  "name": "_ZN4crow10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEE6handleEv"
+- "name": "_ZN4crow10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEE6handleEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void crow::Connection<crow::SocketAdaptor, crow::Crow<>>::handle(Connection<crow::SocketAdaptor, crow::Crow<> > *)"
-- "exceptions": []
-  "name": "_ZN4crow4CrowIJEE3runEv"
+- "name": "_ZN4crow4CrowIJEE3runEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void crow::Crow<>::run()"
-- "exceptions": []
-  "name": "_ZN4crow10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEE10handle_urlEv"
+- "name": "_ZN4crow10ConnectionINS_13SocketAdaptorENS_4CrowIJEEEJEE10handle_urlEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/cxxopts.yaml
+++ b/benchmark-sets/all/cxxopts.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7cxxopts10exceptions9exceptionD0Ev"
+- "name": "_ZN7cxxopts10exceptions9exceptionD0Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void cxxopts::exceptions::exception::~~exception()"
-- "exceptions": []
-  "name": "_ZN7cxxopts11OptionAdderclERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_RKNS1_10shared_ptrIKNS_5ValueEEES7_"
+- "name": "_ZN7cxxopts11OptionAdderclERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_RKNS1_10shared_ptrIKNS_5ValueEEES7_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "OptionAdder & cxxopts::OptionAdder::operator()(const string &, const string &, const shared_ptr<const cxxopts::Value> &, string)"
-- "exceptions": []
-  "name": "_ZNK7cxxopts10exceptions9exception4whatEv"
+- "name": "_ZNK7cxxopts10exceptions9exception4whatEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/dbus-broker.yaml
+++ b/benchmark-sets/all/dbus-broker.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "log_appendf"
+- "name": "log_appendf"
   "params":
   - "name": "log"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void log_appendf(Log *, const char *, void)"
-- "exceptions": []
-  "name": "log_append_common"
+- "name": "log_append_common"
   "params":
   - "name": "log"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void log_append_common(Log *, int, int, const char *, const char *, int, const char *)"
-- "exceptions": []
-  "name": "log_vcommitf"
+- "name": "log_vcommitf"
   "params":
   - "name": "log"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int log_vcommitf(Log *, const char *, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "log_appends"
+- "name": "log_appends"
   "params":
   - "name": "log"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void log_appends(Log *, const char *)"
-- "exceptions": []
-  "name": "message_log_append"
+- "name": "message_log_append"
   "params":
   - "name": "message"
     "type": "bool "

--- a/benchmark-sets/all/dng_sdk.yaml
+++ b/benchmark-sets/all/dng_sdk.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN21dng_ref_counted_blockaSERKS_"
+- "name": "_ZN21dng_ref_counted_blockaSERKS_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "dng_ref_counted_block & dng_ref_counted_block::operator=(const dng_ref_counted_block &)"
-- "exceptions": []
-  "name": "_Z14SafeUint32MultjjjPj"
+- "name": "_Z14SafeUint32MultjjjPj"
   "params":
   - "name": "arg1"
     "type": "int"
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool SafeUint32Mult(uint32_t, uint32_t, uint32_t, uint32_t *)"
-- "exceptions": []
-  "name": "_Z12SafeInt32AddiiPi"
+- "name": "_Z12SafeInt32AddiiPi"
   "params":
   - "name": "arg1"
     "type": "int"
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool SafeInt32Add(int32_t, int32_t, int32_t *)"
-- "exceptions": []
-  "name": "_Z14SafeUint32MultjjjjPj"
+- "name": "_Z14SafeUint32MultjjjjPj"
   "params":
   - "name": "arg1"
     "type": "int"
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool SafeUint32Mult(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t *)"
-- "exceptions": []
-  "name": "_ZN15dng_hue_sat_mapaSERKS_"
+- "name": "_ZN15dng_hue_sat_mapaSERKS_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/double-conversion.yaml
+++ b/benchmark-sets/all/double-conversion.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK17double_conversion23StringToDoubleConverter13StringToFloatEPKciPi"
+- "name": "_ZNK17double_conversion23StringToDoubleConverter13StringToFloatEPKciPi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "float"
   "signature": "float double_conversion::StringToDoubleConverter::StringToFloat(const char *, int, int *)"
-- "exceptions": []
-  "name": "_ZNK17double_conversion23StringToDoubleConverter13StringToFloatEPKtiPi"
+- "name": "_ZNK17double_conversion23StringToDoubleConverter13StringToFloatEPKtiPi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "float"
   "signature": "float double_conversion::StringToDoubleConverter::StringToFloat(const uc16 *, int, int *)"
-- "exceptions": []
-  "name": "_ZNK17double_conversion23StringToDoubleConverter14StringToDoubleEPKtiPi"
+- "name": "_ZNK17double_conversion23StringToDoubleConverter14StringToDoubleEPKtiPi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "double"
   "signature": "double double_conversion::StringToDoubleConverter::StringToDouble(const uc16 *, int, int *)"
-- "exceptions": []
-  "name": "_ZN17double_conversion6StrtodENS_6VectorIKcEEi"
+- "name": "_ZN17double_conversion6StrtodENS_6VectorIKcEEi"
   "params":
   - "name": "buffer"
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "int"
   "return_type": "double"
   "signature": "double double_conversion::Strtod(Vector<const char>, int)"
-- "exceptions": []
-  "name": "_ZN17double_conversion6StrtofENS_6VectorIKcEEi"
+- "name": "_ZN17double_conversion6StrtofENS_6VectorIKcEEi"
   "params":
   - "name": "buffer"
     "type": "bool "

--- a/benchmark-sets/all/draco.yaml
+++ b/benchmark-sets/all/draco.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN5draco14PointAttribute17DeduplicateValuesERKNS_17GeometryAttributeENS_9IndexTypeIjNS_29AttributeValueIndex_tag_type_EEE"
+- "name": "_ZN5draco14PointAttribute17DeduplicateValuesERKNS_17GeometryAttributeENS_9IndexTypeIjNS_29AttributeValueIndex_tag_type_EEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "ValueType draco::PointAttribute::DeduplicateValues(const GeometryAttribute &, AttributeValueIndex)"
-- "exceptions": []
-  "name": "_ZN5draco11CornerTable4InitERKNS_15IndexTypeVectorINS_9IndexTypeIjNS_19FaceIndex_tag_type_EEENSt3__15arrayINS2_IjNS_21VertexIndex_tag_type_EEELm3EEEEE"
+- "name": "_ZN5draco11CornerTable4InitERKNS_15IndexTypeVectorINS_9IndexTypeIjNS_19FaceIndex_tag_type_EEENSt3__15arrayINS2_IjNS_21VertexIndex_tag_type_EEELm3EEEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,15 +17,13 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool draco::CornerTable::Init(const IndexTypeVector<draco::IndexType<unsigned int, draco::FaceIndex_tag_type_>, std::__1::array<draco::IndexType<unsigned int, draco::VertexIndex_tag_type_>, 3UL> > &)"
-- "exceptions": []
-  "name": "_ZN5draco10PointCloud26DeduplicateAttributeValuesEv"
+- "name": "_ZN5draco10PointCloud26DeduplicateAttributeValuesEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "bool"
   "signature": "bool draco::PointCloud::DeduplicateAttributeValues()"
-- "exceptions": []
-  "name": "_ZN5draco14PointAttribute17DeduplicateValuesERKNS_17GeometryAttributeE"
+- "name": "_ZN5draco14PointAttribute17DeduplicateValuesERKNS_17GeometryAttributeE"
   "params":
   - "name": ""
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "ValueType draco::PointAttribute::DeduplicateValues(const GeometryAttribute &)"
-- "exceptions": []
-  "name": "_ZN5draco11CornerTable6CreateERKNS_15IndexTypeVectorINS_9IndexTypeIjNS_19FaceIndex_tag_type_EEENSt3__15arrayINS2_IjNS_21VertexIndex_tag_type_EEELm3EEEEE"
+- "name": "_ZN5draco11CornerTable6CreateERKNS_15IndexTypeVectorINS_9IndexTypeIjNS_19FaceIndex_tag_type_EEENSt3__15arrayINS2_IjNS_21VertexIndex_tag_type_EEELm3EEEEE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/dropbear.yaml
+++ b/benchmark-sets/all/dropbear.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mp_lcm"
+- "name": "mp_lcm"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "mp_err mp_lcm(const mp_int *, const mp_int *, mp_int *)"
-- "exceptions": []
-  "name": "ltc_ecc_projective_add_point"
+- "name": "ltc_ecc_projective_add_point"
   "params":
   - "name": "P"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ltc_ecc_projective_add_point(ecc_point *, ecc_point *, ecc_point *, void *, void *)"
-- "exceptions": []
-  "name": "mp_prime_next_prime"
+- "name": "mp_prime_next_prime"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/duckdb.yaml
+++ b/benchmark-sets/all/duckdb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6duckdb13TableRelation6DeleteERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE"
+- "name": "_ZN6duckdb13TableRelation6DeleteERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void duckdb::TableRelation::Delete(const string &)"
-- "exceptions": []
-  "name": "_ZN6duckdb8Relation4HeadEm"
+- "name": "_ZN6duckdb8Relation4HeadEm"
   "params":
   - "name": ""
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void duckdb::Relation::Head(idx_t)"
-- "exceptions": []
-  "name": "_ZZN6duckdb13ClientContext11VerifyQueryERNS_17ClientContextLockERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS_10unique_ptrINS_12SQLStatementENS3_14default_deleteISD_EELb1EEEENK3$_0clESB_SG_"
+- "name": "_ZZN6duckdb13ClientContext11VerifyQueryERNS_17ClientContextLockERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS_10unique_ptrINS_12SQLStatementENS3_14default_deleteISD_EELb1EEEENK3$_0clESB_SG_"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/e2fsprogs.yaml
+++ b/benchmark-sets/all/e2fsprogs.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ext2fs_symlink"
+- "name": "ext2fs_symlink"
   "params":
   - "name": "fs"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "errcode_t ext2fs_symlink(ext2_filsys, ext2_ino_t, ext2_ino_t, const char *, const char *)"
-- "exceptions": []
-  "name": "ext2fs_dir_iterate"
+- "name": "ext2fs_dir_iterate"
   "params":
   - "name": "fs"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "errcode_t ext2fs_dir_iterate(ext2_filsys, ext2_ino_t, int, char *, DW_TAG_subroutine_typeInfinite loop *, void *)"
-- "exceptions": []
-  "name": "ext2fs_link"
+- "name": "ext2fs_link"
   "params":
   - "name": "fs"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "errcode_t ext2fs_link(ext2_filsys, ext2_ino_t, const char *, ext2_ino_t, int)"
-- "exceptions": []
-  "name": "ext2fs_lookup"
+- "name": "ext2fs_lookup"
   "params":
   - "name": "fs"
     "type": "bool "
@@ -63,8 +59,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "errcode_t ext2fs_lookup(ext2_filsys, ext2_ino_t, const char *, int, char *, ext2_ino_t *)"
-- "exceptions": []
-  "name": "ext2fs_dir_iterate2"
+- "name": "ext2fs_dir_iterate2"
   "params":
   - "name": "fs"
     "type": "bool "

--- a/benchmark-sets/all/easywsclient.yaml
+++ b/benchmark-sets/all/easywsclient.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZN12_GLOBAL__N_114_RealWebSocket9_dispatchERN12easywsclient12Callback_ImpEEN15CallbackAdapterclERKNSt3__16vectorIhNS5_9allocatorIhEEEE"
+- "name": "_ZZN12_GLOBAL__N_114_RealWebSocket9_dispatchERN12easywsclient12Callback_ImpEEN15CallbackAdapterclERKNSt3__16vectorIhNS5_9allocatorIhEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void (anonymous namespace)::_RealWebSocket::operator()(struct CallbackAdapter *, const vector<unsigned char, std::__1::allocator<unsigned char> > &)"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_115_DummyWebSocket9_dispatchERN12easywsclient12Callback_ImpE"
+- "name": "_ZN12_GLOBAL__N_115_DummyWebSocket9_dispatchERN12easywsclient12Callback_ImpE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void (anonymous namespace)::_DummyWebSocket::_dispatch(struct Callback_Imp &)"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_114_RealWebSocket9_dispatchERN12easywsclient12Callback_ImpE"
+- "name": "_ZN12_GLOBAL__N_114_RealWebSocket9_dispatchERN12easywsclient12Callback_ImpE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/eigen.yaml
+++ b/benchmark-sets/all/eigen.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixINSt3__17complexIdEELin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
+- "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixINSt3__17complexIdEELin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void Eigen::Transpose<Eigen::Block<Eigen::Matrix<std::__1::complex<double>, -1, -1, 0, -1, -1>, -1, 1, true> >::resize(Transpose<Eigen::Matrix<int, -1, -1, 0, -1, -1> > *, Index, Index)"
-- "exceptions": []
-  "name": "_ZN5Eigen9DenseBaseINS_5BlockINS_6MatrixIeLin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
+- "name": "_ZN5Eigen9DenseBaseINS_5BlockINS_6MatrixIeLin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void Eigen::DenseBase<Eigen::Block<Eigen::Matrix<long double, -1, -1, 0, -1, -1>, -1, 1, true> >::resize(DenseBase<Eigen::Solve<Eigen::TriangularView<Eigen::Transpose<Eigen::Matrix<int, -1, -1, 0, -1, -1> >, 2U>, Eigen::Matrix<int, -1, 1, 0, -1, 1> > > *, Index, Index)"
-- "exceptions": []
-  "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixINSt3__17complexIfEELin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
+- "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixINSt3__17complexIfEELin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void Eigen::Transpose<Eigen::Block<Eigen::Matrix<std::__1::complex<float>, -1, -1, 0, -1, -1>, -1, 1, true> >::resize(Transpose<Eigen::Matrix<int, -1, -1, 0, -1, -1> > *, Index, Index)"
-- "exceptions": []
-  "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixIiLin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
+- "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixIiLin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
   "params":
   - "name": "this"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void Eigen::Transpose<Eigen::Block<Eigen::Matrix<int, -1, -1, 0, -1, -1>, -1, 1, true> >::resize(Transpose<Eigen::Matrix<int, -1, -1, 0, -1, -1> > *, Index, Index)"
-- "exceptions": []
-  "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixIeLin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
+- "name": "_ZN5Eigen9TransposeINS_5BlockINS_6MatrixIeLin1ELin1ELi0ELin1ELin1EEELin1ELi1ELb1EEEE6resizeEll"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/exiv2.yaml
+++ b/benchmark-sets/all/exiv2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK8TXMPMetaINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE17SerializeToBufferEPS6_jj"
+- "name": "_ZNK8TXMPMetaINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE17SerializeToBufferEPS6_jj"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::SerializeToBuffer(const TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > *, basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > *, XMP_OptionBits, XMP_StringLen)"
-- "exceptions": []
-  "name": "_ZNK8TXMPMetaINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE17SerializeToBufferEPS6_jjPKcSA_i"
+- "name": "_ZNK8TXMPMetaINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE17SerializeToBufferEPS6_jjPKcSA_i"
   "params":
   - "name": ""
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::SerializeToBuffer(const TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > *, basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > *, XMP_OptionBits, XMP_StringLen, XMP_StringPtr, XMP_StringPtr, XMP_Index)"
-- "exceptions": []
-  "name": "_ZN9TXMPUtilsINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE18CatenateArrayItemsERK8TXMPMetaIS6_EPKcSD_SD_SD_jPS6_"
+- "name": "_ZN9TXMPUtilsINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE18CatenateArrayItemsERK8TXMPMetaIS6_EPKcSD_SD_SD_jPS6_"
   "params":
   - "name": ""
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void TXMPUtils<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::CatenateArrayItems(const TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > &, XMP_StringPtr, XMP_StringPtr, XMP_StringPtr, XMP_StringPtr, XMP_OptionBits, basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > *)"
-- "exceptions": []
-  "name": "_ZN8TXMPMetaINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE15ParseFromBufferEPKcjj"
+- "name": "_ZN8TXMPMetaINSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEE15ParseFromBufferEPKcjj"
   "params":
   - "name": ""
     "type": "bool "
@@ -63,8 +59,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::ParseFromBuffer(TXMPMeta<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > *, XMP_StringPtr, XMP_StringLen, XMP_OptionBits)"
-- "exceptions": []
-  "name": "_ZNK12_GLOBAL__N_113TiffThumbnail4copyERKN5Exiv28ExifDataE"
+- "name": "_ZNK12_GLOBAL__N_113TiffThumbnail4copyERKN5Exiv28ExifDataE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/expat.yaml
+++ b/benchmark-sets/all/expat.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "XmlParseXmlDeclNS"
+- "name": "XmlParseXmlDeclNS"
   "params":
   - "name": "isGeneralTextEntity"
     "type": "int"
@@ -24,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int XmlParseXmlDecl(int, const ENCODING *, const char *, const char *, const char **, const char **, const char **, const char **, const ENCODING **, int *)"
-- "exceptions": []
-  "name": "XmlInitUnknownEncoding"
+- "name": "XmlInitUnknownEncoding"
   "params":
   - "name": "mem"
     "type": "bool "
@@ -37,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "ENCODING * XmlInitUnknownEncoding(void *, int *, CONVERTER, void *)"
-- "exceptions": []
-  "name": "XmlInitUnknownEncodingNS"
+- "name": "XmlInitUnknownEncodingNS"
   "params":
   - "name": "mem"
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "ENCODING * XmlInitUnknownEncodingNS(void *, int *, CONVERTER, void *)"
-- "exceptions": []
-  "name": "XML_SetBase"
+- "name": "XML_SetBase"
   "params":
   - "name": "parser"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeXML_Status XML_SetBase(XML_Parser, const XML_Char *)"
-- "exceptions": []
-  "name": "XML_ResumeParser"
+- "name": "XML_ResumeParser"
   "params":
   - "name": "parser"
     "type": "bool "

--- a/benchmark-sets/all/exprtk.yaml
+++ b/benchmark-sets/all/exprtk.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6exprtk6parserIfE20expression_generatorIfEclERKNS_7details13operator_typeERA4_PNS4_15expression_nodeIfEE"
+- "name": "_ZN6exprtk6parserIfE20expression_generatorIfEclERKNS_7details13operator_typeERA4_PNS4_15expression_nodeIfEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "expression_node_ptr exprtk::parser<float>::expression_generator<float>::operator()(expression_generator<double> *, const DW_TAG_enumeration_typeoperator_type &, DW_TAG_array_typeexpression_node_ptr &)"
-- "exceptions": []
-  "name": "_ZN6exprtk7details14vec_data_storeIfEaSERKS2_"
+- "name": "_ZN6exprtk7details14vec_data_storeIfEaSERKS2_"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "type & exprtk::details::vec_data_store<float>::operator=(vec_data_store<double> *, const type &)"
-- "exceptions": []
-  "name": "_ZN6exprtk6parserIdE20expression_generatorIdEclERKNS_7details13operator_typeERA4_PNS4_15expression_nodeIdEE"
+- "name": "_ZN6exprtk6parserIdE20expression_generatorIdEclERKNS_7details13operator_typeERA4_PNS4_15expression_nodeIdEE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/fftw3.yaml
+++ b/benchmark-sets/all/fftw3.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "search"
+- "name": "search"
   "params":
   - "name": "ego"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "plan * search(planner *, const problem *, unsigned int *, flags_t *)"
-- "exceptions": []
-  "name": "elapsed"
+- "name": "elapsed"
   "params":
   - "name": "t1"
     "type": "size_t"

--- a/benchmark-sets/all/file.yaml
+++ b/benchmark-sets/all/file.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "magic_list"
+- "name": "magic_list"
   "params":
   - "name": "ms"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int magic_list(struct magic_set *, const char *)"
-- "exceptions": []
-  "name": "magic_load_buffers"
+- "name": "magic_load_buffers"
   "params":
   - "name": "ms"
     "type": "bool "
@@ -21,22 +19,19 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int magic_load_buffers(struct magic_set *, void **, size_t *, size_t)"
-- "exceptions": []
-  "name": "cdf_tole4"
+- "name": "cdf_tole4"
   "params":
   - "name": "sv"
     "type": "int"
   "return_type": "int"
   "signature": "uint32_t cdf_tole4(uint32_t)"
-- "exceptions": []
-  "name": "cdf_tole8"
+- "name": "cdf_tole8"
   "params":
   - "name": "sv"
     "type": "size_t"
   "return_type": "size_t"
   "signature": "uint64_t cdf_tole8(uint64_t)"
-- "exceptions": []
-  "name": "buffer_apprentice"
+- "name": "buffer_apprentice"
   "params":
   - "name": "ms"
     "type": "bool "

--- a/benchmark-sets/all/firestore.yaml
+++ b/benchmark-sets/all/firestore.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK8firebase9firestore4core7OrderBy7CompareERKNS0_5model8DocumentES6_"
+- "name": "_ZNK8firebase9firestore4core7OrderBy7CompareERKNS0_5model8DocumentES6_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeComparisonResult firebase::firestore::core::OrderBy::Compare(const Document &, const Document &)"
-- "exceptions": []
-  "name": "_ZNK8firebase9firestore4core5Bound18SortsAfterDocumentERKNSt3__16vectorINS1_7OrderByENS3_9allocatorIS5_EEEERKNS0_5model8DocumentE"
+- "name": "_ZNK8firebase9firestore4core5Bound18SortsAfterDocumentERKNSt3__16vectorINS1_7OrderByENS3_9allocatorIS5_EEEERKNS0_5model8DocumentE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool firebase::firestore::core::Bound::SortsAfterDocument(const vector<firebase::firestore::core::OrderBy, std::__1::allocator<firebase::firestore::core::OrderBy> > &, const Document &)"
-- "exceptions": []
-  "name": "_ZNK8firebase9firestore4core5Bound17CompareToDocumentERKNSt3__16vectorINS1_7OrderByENS3_9allocatorIS5_EEEERKNS0_5model8DocumentE"
+- "name": "_ZNK8firebase9firestore4core5Bound17CompareToDocumentERKNSt3__16vectorINS1_7OrderByENS3_9allocatorIS5_EEEERKNS0_5model8DocumentE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeComparisonResult firebase::firestore::core::Bound::CompareToDocument(const vector<firebase::firestore::core::OrderBy, std::__1::allocator<firebase::firestore::core::OrderBy> > &, const Document &)"
-- "exceptions": []
-  "name": "_ZNK8firebase9firestore4core5Bound19SortsBeforeDocumentERKNSt3__16vectorINS1_7OrderByENS3_9allocatorIS5_EEEERKNS0_5model8DocumentE"
+- "name": "_ZNK8firebase9firestore4core5Bound19SortsBeforeDocumentERKNSt3__16vectorINS1_7OrderByENS3_9allocatorIS5_EEEERKNS0_5model8DocumentE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool firebase::firestore::core::Bound::SortsBeforeDocument(const vector<firebase::firestore::core::OrderBy, std::__1::allocator<firebase::firestore::core::OrderBy> > &, const Document &)"
-- "exceptions": []
-  "name": "_ZNK8firebase9firestore4core5Query13MatchesBoundsERKNS0_5model8DocumentE"
+- "name": "_ZNK8firebase9firestore4core5Query13MatchesBoundsERKNS0_5model8DocumentE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/flac.yaml
+++ b/benchmark-sets/all/flac.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4FLAC7Decoder4File8init_oggEPKc"
+- "name": "_ZN4FLAC7Decoder4File8init_oggEPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "FLAC__StreamDecoderInitStatus FLAC::Decoder::File::init_ogg(const char *)"
-- "exceptions": []
-  "name": "_ZN4FLAC7Decoder12FuzzerStream17metadata_callbackEPK20FLAC__StreamMetadata"
+- "name": "_ZN4FLAC7Decoder12FuzzerStream17metadata_callbackEPK20FLAC__StreamMetadata"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void FLAC::Decoder::FuzzerStream::metadata_callback(const FLAC__StreamMetadata *)"
-- "exceptions": []
-  "name": "_ZN4FLAC7Decoder4File4initEPKc"
+- "name": "_ZN4FLAC7Decoder4File4initEPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "FLAC__StreamDecoderInitStatus FLAC::Decoder::File::init(const char *)"
-- "exceptions": []
-  "name": "_ZN4FLAC7Encoder4File8init_oggEPKc"
+- "name": "_ZN4FLAC7Encoder4File8init_oggEPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "FLAC__StreamEncoderInitStatus FLAC::Encoder::File::init_ogg(const char *)"
-- "exceptions": []
-  "name": "_ZN4FLAC7Encoder4File4initEPKc"
+- "name": "_ZN4FLAC7Encoder4File4initEPKc"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/flatbuffers.yaml
+++ b/benchmark-sets/all/flatbuffers.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN11flatbuffers11GenTextFileERKNS_6ParserERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESB_"
+- "name": "_ZN11flatbuffers11GenTextFileERKNS_6ParserERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESB_"
   "params":
   - "name": "parser"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * flatbuffers::GenTextFile(const Parser &, const string &, const string &)"
-- "exceptions": []
-  "name": "_ZN11flatbuffers16GenerateTextFileERKNS_6ParserERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESB_"
+- "name": "_ZN11flatbuffers16GenerateTextFileERKNS_6ParserERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESB_"
   "params":
   - "name": "parser"
     "type": "bool "
@@ -21,15 +19,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * flatbuffers::GenerateTextFile(const Parser &, const string &, const string &)"
-- "exceptions": []
-  "name": "_ZN11flatbuffers6Parser9SerializeEv"
+- "name": "_ZN11flatbuffers6Parser9SerializeEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void flatbuffers::Parser::Serialize()"
-- "exceptions": []
-  "name": "_ZN11flatbuffers12_GLOBAL__N_117TextCodeGenerator12GenerateCodeERKNS_6ParserERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEESD_"
+- "name": "_ZN11flatbuffers12_GLOBAL__N_117TextCodeGenerator12GenerateCodeERKNS_6ParserERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEESD_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeStatus flatbuffers::(anonymous namespace)::TextCodeGenerator::GenerateCode(const Parser &, const string &, const string &)"
-- "exceptions": []
-  "name": "_ZN11flatbuffers21GenerateTextFromTableERKNS_6ParserEPKvRKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEPSB_"
+- "name": "_ZN11flatbuffers21GenerateTextFromTableERKNS_6ParserEPKvRKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEPSB_"
   "params":
   - "name": "parser"
     "type": "bool "

--- a/benchmark-sets/all/fluent-bit.yaml
+++ b/benchmark-sets/all/fluent-bit.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "vivo_http_server_create"
+- "name": "vivo_http_server_create"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct vivo_http * vivo_http_server_create(struct vivo_exporter *, const char *, int, struct flb_config *)"
-- "exceptions": []
-  "name": "flb_config_load_config_format"
+- "name": "flb_config_load_config_format"
   "params":
   - "name": "config"
     "type": "bool "
@@ -21,22 +19,19 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int flb_config_load_config_format(struct flb_config *, struct flb_cf *)"
-- "exceptions": []
-  "name": "udp_conn_event"
+- "name": "udp_conn_event"
   "params":
   - "name": "data"
     "type": "bool "
   "return_type": "int"
   "signature": "int udp_conn_event(void *)"
-- "exceptions": []
-  "name": "flb_start_trace"
+- "name": "flb_start_trace"
   "params":
   - "name": "ctx"
     "type": "bool "
   "return_type": "int"
   "signature": "int flb_start_trace(flb_ctx_t *)"
-- "exceptions": []
-  "name": "in_metrics_init"
+- "name": "in_metrics_init"
   "params":
   - "name": "in"
     "type": "bool "

--- a/benchmark-sets/all/fmt.yaml
+++ b/benchmark-sets/all/fmt.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3fmt3v106vprintENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
+- "name": "_ZN3fmt3v106vprintENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
   "params":
   - "name": "fmt"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void fmt::v10::vprint(string_view, format_args)"
-- "exceptions": []
-  "name": "_ZN3fmt3v108vprintlnEP8_IO_FILENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
+- "name": "_ZN3fmt3v108vprintlnEP8_IO_FILENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
   "params":
   - "name": "f"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void fmt::v10::vprintln(FILE *, string_view, format_args)"
-- "exceptions": []
-  "name": "_ZN3fmt3v1015vprint_bufferedEP8_IO_FILENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
+- "name": "_ZN3fmt3v1015vprint_bufferedEP8_IO_FILENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
   "params":
   - "name": "f"
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void fmt::v10::vprint_buffered(FILE *, string_view, format_args)"
-- "exceptions": []
-  "name": "_ZN3fmt3v106vprintEP8_IO_FILENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
+- "name": "_ZN3fmt3v106vprintEP8_IO_FILENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_7contextEEE"
   "params":
   - "name": "f"
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void fmt::v10::vprint(FILE *, string_view, format_args)"
-- "exceptions": []
-  "name": "_ZN3fmt3v106detail5printEP8_IO_FILENS0_17basic_string_viewIcEE"
+- "name": "_ZN3fmt3v106detail5printEP8_IO_FILENS0_17basic_string_viewIcEE"
   "params":
   - "name": "f"
     "type": "bool "

--- a/benchmark-sets/all/freerdp.yaml
+++ b/benchmark-sets/all/freerdp.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "freerdp_connect"
+- "name": "freerdp_connect"
   "params":
   - "name": "instance"
     "type": "bool "
   "return_type": "int"
   "signature": "BOOL freerdp_connect(freerdp *)"
-- "exceptions": []
-  "name": "client_auto_reconnect_ex"
+- "name": "client_auto_reconnect_ex"
   "params":
   - "name": "instance"
     "type": "bool "
@@ -15,22 +13,19 @@
     "type": "bool "
   "return_type": "int"
   "signature": "BOOL client_auto_reconnect_ex(freerdp *, DW_TAG_subroutine_typeInfinite loop *)"
-- "exceptions": []
-  "name": "client_auto_reconnect"
+- "name": "client_auto_reconnect"
   "params":
   - "name": "instance"
     "type": "bool "
   "return_type": "int"
   "signature": "BOOL client_auto_reconnect(freerdp *)"
-- "exceptions": []
-  "name": "rdp_client_connect"
+- "name": "rdp_client_connect"
   "params":
   - "name": "rdp"
     "type": "bool "
   "return_type": "int"
   "signature": "BOOL rdp_client_connect(rdpRdp *)"
-- "exceptions": []
-  "name": "freerdp_check_event_handles"
+- "name": "freerdp_check_event_handles"
   "params":
   - "name": "context"
     "type": "bool "

--- a/benchmark-sets/all/fribidi.yaml
+++ b/benchmark-sets/all/fribidi.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "fribidi_get_bidi_type"
+- "name": "fribidi_get_bidi_type"
   "params":
   - "name": "ch"
     "type": "int"

--- a/benchmark-sets/all/geos.yaml
+++ b/benchmark-sets/all/geos.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "GEOSMakeValid_r"
+- "name": "GEOSMakeValid_r"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Geometry * GEOSMakeValid_r(GEOSContextHandle_t, const Geometry *)"
-- "exceptions": []
-  "name": "GEOSSingleSidedBuffer"
+- "name": "GEOSSingleSidedBuffer"
   "params":
   - "name": ""
     "type": "bool "
@@ -25,15 +23,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "Geometry * GEOSSingleSidedBuffer(const Geometry *, double, int, int, double, int)"
-- "exceptions": []
-  "name": "GEOSMakeValid"
+- "name": "GEOSMakeValid"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "Geometry * GEOSMakeValid(const Geometry *)"
-- "exceptions": []
-  "name": "GEOSMakeValidWithParams_r"
+- "name": "GEOSMakeValidWithParams_r"
   "params":
   - "name": ""
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Geometry * GEOSMakeValidWithParams_r(GEOSContextHandle_t, const Geometry *, const GEOSMakeValidParams *)"
-- "exceptions": []
-  "name": "GEOSMakeValidWithParams"
+- "name": "GEOSMakeValidWithParams"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/gfwx.yaml
+++ b/benchmark-sets/all/gfwx.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7fuzzing5types9ContainerIhLb0ELb0EE4copyEPKvm"
+- "name": "_ZN7fuzzing5types9ContainerIhLb0ELb0EE4copyEPKvm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,15 +9,13 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void fuzzing::types::Container<unsigned char, false, false>::copy(Container<char, true, false> *, const void *, size_t)"
-- "exceptions": []
-  "name": "_ZN7fuzzing5types9ContainerIcLb1ELb0EE4freeEv"
+- "name": "_ZN7fuzzing5types9ContainerIcLb1ELb0EE4freeEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void fuzzing::types::Container<char, true, false>::free()"
-- "exceptions": []
-  "name": "_ZN7fuzzing5types9ContainerIcLb1ELb0EE8allocateEm"
+- "name": "_ZN7fuzzing5types9ContainerIcLb1ELb0EE8allocateEm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void fuzzing::types::Container<char, true, false>::allocate(size_t)"
-- "exceptions": []
-  "name": "_ZN7fuzzing5types9ContainerIhLb0ELb0EE8allocateEm"
+- "name": "_ZN7fuzzing5types9ContainerIhLb0ELb0EE8allocateEm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void fuzzing::types::Container<unsigned char, false, false>::allocate(Container<char, true, false> *, size_t)"
-- "exceptions": []
-  "name": "_ZN7fuzzing5types9ContainerIhLb0ELb0EE4freeEv"
+- "name": "_ZN7fuzzing5types9ContainerIhLb0ELb0EE4freeEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/glslang.yaml
+++ b/benchmark-sets/all/glslang.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7glslang11HlslGrammar15acceptPostDeclsERNS_10TQualifierE"
+- "name": "_ZN7glslang11HlslGrammar15acceptPostDeclsERNS_10TQualifierE"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool glslang::HlslGrammar::acceptPostDecls(TQualifier &)"
-- "exceptions": []
-  "name": "_ZN7glslang16HlslParseContext18parseShaderStringsERNS_10TPpContextERNS_13TInputScannerEb"
+- "name": "_ZN7glslang16HlslParseContext18parseShaderStringsERNS_10TPpContextERNS_13TInputScannerEb"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool glslang::HlslParseContext::parseShaderStrings(TPpContext &, TInputScanner &, bool)"
-- "exceptions": []
-  "name": "_ZN7glslang11HlslGrammar17acceptTextureTypeERNS_5TTypeE"
+- "name": "_ZN7glslang11HlslGrammar17acceptTextureTypeERNS_5TTypeE"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool glslang::HlslGrammar::acceptTextureType(TType &)"
-- "exceptions": []
-  "name": "_ZN7glslang11HlslGrammar12acceptStructERNS_5TTypeERP11TIntermNode"
+- "name": "_ZN7glslang11HlslGrammar12acceptStructERNS_5TTypeERP11TIntermNode"
   "params":
   - "name": ""
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool glslang::HlslGrammar::acceptStruct(TType &, TIntermNode &*)"
-- "exceptions": []
-  "name": "_ZN7glslang11HlslGrammar17acceptDeclarationERP11TIntermNode"
+- "name": "_ZN7glslang11HlslGrammar17acceptDeclarationERP11TIntermNode"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/gnutls.yaml
+++ b/benchmark-sets/all/gnutls.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gnutls_record_recv_packet"
+- "name": "gnutls_record_recv_packet"
   "params":
   - "name": "session"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t gnutls_record_recv_packet(gnutls_session_t, gnutls_packet_t *)"
-- "exceptions": []
-  "name": "gnutls_bye"
+- "name": "gnutls_bye"
   "params":
   - "name": "session"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int gnutls_bye(gnutls_session_t, gnutls_close_request_t)"
-- "exceptions": []
-  "name": "gnutls_session_ticket_send"
+- "name": "gnutls_session_ticket_send"
   "params":
   - "name": "session"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int gnutls_session_ticket_send(gnutls_session_t, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "gnutls_certificate_verify_peers3"
+- "name": "gnutls_certificate_verify_peers3"
   "params":
   - "name": "session"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int gnutls_certificate_verify_peers3(gnutls_session_t, const char *, unsigned int *)"
-- "exceptions": []
-  "name": "gnutls_record_recv_seq"
+- "name": "gnutls_record_recv_seq"
   "params":
   - "name": "session"
     "type": "bool "

--- a/benchmark-sets/all/gpac.yaml
+++ b/benchmark-sets/all/gpac.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gf_sc_scene_update"
+- "name": "gf_sc_scene_update"
   "params":
   - "name": "compositor"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "GF_Err gf_sc_scene_update(GF_Compositor *, char *, char *)"
-- "exceptions": []
-  "name": "gf_sc_texture_update_frame"
+- "name": "gf_sc_texture_update_frame"
   "params":
   - "name": "txh"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void gf_sc_texture_update_frame(GF_TextureHandler *, Bool)"
-- "exceptions": []
-  "name": "visual_draw_frame"
+- "name": "visual_draw_frame"
   "params":
   - "name": "visual"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "Bool visual_draw_frame(GF_VisualManager *, GF_Node *, GF_TraverseState *, Bool)"
-- "exceptions": []
-  "name": "gf_sc_draw_frame"
+- "name": "gf_sc_draw_frame"
   "params":
   - "name": "compositor"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "Bool gf_sc_draw_frame(GF_Compositor *, Bool, s32 *)"
-- "exceptions": []
-  "name": "visual_2d_draw_frame"
+- "name": "visual_2d_draw_frame"
   "params":
   - "name": "visual"
     "type": "bool "

--- a/benchmark-sets/all/gpsd.yaml
+++ b/benchmark-sets/all/gpsd.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gpsd_multipoll"
+- "name": "gpsd_multipoll"
   "params":
   - "name": ""
     "type": "bool"
@@ -12,8 +11,7 @@
     "type": "float"
   "return_type": "int"
   "signature": "int gpsd_multipoll(const _Bool, struct gps_device_t *, DW_TAG_subroutine_typeInfinite loop *, float)"
-- "exceptions": []
-  "name": "sirf_parse"
+- "name": "sirf_parse"
   "params":
   - "name": ""
     "type": "bool "
@@ -23,15 +21,13 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "gps_mask_t sirf_parse(struct gps_device_t *, unsigned char *, size_t)"
-- "exceptions": []
-  "name": "gpsd_poll"
+- "name": "gpsd_poll"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "size_t"
   "signature": "gps_mask_t gpsd_poll(struct gps_device_t *)"
-- "exceptions": []
-  "name": "gps_mainloop"
+- "name": "gps_mainloop"
   "params":
   - "name": ""
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int gps_mainloop(struct gps_data_t *, int, DW_TAG_subroutine_typeInfinite loop *)"
-- "exceptions": []
-  "name": "gpsd_activate"
+- "name": "gpsd_activate"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/grok.yaml
+++ b/benchmark-sets/all/grok.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3grk20CodeStreamDecompress15decompressTilesEv"
+- "name": "_ZN3grk20CodeStreamDecompress15decompressTilesEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "bool"
   "signature": "bool grk::CodeStreamDecompress::decompressTiles()"
-- "exceptions": []
-  "name": "_ZZN3grk20CodeStreamDecompress14decompressTileEtENK3$_0clEv"
+- "name": "_ZZN3grk20CodeStreamDecompress14decompressTileEtENK3$_0clEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "bool"
   "signature": "bool grk::CodeStreamDecompress::operator()(const void *)"
-- "exceptions": []
-  "name": "_ZN3grk18CodeStreamCompress4initEP16_grk_cparametersPNS_8GrkImageE"
+- "name": "_ZN3grk18CodeStreamCompress4initEP16_grk_cparametersPNS_8GrkImageE"
   "params":
   - "name": ""
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool grk::CodeStreamCompress::init(grk_cparameters *, GrkImage *)"
-- "exceptions": []
-  "name": "_ZN3grk18CodeStreamCompress8compressEP16_grk_plugin_tile"
+- "name": "_ZN3grk18CodeStreamCompress8compressEP16_grk_plugin_tile"
   "params":
   - "name": ""
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "N/A ()"
-- "exceptions": []
-  "name": "_ZN3grk20CodeStreamDecompress14decompressTileEv"
+- "name": "_ZN3grk20CodeStreamDecompress14decompressTileEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/gss-ntlmssp.yaml
+++ b/benchmark-sets/all/gss-ntlmssp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gssntlm_init_sec_context"
+- "name": "gssntlm_init_sec_context"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -30,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "uint32_t gssntlm_init_sec_context(uint32_t *, gss_cred_id_t, gss_ctx_id_t *, gss_name_t, gss_OID, uint32_t, uint32_t, gss_channel_bindings_t, gss_buffer_t, gss_OID *, gss_buffer_t, uint32_t *, uint32_t *)"
-- "exceptions": []
-  "name": "gss_accept_sec_context"
+- "name": "gss_accept_sec_context"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -57,8 +55,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OM_uint32 gss_accept_sec_context(OM_uint32 *, gss_ctx_id_t *, gss_cred_id_t, gss_buffer_t, gss_channel_bindings_t, gss_name_t *, gss_OID *, gss_buffer_t, OM_uint32 *, OM_uint32 *, gss_cred_id_t *)"
-- "exceptions": []
-  "name": "gssntlm_cli_auth"
+- "name": "gssntlm_cli_auth"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -74,8 +71,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "uint32_t gssntlm_cli_auth(uint32_t *, struct gssntlm_ctx *, struct gssntlm_cred *, struct ntlm_buffer *, uint32_t, gss_channel_bindings_t)"
-- "exceptions": []
-  "name": "gss_inquire_cred_by_mech"
+- "name": "gss_inquire_cred_by_mech"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -93,8 +89,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OM_uint32 gss_inquire_cred_by_mech(OM_uint32 *, gss_cred_id_t, gss_OID, gss_name_t *, OM_uint32 *, OM_uint32 *, gss_cred_usage_t *)"
-- "exceptions": []
-  "name": "gss_init_sec_context"
+- "name": "gss_init_sec_context"
   "params":
   - "name": "minor_status"
     "type": "bool "

--- a/benchmark-sets/all/guetzli.yaml
+++ b/benchmark-sets/all/guetzli.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN11butteraugli18ButteraugliDiffmapERKNSt3__16vectorINS_5ImageIfEENS0_9allocatorIS3_EEEES8_RS3_"
+- "name": "_ZN11butteraugli18ButteraugliDiffmapERKNSt3__16vectorINS_5ImageIfEENS0_9allocatorIS3_EEEES8_RS3_"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void butteraugli::ButteraugliDiffmap(const vector<butteraugli::Image<float>, std::__1::allocator<butteraugli::Image<float> > > &, const vector<butteraugli::Image<float>, std::__1::allocator<butteraugli::Image<float> > > &, ImageF &)"
-- "exceptions": []
-  "name": "_ZN7guetzli7ProcessERKNS_6ParamsEPNS_12ProcessStatsERKNSt3__16vectorIhNS5_9allocatorIhEEEEiiPNS5_12basic_stringIcNS5_11char_traitsIcEENS7_IcEEEE"
+- "name": "_ZN7guetzli7ProcessERKNS_6ParamsEPNS_12ProcessStatsERKNSt3__16vectorIhNS5_9allocatorIhEEEEiiPNS5_12basic_stringIcNS5_11char_traitsIcEENS7_IcEEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool guetzli::Process(const struct Params &, struct ProcessStats *, const vector<unsigned char, std::__1::allocator<unsigned char> > &, int, int, string *)"
-- "exceptions": []
-  "name": "_ZN7guetzli27BuildSequentialHuffmanCodesERKNS_8JPEGDataEPNSt3__16vectorINS_16HuffmanCodeTableENS3_9allocatorIS5_EEEES9_"
+- "name": "_ZN7guetzli27BuildSequentialHuffmanCodesERKNS_8JPEGDataEPNSt3__16vectorINS_16HuffmanCodeTableENS3_9allocatorIS5_EEEES9_"
   "params":
   - "name": ""
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void guetzli::BuildSequentialHuffmanCodes(const struct JPEGData &, vector<guetzli::HuffmanCodeTable, std::__1::allocator<guetzli::HuffmanCodeTable> > *, vector<guetzli::HuffmanCodeTable, std::__1::allocator<guetzli::HuffmanCodeTable> > *)"
-- "exceptions": []
-  "name": "_ZNK11butteraugli21ButteraugliComparator4MaskEPNSt3__16vectorINS_5ImageIfEENS1_9allocatorIS4_EEEES8_"
+- "name": "_ZNK11butteraugli21ButteraugliComparator4MaskEPNSt3__16vectorINS_5ImageIfEENS1_9allocatorIS4_EEEES8_"
   "params":
   - "name": ""
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void butteraugli::ButteraugliComparator::Mask(DW_TAG_restrict_typevector<butteraugli::Image<float>, std::__1::allocator<butteraugli::Image<float> > > *, DW_TAG_restrict_typevector<butteraugli::Image<float>, std::__1::allocator<butteraugli::Image<float> > > *)"
-- "exceptions": []
-  "name": "_ZN11butteraugli20ButteraugliInterfaceERKNSt3__16vectorINS_5ImageIfEENS0_9allocatorIS3_EEEES8_RS3_Rd"
+- "name": "_ZN11butteraugli20ButteraugliInterfaceERKNSt3__16vectorINS_5ImageIfEENS0_9allocatorIS3_EEEES8_RS3_Rd"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/h2o.yaml
+++ b/benchmark-sets/all/h2o.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "BrotliEncoderCompress"
+- "name": "BrotliEncoderCompress"
   "params":
   - "name": ""
     "type": "int"
@@ -18,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int BrotliEncoderCompress(int, int, BrotliEncoderMode, size_t, const uint8_t *, size_t *, uint8_t *)"
-- "exceptions": []
-  "name": "BrotliEncoderCompressStream"
+- "name": "BrotliEncoderCompressStream"
   "params":
   - "name": ""
     "type": "bool "
@@ -37,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int BrotliEncoderCompressStream(BrotliEncoderState *, BrotliEncoderOperation, size_t *, const uint8_t **, size_t *, uint8_t **, size_t *)"
-- "exceptions": []
-  "name": "ptls_init_compressed_certificate"
+- "name": "ptls_init_compressed_certificate"
   "params":
   - "name": ""
     "type": "bool "
@@ -52,8 +49,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ptls_init_compressed_certificate(ptls_emit_compressed_certificate_t *, ptls_iovec_t *, size_t, ptls_iovec_t)"
-- "exceptions": []
-  "name": "h2o_send_redirect_internal"
+- "name": "h2o_send_redirect_internal"
   "params":
   - "name": ""
     "type": "bool "
@@ -69,8 +65,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void h2o_send_redirect_internal(h2o_req_t *, h2o_iovec_t, const char *, size_t, int)"
-- "exceptions": []
-  "name": "h2o_send_redirect"
+- "name": "h2o_send_redirect"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/h3.yaml
+++ b/benchmark-sets/all/h3.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "scaleBBox"
+- "name": "scaleBBox"
   "params":
   - "name": "bbox"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "double"
   "return_type": "void"
   "signature": "void scaleBBox(BBox *, double)"
-- "exceptions": []
-  "name": "iterStepRes"
+- "name": "iterStepRes"
   "params":
   - "name": "itR"
     "type": "bool "
   "return_type": "void"
   "signature": "void iterStepRes(IterCellsResolution *)"
-- "exceptions": []
-  "name": "iterInitBaseCellNum"
+- "name": "iterInitBaseCellNum"
   "params":
   - "name": "baseCellNum"
     "type": "int"
@@ -24,8 +21,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "IterCellsChildren iterInitBaseCellNum(int, int)"
-- "exceptions": []
-  "name": "bboxOverlapsBBox"
+- "name": "bboxOverlapsBBox"
   "params":
   - "name": "a"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool bboxOverlapsBBox(const BBox *, const BBox *)"
-- "exceptions": []
-  "name": "iterInitRes"
+- "name": "iterInitRes"
   "params":
   - "name": "res"
     "type": "bool "

--- a/benchmark-sets/all/haproxy.yaml
+++ b/benchmark-sets/all/haproxy.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "init"
+- "name": "init"
   "params":
   - "name": "argc"
     "type": "int"

--- a/benchmark-sets/all/harfbuzz.yaml
+++ b/benchmark-sets/all/harfbuzz.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZNK2OT21ChainContextFormat1_4INS_6Layout11MediumTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetIS2_EEE_clES9_"
+- "name": "_ZZNK2OT21ChainContextFormat1_4INS_6Layout11MediumTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetIS2_EEE_clES9_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void OT::ChainContextFormat1_4<OT::Layout::MediumTypes>::operator()(const void *, const ChainRuleSet &)"
-- "exceptions": []
-  "name": "_ZZ16hb_shape_justifyENK3$_0clEd"
+- "name": "_ZZ16hb_shape_justifyENK3$_0clEd"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "double"
   "return_type": "double"
   "signature": "double hb_shape_justify::$_0::operator()(const void *, double)"
-- "exceptions": []
-  "name": "_ZZNK2OT21ChainContextFormat1_4INS_6Layout10SmallTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetIS2_EEE_clES9_"
+- "name": "_ZZNK2OT21ChainContextFormat1_4INS_6Layout10SmallTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetIS2_EEE_clES9_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void OT::ChainContextFormat1_4<OT::Layout::SmallTypes>::operator()(const void *, const ChainRuleSet &)"
-- "exceptions": []
-  "name": "_ZZNK2OT21ChainContextFormat2_5INS_6Layout11MediumTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetINS1_10SmallTypesEEEE_clESA_"
+- "name": "_ZZNK2OT21ChainContextFormat2_5INS_6Layout11MediumTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetINS1_10SmallTypesEEEE_clESA_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void OT::ChainContextFormat2_5<OT::Layout::MediumTypes>::operator()(const void *, const ChainRuleSet &)"
-- "exceptions": []
-  "name": "_ZZNK2OT21ChainContextFormat2_5INS_6Layout10SmallTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetIS2_EEE_clES9_"
+- "name": "_ZZNK2OT21ChainContextFormat2_5INS_6Layout10SmallTypesEE14collect_glyphsEPNS_27hb_collect_glyphs_context_tEENKUlRKNS_12ChainRuleSetIS2_EEE_clES9_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/hdf5.yaml
+++ b/benchmark-sets/all/hdf5.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "H5D__get_space"
+- "name": "H5D__get_space"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "size_t"
   "signature": "hid_t H5D__get_space(const H5D_t *)"
-- "exceptions": []
-  "name": "H5D__write"
+- "name": "H5D__write"
   "params":
   - "name": ""
     "type": "size_t"
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "herr_t H5D__write(size_t, H5D_dset_io_info_t *)"
-- "exceptions": []
-  "name": "H5D__read"
+- "name": "H5D__read"
   "params":
   - "name": ""
     "type": "size_t"
@@ -24,15 +21,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "herr_t H5D__read(size_t, H5D_dset_io_info_t *)"
-- "exceptions": []
-  "name": "H5D__virtual_set_extent_unlim"
+- "name": "H5D__virtual_set_extent_unlim"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "herr_t H5D__virtual_set_extent_unlim(const H5D_t *)"
-- "exceptions": []
-  "name": "H5D__chunk_copy"
+- "name": "H5D__chunk_copy"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/hermes.yaml
+++ b/benchmark-sets/all/hermes.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8facebook3jsi16RuntimeDecoratorINS_6hermes17HermesRuntimeImplENS0_17ThreadSafeRuntimeEE26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS0_18PreparedJavaScriptEEE"
+- "name": "_ZN8facebook3jsi16RuntimeDecoratorINS_6hermes17HermesRuntimeImplENS0_17ThreadSafeRuntimeEE26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS0_18PreparedJavaScriptEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Value facebook::jsi::RuntimeDecorator<facebook::hermes::HermesRuntimeImpl, facebook::jsi::ThreadSafeRuntime>::evaluatePreparedJavaScript(RuntimeDecorator<facebook::hermes::HermesRuntimeImpl, facebook::jsi::ThreadSafeRuntime> *, const shared_ptr<const facebook::jsi::PreparedJavaScript> &)"
-- "exceptions": []
-  "name": "_ZN8facebook6hermes13HermesRuntime15debugJavaScriptERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEESA_RKNS1_10DebugFlagsE"
+- "name": "_ZN8facebook6hermes13HermesRuntime15debugJavaScriptERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEESA_RKNS1_10DebugFlagsE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void facebook::hermes::HermesRuntime::debugJavaScript(const string &, const string &, const struct DebugFlags &)"
-- "exceptions": []
-  "name": "_ZN6hermes2vm7Runtime3runEN4llvh9StringRefES3_RKNS_3hbc12CompileFlagsE"
+- "name": "_ZN6hermes2vm7Runtime3runEN4llvh9StringRefES3_RKNS_3hbc12CompileFlagsE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "CallResult<hermes::vm::HermesValue, (hermes::vm::detail::CallResultSpecialize)2> hermes::vm::Runtime::run(StringRef, StringRef, const struct CompileFlags &)"
-- "exceptions": []
-  "name": "_ZN6hermes2vm8Debugger11runDebuggerENS1_9RunReasonERNS0_16InterpreterStateE"
+- "name": "_ZN6hermes2vm8Debugger11runDebuggerENS1_9RunReasonERNS0_16InterpreterStateE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeExecutionStatus hermes::vm::Debugger::runDebugger(DW_TAG_enumeration_typeRunReason, struct InterpreterState &)"
-- "exceptions": []
-  "name": "_ZN8facebook3jsi20WithRuntimeDecoratorINS0_6detail8WithLockINS_6hermes17HermesRuntimeImplENS4_12_GLOBAL__N_111HermesMutexEEES5_NS0_17ThreadSafeRuntimeEE26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS0_18PreparedJavaScriptEEE"
+- "name": "_ZN8facebook3jsi20WithRuntimeDecoratorINS0_6detail8WithLockINS_6hermes17HermesRuntimeImplENS4_12_GLOBAL__N_111HermesMutexEEES5_NS0_17ThreadSafeRuntimeEE26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS0_18PreparedJavaScriptEEE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/highwayhash.yaml
+++ b/benchmark-sets/all/highwayhash.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK11highwayhash14HighwayHashCatILj4EEclERA4_KmPKNS_10StringViewEmPA4_m"
+- "name": "_ZNK11highwayhash14HighwayHashCatILj4EEclERA4_KmPKNS_10StringViewEmPA4_m"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void highwayhash::HighwayHashCat<4u>::operator()(const struct HighwayHashCat<2U> *, const HHKey &, const struct DW_TAG_restrict_typeStringView *, const size_t, DW_TAG_restrict_typeHHResult256 *)"
-- "exceptions": []
-  "name": "_ZNK11highwayhash14HighwayHashCatILj4EEclERA4_KmPKNS_10StringViewEmPA2_m"
+- "name": "_ZNK11highwayhash14HighwayHashCatILj4EEclERA4_KmPKNS_10StringViewEmPA2_m"
   "params":
   - "name": "this"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void highwayhash::HighwayHashCat<4u>::operator()(const struct HighwayHashCat<2U> *, const HHKey &, const struct DW_TAG_restrict_typeStringView *, const size_t, DW_TAG_restrict_typeHHResult128 *)"
-- "exceptions": []
-  "name": "_ZNK11highwayhash14HighwayHashCatILj2EEclERA4_KmPKNS_10StringViewEmPA2_m"
+- "name": "_ZNK11highwayhash14HighwayHashCatILj2EEclERA4_KmPKNS_10StringViewEmPA2_m"
   "params":
   - "name": "this"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void highwayhash::HighwayHashCat<2u>::operator()(const struct HighwayHashCat<2U> *, const HHKey &, const struct DW_TAG_restrict_typeStringView *, const size_t, DW_TAG_restrict_typeHHResult128 *)"
-- "exceptions": []
-  "name": "_ZNK11highwayhash14HighwayHashCatILj4EEclERA4_KmPKNS_10StringViewEmPm"
+- "name": "_ZNK11highwayhash14HighwayHashCatILj4EEclERA4_KmPKNS_10StringViewEmPm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void highwayhash::HighwayHashCat<4u>::operator()(const struct HighwayHashCat<2U> *, const HHKey &, const struct DW_TAG_restrict_typeStringView *, const size_t, DW_TAG_restrict_typeHHResult64 *)"
-- "exceptions": []
-  "name": "_ZNK11highwayhash14HighwayHashCatILj2EEclERA4_KmPKNS_10StringViewEmPA4_m"
+- "name": "_ZNK11highwayhash14HighwayHashCatILj2EEclERA4_KmPKNS_10StringViewEmPA4_m"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/hiredis.yaml
+++ b/benchmark-sets/all/hiredis.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "redisAsyncRead"
+- "name": "redisAsyncRead"
   "params":
   - "name": "ac"
     "type": "bool "
   "return_type": "void"
   "signature": "void redisAsyncRead(redisAsyncContext *)"
-- "exceptions": []
-  "name": "redisCommand"
+- "name": "redisCommand"
   "params":
   - "name": "c"
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void * redisCommand(redisContext *, const char *, void)"
-- "exceptions": []
-  "name": "redisCommandArgv"
+- "name": "redisCommandArgv"
   "params":
   - "name": "c"
     "type": "bool "
@@ -28,15 +25,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void * redisCommandArgv(redisContext *, int, const char **, const size_t *)"
-- "exceptions": []
-  "name": "redisProcessCallbacks"
+- "name": "redisProcessCallbacks"
   "params":
   - "name": "ac"
     "type": "bool "
   "return_type": "void"
   "signature": "void redisProcessCallbacks(redisAsyncContext *)"
-- "exceptions": []
-  "name": "redisvCommand"
+- "name": "redisvCommand"
   "params":
   - "name": "c"
     "type": "bool "

--- a/benchmark-sets/all/hoextdown.yaml
+++ b/benchmark-sets/all/hoextdown.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "hoedown_buffer_putf"
+- "name": "hoedown_buffer_putf"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int hoedown_buffer_putf(hoedown_buffer *, FILE *)"
-- "exceptions": []
-  "name": "hoedown_document_render_inline"
+- "name": "hoedown_document_render_inline"
   "params":
   - "name": "doc"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void hoedown_document_render_inline(hoedown_document *, hoedown_buffer *, const uint8_t *, size_t)"
-- "exceptions": []
-  "name": "hoedown_buffer_sets"
+- "name": "hoedown_buffer_sets"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void hoedown_buffer_sets(hoedown_buffer *, const char *)"
-- "exceptions": []
-  "name": "hoedown_buffer_put_utf8"
+- "name": "hoedown_buffer_put_utf8"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void hoedown_buffer_put_utf8(hoedown_buffer *, unsigned int)"
-- "exceptions": []
-  "name": "hoedown_html_toc_renderer_new"
+- "name": "hoedown_html_toc_renderer_new"
   "params":
   - "name": "nesting_level"
     "type": "int"

--- a/benchmark-sets/all/hostap.yaml
+++ b/benchmark-sets/all/hostap.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "wpa_supplicant_deinit"
+- "name": "wpa_supplicant_deinit"
   "params":
   - "name": "global"
     "type": "bool "
   "return_type": "void"
   "signature": "void wpa_supplicant_deinit(struct wpa_global *)"
-- "exceptions": []
-  "name": "wpa_supplicant_add_iface"
+- "name": "wpa_supplicant_add_iface"
   "params":
   - "name": "global"
     "type": "bool "
@@ -17,22 +15,19 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct wpa_supplicant * wpa_supplicant_add_iface(struct wpa_global *, struct wpa_interface *, struct wpa_supplicant *)"
-- "exceptions": []
-  "name": "wpa_supplicant_init"
+- "name": "wpa_supplicant_init"
   "params":
   - "name": "params"
     "type": "bool "
   "return_type": "void"
   "signature": "struct wpa_global * wpa_supplicant_init(struct wpa_params *)"
-- "exceptions": []
-  "name": "wpa_supplicant_reload_configuration"
+- "name": "wpa_supplicant_reload_configuration"
   "params":
   - "name": "wpa_s"
     "type": "bool "
   "return_type": "int"
   "signature": "int wpa_supplicant_reload_configuration(struct wpa_supplicant *)"
-- "exceptions": []
-  "name": "wpa_supplicant_run"
+- "name": "wpa_supplicant_run"
   "params":
   - "name": "global"
     "type": "bool "

--- a/benchmark-sets/all/hpn-ssh.yaml
+++ b/benchmark-sets/all/hpn-ssh.yaml
@@ -1,34 +1,29 @@
 "functions":
-- "exceptions": []
-  "name": "kex_gen_server"
+- "name": "kex_gen_server"
   "params":
   - "name": "ssh"
     "type": "bool "
   "return_type": "int"
   "signature": "int kex_gen_server(struct ssh *)"
-- "exceptions": []
-  "name": "kex_send_newkeys"
+- "name": "kex_send_newkeys"
   "params":
   - "name": "ssh"
     "type": "bool "
   "return_type": "int"
   "signature": "int kex_send_newkeys(struct ssh *)"
-- "exceptions": []
-  "name": "kexgex_client"
+- "name": "kexgex_client"
   "params":
   - "name": "ssh"
     "type": "bool "
   "return_type": "int"
   "signature": "int kexgex_client(struct ssh *)"
-- "exceptions": []
-  "name": "kex_gen_client"
+- "name": "kex_gen_client"
   "params":
   - "name": "ssh"
     "type": "bool "
   "return_type": "int"
   "signature": "int kex_gen_client(struct ssh *)"
-- "exceptions": []
-  "name": "kexgex_server"
+- "name": "kexgex_server"
   "params":
   - "name": "ssh"
     "type": "bool "

--- a/benchmark-sets/all/htslib.yaml
+++ b/benchmark-sets/all/htslib.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sam_index_build2"
+- "name": "sam_index_build2"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sam_index_build2(const char *, const char *, int)"
-- "exceptions": []
-  "name": "bcf_index_build"
+- "name": "bcf_index_build"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int bcf_index_build(const char *, int)"
-- "exceptions": []
-  "name": "sam_index_build3"
+- "name": "sam_index_build3"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sam_index_build3(const char *, const char *, int, int)"
-- "exceptions": []
-  "name": "sam_index_build"
+- "name": "sam_index_build"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sam_index_build(const char *, int)"
-- "exceptions": []
-  "name": "bam_index_build"
+- "name": "bam_index_build"
   "params":
   - "name": "fn"
     "type": "bool "

--- a/benchmark-sets/all/http-parser.yaml
+++ b/benchmark-sets/all/http-parser.yaml
@@ -1,27 +1,23 @@
 "functions":
-- "exceptions": []
-  "name": "http_errno_description"
+- "name": "http_errno_description"
   "params":
   - "name": ""
     "type": "int"
   "return_type": "void"
   "signature": "const char * http_errno_description(DW_TAG_enumeration_typehttp_errno)"
-- "exceptions": []
-  "name": "http_should_keep_alive"
+- "name": "http_should_keep_alive"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "int http_should_keep_alive(const http_parser *)"
-- "exceptions": []
-  "name": "http_errno_name"
+- "name": "http_errno_name"
   "params":
   - "name": ""
     "type": "int"
   "return_type": "void"
   "signature": "const char * http_errno_name(DW_TAG_enumeration_typehttp_errno)"
-- "exceptions": []
-  "name": "http_parser_pause"
+- "name": "http_parser_pause"
   "params":
   - "name": ""
     "type": "bool "
@@ -29,8 +25,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void http_parser_pause(http_parser *, int)"
-- "exceptions": []
-  "name": "http_status_str"
+- "name": "http_status_str"
   "params":
   - "name": ""
     "type": "int"

--- a/benchmark-sets/all/hunspell.yaml
+++ b/benchmark-sets/all/hunspell.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "Hunspell_suggest"
+- "name": "Hunspell_suggest"
   "params":
   - "name": "pHunspell"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int Hunspell_suggest(Hunhandle *, char ***, const char *)"
-- "exceptions": []
-  "name": "Hunspell_generate"
+- "name": "Hunspell_generate"
   "params":
   - "name": "pHunspell"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int Hunspell_generate(Hunhandle *, char ***, const char *, const char *)"
-- "exceptions": []
-  "name": "_ZN8Hunspell7suggestEPPPcPKc"
+- "name": "_ZN8Hunspell7suggestEPPPcPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int Hunspell::suggest(char ***, const char *)"
-- "exceptions": []
-  "name": "_ZN12HunspellImpl7suggestEPPPcPKc"
+- "name": "_ZN12HunspellImpl7suggestEPPPcPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int HunspellImpl::suggest(char ***, const char *)"
-- "exceptions": []
-  "name": "Hunspell_stem2"
+- "name": "Hunspell_stem2"
   "params":
   - "name": "pHunspell"
     "type": "bool "

--- a/benchmark-sets/all/ibmswtpm2.yaml
+++ b/benchmark-sets/all/ibmswtpm2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "TPM2_Create"
+- "name": "TPM2_Create"
   "params":
   - "name": "in"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Create(Create_In *, Create_Out *)"
-- "exceptions": []
-  "name": "TPM2_Import"
+- "name": "TPM2_Import"
   "params":
   - "name": "in"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Import(Import_In *, Import_Out *)"
-- "exceptions": []
-  "name": "TPM2_CreatePrimary"
+- "name": "TPM2_CreatePrimary"
   "params":
   - "name": "in"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_CreatePrimary(CreatePrimary_In *, CreatePrimary_Out *)"
-- "exceptions": []
-  "name": "TPM2_Load"
+- "name": "TPM2_Load"
   "params":
   - "name": "in"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Load(Load_In *, Load_Out *)"
-- "exceptions": []
-  "name": "TPM2_CreateLoaded"
+- "name": "TPM2_CreateLoaded"
   "params":
   - "name": "in"
     "type": "bool "

--- a/benchmark-sets/all/icu.yaml
+++ b/benchmark-sets/all/icu.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6icu_7613MessageFormat12applyPatternERKNS_13UnicodeStringER11UParseErrorR10UErrorCode"
+- "name": "_ZN6icu_7613MessageFormat12applyPatternERKNS_13UnicodeStringER11UParseErrorR10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icu_76::MessageFormat::applyPattern(const UnicodeString &, UParseError &, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZN6icu_7613MessageFormat20cacheExplicitFormatsER10UErrorCode"
+- "name": "_ZN6icu_7613MessageFormat20cacheExplicitFormatsER10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icu_76::MessageFormat::cacheExplicitFormats(UErrorCode &)"
-- "exceptions": []
-  "name": "_ZNK6icu_7621RuleBasedNumberFormat6formatElRKNS_13UnicodeStringERS1_RNS_13FieldPositionER10UErrorCode"
+- "name": "_ZNK6icu_7621RuleBasedNumberFormat6formatElRKNS_13UnicodeStringERS1_RNS_13FieldPositionER10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "UnicodeString & icu_76::RuleBasedNumberFormat::format(int64_t, const UnicodeString &, UnicodeString &, FieldPosition &, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZN6icu_7613MessageFormat23createAppropriateFormatERNS_13UnicodeStringES2_RNS_11Formattable4TypeER11UParseErrorR10UErrorCode"
+- "name": "_ZN6icu_7613MessageFormat23createAppropriateFormatERNS_13UnicodeStringES2_RNS_11Formattable4TypeER11UParseErrorR10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Format * icu_76::MessageFormat::createAppropriateFormat(UnicodeString &, UnicodeString &, DW_TAG_enumeration_typeType &, UParseError &, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZNK6icu_7614TimeZoneFormat5parseE20UTimeZoneFormatStyleRKNS_13UnicodeStringERNS_13ParsePositionEiP23UTimeZoneFormatTimeType"
+- "name": "_ZNK6icu_7614TimeZoneFormat5parseE20UTimeZoneFormatStyleRKNS_13UnicodeStringERNS_13ParsePositionEiP23UTimeZoneFormatTimeType"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/igraph.yaml
+++ b/benchmark-sets/all/igraph.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "igraph_sparsemat_arpack_rssolve"
+- "name": "igraph_sparsemat_arpack_rssolve"
   "params":
   - "name": "A"
     "type": "bool "

--- a/benchmark-sets/all/inih.yaml
+++ b/benchmark-sets/all/inih.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ini_parse_file"
+- "name": "ini_parse_file"
   "params":
   - "name": "file"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ini_parse_file(FILE *, ini_handler, void *)"
-- "exceptions": []
-  "name": "ini_parse"
+- "name": "ini_parse"
   "params":
   - "name": "filename"
     "type": "bool "

--- a/benchmark-sets/all/janet.yaml
+++ b/benchmark-sets/all/janet.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "janet_dobytes"
+- "name": "janet_dobytes"
   "params":
   - "name": "env"
     "type": "bool "
@@ -14,15 +13,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int janet_dobytes(JanetTable *, const uint8_t *, int32_t, const char *, Janet *)"
-- "exceptions": []
-  "name": "janet_loop_fiber"
+- "name": "janet_loop_fiber"
   "params":
   - "name": "fiber"
     "type": "bool "
   "return_type": "int"
   "signature": "int janet_loop_fiber(JanetFiber *)"
-- "exceptions": []
-  "name": "janet_dostring"
+- "name": "janet_dostring"
   "params":
   - "name": "env"
     "type": "bool "

--- a/benchmark-sets/all/jansson.yaml
+++ b/benchmark-sets/all/jansson.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "json_dumpfd"
+- "name": "json_dumpfd"
   "params":
   - "name": "json"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int json_dumpfd(const json_t *, int, size_t)"
-- "exceptions": []
-  "name": "json_dumpb"
+- "name": "json_dumpb"
   "params":
   - "name": "json"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "size_t json_dumpb(const json_t *, char *, size_t, size_t)"
-- "exceptions": []
-  "name": "json_load_file"
+- "name": "json_load_file"
   "params":
   - "name": "path"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "json_t * json_load_file(const char *, size_t, json_error_t *)"
-- "exceptions": []
-  "name": "json_dump_file"
+- "name": "json_dump_file"
   "params":
   - "name": "json"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int json_dump_file(const json_t *, const char *, size_t)"
-- "exceptions": []
-  "name": "json_dumpf"
+- "name": "json_dumpf"
   "params":
   - "name": "json"
     "type": "bool "

--- a/benchmark-sets/all/janus-gateway.yaml
+++ b/benchmark-sets/all/janus-gateway.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "janus_sdp_generate_answer_mline"
+- "name": "janus_sdp_generate_answer_mline"
   "params":
   - "name": "offer"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int janus_sdp_generate_answer_mline(janus_sdp *, janus_sdp *, janus_sdp_mline *, void)"
-- "exceptions": []
-  "name": "janus_rtp_simulcasting_context_process_rtp"
+- "name": "janus_rtp_simulcasting_context_process_rtp"
   "params":
   - "name": "context"
     "type": "bool "
@@ -35,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "gboolean janus_rtp_simulcasting_context_process_rtp(janus_rtp_simulcasting_context *, char *, int, uint8_t *, int, uint32_t *, char **, janus_videocodec, janus_rtp_switching_context *, janus_mutex *)"
-- "exceptions": []
-  "name": "janus_sdp_generate_offer"
+- "name": "janus_sdp_generate_offer"
   "params":
   - "name": "name"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "janus_sdp * janus_sdp_generate_offer(const char *, const char *, void)"
-- "exceptions": []
-  "name": "janus_rtp_svc_context_process_rtp"
+- "name": "janus_rtp_svc_context_process_rtp"
   "params":
   - "name": "context"
     "type": "bool "
@@ -65,8 +61,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "gboolean janus_rtp_svc_context_process_rtp(janus_rtp_svc_context *, char *, int, uint8_t *, int, janus_videocodec, janus_vp9_svc_info *, janus_rtp_switching_context *)"
-- "exceptions": []
-  "name": "janus_sdp_generate_offer_mline"
+- "name": "janus_sdp_generate_offer_mline"
   "params":
   - "name": "offer"
     "type": "bool "

--- a/benchmark-sets/all/jbig2dec.yaml
+++ b/benchmark-sets/all/jbig2dec.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "jbig2_make_global_ctx"
+- "name": "jbig2_make_global_ctx"
   "params":
   - "name": "ctx"
     "type": "bool "
   "return_type": "void"
   "signature": "Jbig2GlobalCtx * jbig2_make_global_ctx(Jbig2Ctx *)"
-- "exceptions": []
-  "name": "jbig2_global_ctx_free"
+- "name": "jbig2_global_ctx_free"
   "params":
   - "name": "global_ctx"
     "type": "bool "
   "return_type": "void"
   "signature": "Jbig2Allocator * jbig2_global_ctx_free(Jbig2GlobalCtx *)"
-- "exceptions": []
-  "name": "jbig2_sd_glyph"
+- "name": "jbig2_sd_glyph"
   "params":
   - "name": "dict"
     "type": "bool "

--- a/benchmark-sets/all/jq.yaml
+++ b/benchmark-sets/all/jq.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "jq_util_input_next_input"
+- "name": "jq_util_input_next_input"
   "params":
   - "name": "state"
     "type": "bool "
   "return_type": "void"
   "signature": "jv jq_util_input_next_input(jq_util_input_state *)"
-- "exceptions": []
-  "name": "jq_util_input_next_input_cb"
+- "name": "jq_util_input_next_input_cb"
   "params":
   - "name": "jq"
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "jv jq_util_input_next_input_cb(jq_state *, void *)"
-- "exceptions": []
-  "name": "jv_string_implode"
+- "name": "jv_string_implode"
   "params":
   - "name": "j"
     "type": "size_t"
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "jv jv_string_implode(jv)"
-- "exceptions": []
-  "name": "jv_show"
+- "name": "jv_show"
   "params":
   - "name": "x"
     "type": "size_t"

--- a/benchmark-sets/all/json-c.yaml
+++ b/benchmark-sets/all/json-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "json_object_equal"
+- "name": "json_object_equal"
   "params":
   - "name": "jso1"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int json_object_equal(struct json_object *, struct json_object *)"
-- "exceptions": []
-  "name": "json_tokener_parse"
+- "name": "json_tokener_parse"
   "params":
   - "name": "str"
     "type": "bool "
   "return_type": "void"
   "signature": "struct json_object * json_tokener_parse(const char *)"
-- "exceptions": []
-  "name": "json_object_deep_copy"
+- "name": "json_object_deep_copy"
   "params":
   - "name": "src"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int json_object_deep_copy(struct json_object *, struct json_object **, json_c_shallow_copy_fn *)"
-- "exceptions": []
-  "name": "json_tokener_parse_verbose"
+- "name": "json_tokener_parse_verbose"
   "params":
   - "name": "str"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct json_object * json_tokener_parse_verbose(const char *, DW_TAG_enumeration_typejson_tokener_error *)"
-- "exceptions": []
-  "name": "json_object_new_string"
+- "name": "json_object_new_string"
   "params":
   - "name": "s"
     "type": "bool "

--- a/benchmark-sets/all/json.yaml
+++ b/benchmark-sets/all/json.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8nlohmann16json_abi_v3_11_310basic_jsonINSt3__13mapENS2_6vectorENS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEblmdS8_NS0_14adl_serializerENS4_IhNS8_IhEEEEvE3endEv"
+- "name": "_ZN8nlohmann16json_abi_v3_11_310basic_jsonINSt3__13mapENS2_6vectorENS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEblmdS8_NS0_14adl_serializerENS4_IhNS8_IhEEEEvE3endEv"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "iterator nlohmann::json_abi_v3_11_3::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void>::end(basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void> *)"
-- "exceptions": []
-  "name": "_ZN8nlohmann16json_abi_v3_11_310basic_jsonINSt3__13mapENS2_6vectorENS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEblmdS8_NS0_14adl_serializerENS4_IhNS8_IhEEEEvE5beginEv"
+- "name": "_ZN8nlohmann16json_abi_v3_11_310basic_jsonINSt3__13mapENS2_6vectorENS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEblmdS8_NS0_14adl_serializerENS4_IhNS8_IhEEEEvE5beginEv"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,15 +15,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "iterator nlohmann::json_abi_v3_11_3::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void>::begin(basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void> *)"
-- "exceptions": []
-  "name": "_ZNK8nlohmann16json_abi_v3_11_36detail9iter_implINS0_10basic_jsonINSt3__13mapENS4_6vectorENS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEblmdSA_NS0_14adl_serializerENS6_IhNSA_IhEEEEvEEEptEv"
+- "name": "_ZNK8nlohmann16json_abi_v3_11_36detail9iter_implINS0_10basic_jsonINSt3__13mapENS4_6vectorENS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEblmdSA_NS0_14adl_serializerENS6_IhNSA_IhEEEEvEEEptEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "pointer nlohmann::json_abi_v3_11_3::detail::iter_impl<nlohmann::json_abi_v3_11_3::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void> >::operator->(const iter_impl<nlohmann::json_abi_v3_11_3::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void> > *)"
-- "exceptions": []
-  "name": "_ZN8nlohmann16json_abi_v3_11_36detail28json_sax_dom_callback_parserINS0_10basic_jsonINSt3__13mapENS4_6vectorENS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEblmdSA_NS0_14adl_serializerENS6_IhNSA_IhEEEEvEEE6stringERSC_"
+- "name": "_ZN8nlohmann16json_abi_v3_11_36detail28json_sax_dom_callback_parserINS0_10basic_jsonINSt3__13mapENS4_6vectorENS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEblmdSA_NS0_14adl_serializerENS6_IhNSA_IhEEEEvEEE6stringERSC_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool nlohmann::json_abi_v3_11_3::detail::json_sax_dom_callback_parser<nlohmann::json_abi_v3_11_3::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void> >::string(json_sax_dom_callback_parser<nlohmann::json_abi_v3_11_3::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, void> > *, string_t &)"
-- "exceptions": []
-  "name": "_ZN8nlohmann16json_abi_v3_11_36detail28json_sax_dom_callback_parserINS0_10basic_jsonINSt3__13mapENS4_6vectorENS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEblmdSA_NS0_14adl_serializerENS6_IhNSA_IhEEEEvEEE4nullEv"
+- "name": "_ZN8nlohmann16json_abi_v3_11_36detail28json_sax_dom_callback_parserINS0_10basic_jsonINSt3__13mapENS4_6vectorENS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEblmdSA_NS0_14adl_serializerENS6_IhNSA_IhEEEEvEEE4nullEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/jsoncons.yaml
+++ b/benchmark-sets/all/jsoncons.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8jsoncons15index_key_valueINS_10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEEEaSEOS7_"
+- "name": "_ZN8jsoncons15index_key_valueINS_10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEEEaSEOS7_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct index_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > > & jsoncons::index_key_value<jsoncons::basic_json<char, jsoncons::order_preserving_policy, std::__1::allocator<char> > >::operator=(struct index_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > > *, struct DW_TAG_rvalue_reference_typeindex_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > >)"
-- "exceptions": []
-  "name": "_ZN8jsonconsltERKNS_12basic_bigintINSt3__19allocatorIhEEEES6_"
+- "name": "_ZN8jsonconsltERKNS_12basic_bigintINSt3__19allocatorIhEEEES6_"
   "params":
   - "name": "x"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool jsoncons::operator<(const basic_bigint<std::__1::allocator<unsigned char> > &, const basic_bigint<std::__1::allocator<unsigned char> > &)"
-- "exceptions": []
-  "name": "_ZN8jsoncons10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEaSERKS5_"
+- "name": "_ZN8jsoncons10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEaSERKS5_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > & jsoncons::basic_json<char, jsoncons::order_preserving_policy, std::__1::allocator<char> >::operator=(basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > *, const basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > &)"
-- "exceptions": []
-  "name": "_ZN8jsoncons15index_key_valueINS_10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEEEaSERKS7_"
+- "name": "_ZN8jsoncons15index_key_valueINS_10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEEEaSERKS7_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct index_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > > & jsoncons::index_key_value<jsoncons::basic_json<char, jsoncons::order_preserving_policy, std::__1::allocator<char> > >::operator=(struct index_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > > *, const struct index_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::__1::allocator<char> > > &)"
-- "exceptions": []
-  "name": "_ZN8jsoncons10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEaSEOS5_"
+- "name": "_ZN8jsoncons10basic_jsonIcNS_23order_preserving_policyENSt3__19allocatorIcEEEaSEOS5_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/jsoncpp.yaml
+++ b/benchmark-sets/all/jsoncpp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4Json6Reader5parseERNSt3__113basic_istreamIcNS1_11char_traitsIcEEEERNS_5ValueEb"
+- "name": "_ZN4Json6Reader5parseERNSt3__113basic_istreamIcNS1_11char_traitsIcEEEERNS_5ValueEb"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool Json::Reader::parse(istream &, Value &, bool)"
-- "exceptions": []
-  "name": "_ZN4Json6Reader5parseERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEERNS_5ValueEb"
+- "name": "_ZN4Json6Reader5parseERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEERNS_5ValueEb"
   "params":
   - "name": ""
     "type": "bool "
@@ -25,15 +23,13 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool Json::Reader::parse(const string &, Value &, bool)"
-- "exceptions": []
-  "name": "_ZN4Json6Reader9readValueEv"
+- "name": "_ZN4Json6Reader9readValueEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "bool"
   "signature": "bool Json::Reader::readValue()"
-- "exceptions": []
-  "name": "_ZN4Json6Reader10readObjectERNS0_5TokenE"
+- "name": "_ZN4Json6Reader10readObjectERNS0_5TokenE"
   "params":
   - "name": ""
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool Json::Reader::readObject(Token &)"
-- "exceptions": []
-  "name": "_ZN4Json6Reader9readArrayERNS0_5TokenE"
+- "name": "_ZN4Json6Reader9readArrayERNS0_5TokenE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/jsonnet.yaml
+++ b/benchmark-sets/all/jsonnet.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8nlohmann6detail6parserINS_10basic_jsonINSt3__13mapENS3_6vectorENS3_12basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEblmdS9_NS_14adl_serializerEEEE5parseEbRSD_"
+- "name": "_ZN8nlohmann6detail6parserINS_10basic_jsonINSt3__13mapENS3_6vectorENS3_12basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEblmdS9_NS_14adl_serializerEEEE5parseEbRSD_"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void nlohmann::detail::parser<nlohmann::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::adl_serializer> >::parse(parser<nlohmann::basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::adl_serializer> > *, const bool, basic_json<std::__1::map, std::__1::vector, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool, long, unsigned long, double, std::__1::allocator, nlohmann::adl_serializer> &)"
-- "exceptions": []
-  "name": "jsonnet_evaluate_file_stream"
+- "name": "jsonnet_evaluate_file_stream"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * jsonnet_evaluate_file_stream(struct JsonnetVm *, const char *, int *)"
-- "exceptions": []
-  "name": "jsonnet_evaluate_file_multi"
+- "name": "jsonnet_evaluate_file_multi"
   "params":
   - "name": ""
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * jsonnet_evaluate_file_multi(struct JsonnetVm *, const char *, int *)"
-- "exceptions": []
-  "name": "_ZN7jsonnet8internal11jsonnet_fmtEPNS0_3ASTERNSt3__16vectorINS0_13FodderElementENS3_9allocatorIS5_EEEERKNS0_7FmtOptsE"
+- "name": "_ZN7jsonnet8internal11jsonnet_fmtEPNS0_3ASTERNSt3__16vectorINS0_13FodderElementENS3_9allocatorIS5_EEEERKNS0_7FmtOptsE"
   "params":
   - "name": ""
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "string jsonnet::internal::jsonnet_fmt(struct AST *, Fodder &, const struct FmtOpts &)"
-- "exceptions": []
-  "name": "jsonnet_evaluate_file"
+- "name": "jsonnet_evaluate_file"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/kamailio.yaml
+++ b/benchmark-sets/all/kamailio.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "tcp_init_children"
+- "name": "tcp_init_children"
   "params":
   - "name": "woneinit"
     "type": "bool "
   "return_type": "int"
   "signature": "int tcp_init_children(int *)"
-- "exceptions": []
-  "name": "tcp_receive_loop"
+- "name": "tcp_receive_loop"
   "params":
   - "name": "unix_sock"
     "type": "int"
   "return_type": "void"
   "signature": "void tcp_receive_loop(int)"
-- "exceptions": []
-  "name": "fix_actions"
+- "name": "fix_actions"
   "params":
   - "name": "a"
     "type": "bool "

--- a/benchmark-sets/all/kcodecs.yaml
+++ b/benchmark-sets/all/kcodecs.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN13QPluginLoader4loadEv"
+- "name": "_ZN13QPluginLoader4loadEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "bool"
   "signature": "bool QPluginLoader::load()"
-- "exceptions": []
-  "name": "_ZN15QLibraryPrivate8isPluginEv"
+- "name": "_ZN15QLibraryPrivate8isPluginEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "bool"
   "signature": "bool QLibraryPrivate::isPlugin()"
-- "exceptions": []
-  "name": "_ZNK14QFactoryLoader6keyMapEv"
+- "name": "_ZNK14QFactoryLoader6keyMapEv"
   "params":
   - "name": ""
     "type": "bool "
@@ -22,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "QMultiMap<int, QString> QFactoryLoader::keyMap()"
-- "exceptions": []
-  "name": "_ZNK14QFactoryLoader8instanceEi"
+- "name": "_ZNK14QFactoryLoader8instanceEi"
   "params":
   - "name": ""
     "type": "bool "
@@ -31,8 +27,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "QObject * QFactoryLoader::instance(int)"
-- "exceptions": []
-  "name": "_ZN15QLibraryPrivate17updatePluginStateEv"
+- "name": "_ZN15QLibraryPrivate17updatePluginStateEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/keystone.yaml
+++ b/benchmark-sets/all/keystone.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_19AsmParser3RunEbmb"
+- "name": "_ZN12_GLOBAL__N_19AsmParser3RunEbmb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool"
   "return_type": "size_t"
   "signature": "size_t (anonymous namespace)::AsmParser::Run(bool, uint64_t, bool)"
-- "exceptions": []
-  "name": "_ZL16adjustFixupValuejm"
+- "name": "_ZL16adjustFixupValuejm"
   "params":
   - "name": "Kind"
     "type": "int"
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "unsigned int adjustFixupValue(unsigned int, uint64_t)"
-- "exceptions": []
-  "name": "_ZNK12_GLOBAL__N_114SystemZOperand5isMemENS_10MemoryKindENS_12RegisterKindE"
+- "name": "_ZNK12_GLOBAL__N_114SystemZOperand5isMemENS_10MemoryKindENS_12RegisterKindE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,15 +29,13 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool (anonymous namespace)::SystemZOperand::isMem(DW_TAG_enumeration_typeMemoryKind, DW_TAG_enumeration_typeRegisterKind)"
-- "exceptions": []
-  "name": "ks_strerror"
+- "name": "ks_strerror"
   "params":
   - "name": "code"
     "type": "int"
   "return_type": "void"
   "signature": "const char * ks_strerror(ks_err)"
-- "exceptions": []
-  "name": "ks_arch_supported"
+- "name": "ks_arch_supported"
   "params":
   - "name": "arch"
     "type": "int"

--- a/benchmark-sets/all/knot-dns.yaml
+++ b/benchmark-sets/all/knot-dns.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gnutls_bye"
+- "name": "gnutls_bye"
   "params":
   - "name": "session"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int gnutls_bye(gnutls_session_t, gnutls_close_request_t)"
-- "exceptions": []
-  "name": "_gnutls_recv_int"
+- "name": "_gnutls_recv_int"
   "params":
   - "name": "session"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "ssize_t _gnutls_recv_int(gnutls_session_t, content_type_t, uint8_t *, size_t, void *, unsigned int)"
-- "exceptions": []
-  "name": "gnutls_record_recv_packet"
+- "name": "gnutls_record_recv_packet"
   "params":
   - "name": "session"
     "type": "bool "
@@ -34,15 +31,13 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t gnutls_record_recv_packet(gnutls_session_t, gnutls_packet_t *)"
-- "exceptions": []
-  "name": "gnutls_handshake"
+- "name": "gnutls_handshake"
   "params":
   - "name": "session"
     "type": "bool "
   "return_type": "int"
   "signature": "int gnutls_handshake(gnutls_session_t)"
-- "exceptions": []
-  "name": "handshake_client"
+- "name": "handshake_client"
   "params":
   - "name": "session"
     "type": "bool "

--- a/benchmark-sets/all/krb5.yaml
+++ b/benchmark-sets/all/krb5.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "krb5_gss_store_cred_into"
+- "name": "krb5_gss_store_cred_into"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -22,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OM_uint32 krb5_gss_store_cred_into(OM_uint32 *, gss_cred_id_t, gss_cred_usage_t, const gss_OID, OM_uint32, OM_uint32, gss_const_key_value_set_t, gss_OID_set *, gss_cred_usage_t *)"
-- "exceptions": []
-  "name": "iakerb_gss_accept_sec_context"
+- "name": "iakerb_gss_accept_sec_context"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -49,8 +47,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OM_uint32 iakerb_gss_accept_sec_context(OM_uint32 *, gss_ctx_id_t *, gss_cred_id_t, gss_buffer_t, gss_channel_bindings_t, gss_name_t *, gss_OID *, gss_buffer_t, OM_uint32 *, OM_uint32 *, gss_cred_id_t *)"
-- "exceptions": []
-  "name": "krb5_gss_store_cred"
+- "name": "krb5_gss_store_cred"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -70,8 +67,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OM_uint32 krb5_gss_store_cred(OM_uint32 *, gss_cred_id_t, gss_cred_usage_t, const gss_OID, OM_uint32, OM_uint32, gss_OID_set *, gss_cred_usage_t *)"
-- "exceptions": []
-  "name": "krb5_gss_acquire_cred_impersonate_name"
+- "name": "krb5_gss_acquire_cred_impersonate_name"
   "params":
   - "name": "minor_status"
     "type": "bool "
@@ -93,8 +89,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OM_uint32 krb5_gss_acquire_cred_impersonate_name(OM_uint32 *, const gss_cred_id_t, const gss_name_t, OM_uint32, const gss_OID_set, gss_cred_usage_t, gss_cred_id_t *, gss_OID_set *, OM_uint32 *)"
-- "exceptions": []
-  "name": "iakerb_gss_init_sec_context"
+- "name": "iakerb_gss_init_sec_context"
   "params":
   - "name": "minor_status"
     "type": "bool "

--- a/benchmark-sets/all/lame.yaml
+++ b/benchmark-sets/all/lame.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN11EncoderCoreIlLb1EE6encodeERNSt3__16vectorIlNS1_9allocatorIlEEEEPhmb"
+- "name": "_ZN11EncoderCoreIlLb1EE6encodeERNSt3__16vectorIlNS1_9allocatorIlEEEEPhmb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "int EncoderCore<long, true>::encode(EncoderCore<short, false> *, vector<short, std::__1::allocator<short> > &, uint8_t *, const size_t, const bool)"
-- "exceptions": []
-  "name": "lame_encode_finish"
+- "name": "lame_encode_finish"
   "params":
   - "name": "gfp"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int lame_encode_finish(lame_global_flags *, unsigned char *, int)"
-- "exceptions": []
-  "name": "_ZN11EncoderCoreIdLb1EE6encodeERNSt3__16vectorIdNS1_9allocatorIdEEEEPhmb"
+- "name": "_ZN11EncoderCoreIdLb1EE6encodeERNSt3__16vectorIdNS1_9allocatorIdEEEEPhmb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "int EncoderCore<double, true>::encode(EncoderCore<short, false> *, vector<short, std::__1::allocator<short> > &, uint8_t *, const size_t, const bool)"
-- "exceptions": []
-  "name": "_ZN11EncoderCoreIfLb1EE6encodeERNSt3__16vectorIfNS1_9allocatorIfEEEEPhmb"
+- "name": "_ZN11EncoderCoreIfLb1EE6encodeERNSt3__16vectorIfNS1_9allocatorIfEEEEPhmb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "int EncoderCore<float, true>::encode(EncoderCore<short, false> *, vector<short, std::__1::allocator<short> > &, uint8_t *, const size_t, const bool)"
-- "exceptions": []
-  "name": "id3tag_set_fieldvalue_ucs2"
+- "name": "id3tag_set_fieldvalue_ucs2"
   "params":
   - "name": "gfp"
     "type": "bool "

--- a/benchmark-sets/all/lcms.yaml
+++ b/benchmark-sets/all/lcms.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "cmsCreateDeviceLinkFromCubeFileTHR"
+- "name": "cmsCreateDeviceLinkFromCubeFileTHR"
   "params":
   - "name": "ContextID"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "cmsHPROFILE cmsCreateDeviceLinkFromCubeFileTHR(cmsContext, const char *)"
-- "exceptions": []
-  "name": "cmsCreateProofingTransform"
+- "name": "cmsCreateProofingTransform"
   "params":
   - "name": "InputProfile"
     "type": "bool "
@@ -29,15 +27,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "cmsHTRANSFORM cmsCreateProofingTransform(cmsHPROFILE, cmsUInt32Number, cmsHPROFILE, cmsUInt32Number, cmsHPROFILE, cmsUInt32Number, cmsUInt32Number, cmsUInt32Number)"
-- "exceptions": []
-  "name": "cmsCreateDeviceLinkFromCubeFile"
+- "name": "cmsCreateDeviceLinkFromCubeFile"
   "params":
   - "name": "cFileName"
     "type": "bool "
   "return_type": "void"
   "signature": "cmsHPROFILE cmsCreateDeviceLinkFromCubeFile(const char *)"
-- "exceptions": []
-  "name": "_cmsDefaultICCintents"
+- "name": "_cmsDefaultICCintents"
   "params":
   - "name": "ContextID"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "cmsPipeline * _cmsDefaultICCintents(cmsContext, cmsUInt32Number, cmsUInt32Number *, cmsHPROFILE *, cmsBool *, cmsFloat64Number *, cmsUInt32Number)"
-- "exceptions": []
-  "name": "cmsCreateProofingTransformTHR"
+- "name": "cmsCreateProofingTransformTHR"
   "params":
   - "name": "ContextID"
     "type": "bool "

--- a/benchmark-sets/all/leptonica.yaml
+++ b/benchmark-sets/all/leptonica.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "TIFFFdOpen"
+- "name": "TIFFFdOpen"
   "params":
   - "name": "fd"
     "type": "int"
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "TIFF * TIFFFdOpen(int, const char *, const char *)"
-- "exceptions": []
-  "name": "WebPEncodeLosslessBGR"
+- "name": "WebPEncodeLosslessBGR"
   "params":
   - "name": "in"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t WebPEncodeLosslessBGR(const uint8_t *, int, int, int, uint8_t **)"
-- "exceptions": []
-  "name": "WebPEncodeLosslessBGRA"
+- "name": "WebPEncodeLosslessBGRA"
   "params":
   - "name": "in"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t WebPEncodeLosslessBGRA(const uint8_t *, int, int, int, uint8_t **)"
-- "exceptions": []
-  "name": "WebPEncodeLosslessRGB"
+- "name": "WebPEncodeLosslessRGB"
   "params":
   - "name": "in"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t WebPEncodeLosslessRGB(const uint8_t *, int, int, int, uint8_t **)"
-- "exceptions": []
-  "name": "jbGetComponents"
+- "name": "jbGetComponents"
   "params":
   - "name": "pixs"
     "type": "bool "

--- a/benchmark-sets/all/leveldb.yaml
+++ b/benchmark-sets/all/leveldb.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7leveldb12_GLOBAL__N_16DBIter4PrevEv"
+- "name": "_ZN7leveldb12_GLOBAL__N_16DBIter4PrevEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void leveldb::(anonymous namespace)::DBIter::Prev()"
-- "exceptions": []
-  "name": "_ZN7leveldb12_GLOBAL__N_16DBIter10SeekToLastEv"
+- "name": "_ZN7leveldb12_GLOBAL__N_16DBIter10SeekToLastEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void leveldb::(anonymous namespace)::DBIter::SeekToLast()"
-- "exceptions": []
-  "name": "_ZN7leveldb12_GLOBAL__N_16DBIter4SeekERKNS_5SliceE"
+- "name": "_ZN7leveldb12_GLOBAL__N_16DBIter4SeekERKNS_5SliceE"
   "params":
   - "name": ""
     "type": "bool "
@@ -22,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void leveldb::(anonymous namespace)::DBIter::Seek(const Slice &)"
-- "exceptions": []
-  "name": "_ZN7leveldb6DBImpl19GetApproximateSizesEPKNS_5RangeEiPm"
+- "name": "_ZN7leveldb6DBImpl19GetApproximateSizesEPKNS_5RangeEiPm"
   "params":
   - "name": ""
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void leveldb::DBImpl::GetApproximateSizes(const struct Range *, int, uint64_t *)"
-- "exceptions": []
-  "name": "_ZN7leveldb6DBImpl24TEST_NewInternalIteratorEv"
+- "name": "_ZN7leveldb6DBImpl24TEST_NewInternalIteratorEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libaom.yaml
+++ b/benchmark-sets/all/libaom.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "av1_filter_block_plane_vert_opt_chroma"
+- "name": "av1_filter_block_plane_vert_opt_chroma"
   "params":
   - "name": ""
     "type": "bool "
@@ -24,8 +23,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void av1_filter_block_plane_vert_opt_chroma(const const AV1_COMMON *, const const MACROBLOCKD *, const const MACROBLOCKD_PLANE *, const uint32_t, const uint32_t, AV1_DEBLOCKING_PARAMETERS *, TX_SIZE *, int, bool, int)"
-- "exceptions": []
-  "name": "av1_realloc_and_scale_if_required"
+- "name": "av1_realloc_and_scale_if_required"
   "params":
   - "name": ""
     "type": "bool "
@@ -47,8 +45,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "YV12_BUFFER_CONFIG * av1_realloc_and_scale_if_required(AV1_COMMON *, YV12_BUFFER_CONFIG *, YV12_BUFFER_CONFIG *, const InterpFilter, const int, const _Bool, const _Bool, const int, const _Bool)"
-- "exceptions": []
-  "name": "av1_highbd_dr_prediction_z3_avx2"
+- "name": "av1_highbd_dr_prediction_z3_avx2"
   "params":
   - "name": ""
     "type": "bool "
@@ -72,8 +69,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void av1_highbd_dr_prediction_z3_avx2(uint16_t *, ptrdiff_t, int, int, const uint16_t *, const uint16_t *, int, int, int, int)"
-- "exceptions": []
-  "name": "av1_dr_prediction_z3_sse4_1"
+- "name": "av1_dr_prediction_z3_sse4_1"
   "params":
   - "name": ""
     "type": "bool "
@@ -95,8 +91,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void av1_dr_prediction_z3_sse4_1(uint8_t *, ptrdiff_t, int, int, const uint8_t *, const uint8_t *, int, int, int)"
-- "exceptions": []
-  "name": "av1_resize_and_extend_frame_nonnormative"
+- "name": "av1_resize_and_extend_frame_nonnormative"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libarchive.yaml
+++ b/benchmark-sets/all/libarchive.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "archive_entry_linkify"
+- "name": "archive_entry_linkify"
   "params":
   - "name": "res"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void archive_entry_linkify(struct archive_entry_linkresolver *, struct archive_entry **, struct archive_entry **)"
-- "exceptions": []
-  "name": "archive_entry_acl_text_w"
+- "name": "archive_entry_acl_text_w"
   "params":
   - "name": "entry"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "const wchar_t * archive_entry_acl_text_w(struct archive_entry *, int)"
-- "exceptions": []
-  "name": "archive_entry_acl_to_text_w"
+- "name": "archive_entry_acl_to_text_w"
   "params":
   - "name": "entry"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "wchar_t * archive_entry_acl_to_text_w(struct archive_entry *, la_ssize_t *, int)"
-- "exceptions": []
-  "name": "_archive_entry_acl_text_l"
+- "name": "_archive_entry_acl_text_l"
   "params":
   - "name": "entry"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int _archive_entry_acl_text_l(struct archive_entry *, int, const char **, size_t *, struct archive_string_conv *)"
-- "exceptions": []
-  "name": "archive_entry_acl_text"
+- "name": "archive_entry_acl_text"
   "params":
   - "name": "entry"
     "type": "bool "

--- a/benchmark-sets/all/libass.yaml
+++ b/benchmark-sets/all/libass.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN16hb_lazy_loader_tIN2OT18cff2_accelerator_tE21hb_face_lazy_loader_tIS1_Lj17EE9hb_face_tLj17ES1_E6createEPS4_"
+- "name": "_ZN16hb_lazy_loader_tIN2OT18cff2_accelerator_tE21hb_face_lazy_loader_tIS1_Lj17EE9hb_face_tLj17ES1_E6createEPS4_"
   "params":
   - "name": "data"
     "type": "bool "
   "return_type": "void"
   "signature": "struct GSUB_accelerator_t * hb_lazy_loader_t<OT::cff2_accelerator_t, hb_face_lazy_loader_t<OT::cff2_accelerator_t, 17u>, hb_face_t, 17u, OT::cff2_accelerator_t>::create(struct hb_face_t *)"
-- "exceptions": []
-  "name": "_ZN22hb_table_lazy_loader_tIN2OT4COLRELj35ELb1EE6createEP9hb_face_t"
+- "name": "_ZN22hb_table_lazy_loader_tIN2OT4COLRELj35ELb1EE6createEP9hb_face_t"
   "params":
   - "name": "face"
     "type": "bool "
   "return_type": "void"
   "signature": "hb_blob_t * hb_table_lazy_loader_t<OT::COLR, 35u, true>::create(hb_face_t *)"
-- "exceptions": []
-  "name": "_ZN16hb_lazy_loader_tIN2OT18cff1_accelerator_tE21hb_face_lazy_loader_tIS1_Lj16EE9hb_face_tLj16ES1_E6createEPS4_"
+- "name": "_ZN16hb_lazy_loader_tIN2OT18cff1_accelerator_tE21hb_face_lazy_loader_tIS1_Lj16EE9hb_face_tLj16ES1_E6createEPS4_"
   "params":
   - "name": "data"
     "type": "bool "

--- a/benchmark-sets/all/libavc.yaml
+++ b/benchmark-sets/all/libavc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "irc_add_pic_to_stack_re_enc"
+- "name": "irc_add_pic_to_stack_re_enc"
   "params":
   - "name": "ps_pic_handling"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "WORD32 irc_add_pic_to_stack_re_enc(pic_handling_t *, WORD32, picture_type_e)"
-- "exceptions": []
-  "name": "irc_add_picture_to_stack_re_enc"
+- "name": "irc_add_picture_to_stack_re_enc"
   "params":
   - "name": "rate_control_api"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void irc_add_picture_to_stack_re_enc(rate_control_api_t *, WORD32, picture_type_e)"
-- "exceptions": []
-  "name": "ih264_dpb_mgr_count_ref_frames"
+- "name": "ih264_dpb_mgr_count_ref_frames"
   "params":
   - "name": "ps_dpb_mgr"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "WORD32 ih264_dpb_mgr_count_ref_frames(dpb_mgr_t *, WORD32, WORD32)"
-- "exceptions": []
-  "name": "irc_calc_per_frm_bits"
+- "name": "irc_calc_per_frm_bits"
   "params":
   - "name": "ps_rd_model"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "WORD32 irc_calc_per_frm_bits(rc_rd_model_t *, UWORD16 *, UWORD8 *, UWORD8, UWORD32 *, UWORD8, float *, float *, UWORD8, UWORD32, UWORD32, UWORD8 *)"
-- "exceptions": []
-  "name": "isvcd_compute_interlyr_motion_mode"
+- "name": "isvcd_compute_interlyr_motion_mode"
   "params":
   - "name": "pv_comp_mode_mv_ctxt"
     "type": "bool "

--- a/benchmark-sets/all/libbpf.yaml
+++ b/benchmark-sets/all/libbpf.yaml
@@ -1,27 +1,23 @@
 "functions":
-- "exceptions": []
-  "name": "bpf_object__load"
+- "name": "bpf_object__load"
   "params":
   - "name": "obj"
     "type": "bool "
   "return_type": "int"
   "signature": "int bpf_object__load(struct bpf_object *)"
-- "exceptions": []
-  "name": "bpf_object__open"
+- "name": "bpf_object__open"
   "params":
   - "name": "path"
     "type": "bool "
   "return_type": "void"
   "signature": "struct bpf_object * bpf_object__open(const char *)"
-- "exceptions": []
-  "name": "bpf_object__load_skeleton"
+- "name": "bpf_object__load_skeleton"
   "params":
   - "name": "s"
     "type": "bool "
   "return_type": "int"
   "signature": "int bpf_object__load_skeleton(struct bpf_object_skeleton *)"
-- "exceptions": []
-  "name": "bpf_object__open_skeleton"
+- "name": "bpf_object__open_skeleton"
   "params":
   - "name": "s"
     "type": "bool "
@@ -29,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int bpf_object__open_skeleton(struct bpf_object_skeleton *, const struct bpf_object_open_opts *)"
-- "exceptions": []
-  "name": "bpf_object__open_file"
+- "name": "bpf_object__open_file"
   "params":
   - "name": "path"
     "type": "bool "

--- a/benchmark-sets/all/libcacard.yaml
+++ b/benchmark-sets/all/libcacard.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "vcard_emul_force_card_remove"
+- "name": "vcard_emul_force_card_remove"
   "params":
   - "name": "vreader"
     "type": "bool "
   "return_type": "int"
   "signature": "VCardEmulError vcard_emul_force_card_remove(VReader *)"
-- "exceptions": []
-  "name": "vcard_emul_reset"
+- "name": "vcard_emul_reset"
   "params":
   - "name": "card"
     "type": "bool "
@@ -15,15 +13,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void vcard_emul_reset(VCard *, VCardPower)"
-- "exceptions": []
-  "name": "vcard_emul_force_card_insert"
+- "name": "vcard_emul_force_card_insert"
   "params":
   - "name": "vreader"
     "type": "bool "
   "return_type": "int"
   "signature": "VCardEmulError vcard_emul_force_card_insert(VReader *)"
-- "exceptions": []
-  "name": "vcard_emul_get_atr"
+- "name": "vcard_emul_get_atr"
   "params":
   - "name": "card"
     "type": "bool "

--- a/benchmark-sets/all/libcbor.yaml
+++ b/benchmark-sets/all/libcbor.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "cbor_intermediate_decref"
+- "name": "cbor_intermediate_decref"
   "params":
   - "name": "item"
     "type": "bool "
   "return_type": "void"
   "signature": "void cbor_intermediate_decref(cbor_item_t *)"
-- "exceptions": []
-  "name": "cbor_refcount"
+- "name": "cbor_refcount"
   "params":
   - "name": "item"
     "type": "bool "

--- a/benchmark-sets/all/libcoap.yaml
+++ b/benchmark-sets/all/libcoap.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "coap_ws_read"
+- "name": "coap_ws_read"
   "params":
   - "name": "session"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "ssize_t coap_ws_read(coap_session_t *, uint8_t *, size_t)"
-- "exceptions": []
-  "name": "coap_new_client_session_oscore_pki"
+- "name": "coap_new_client_session_oscore_pki"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "coap_session_t * coap_new_client_session_oscore_pki(coap_context_t *, const coap_address_t *, const coap_address_t *, coap_proto_t, coap_dtls_pki_t *, coap_oscore_conf_t *)"
-- "exceptions": []
-  "name": "coap_new_client_session_oscore_pki_lkd"
+- "name": "coap_new_client_session_oscore_pki_lkd"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "coap_session_t * coap_new_client_session_oscore_pki_lkd(coap_context_t *, const coap_address_t *, const coap_address_t *, coap_proto_t, coap_dtls_pki_t *, coap_oscore_conf_t *)"
-- "exceptions": []
-  "name": "coap_new_client_session_oscore_psk_lkd"
+- "name": "coap_new_client_session_oscore_psk_lkd"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "coap_session_t * coap_new_client_session_oscore_psk_lkd(coap_context_t *, const coap_address_t *, const coap_address_t *, coap_proto_t, coap_dtls_cpsk_t *, coap_oscore_conf_t *)"
-- "exceptions": []
-  "name": "coap_new_client_session_oscore_psk"
+- "name": "coap_new_client_session_oscore_psk"
   "params":
   - "name": "ctx"
     "type": "bool "

--- a/benchmark-sets/all/libcue.yaml
+++ b/benchmark-sets/all/libcue.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "cue_parse_file"
+- "name": "cue_parse_file"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "Cd * cue_parse_file(FILE *)"
-- "exceptions": []
-  "name": "track_get_isrc"
+- "name": "track_get_isrc"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "const char * track_get_isrc(const Track *)"
-- "exceptions": []
-  "name": "rem_get"
+- "name": "rem_get"
   "params":
   - "name": ""
     "type": "int"
@@ -22,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * rem_get(RemType, Rem *)"
-- "exceptions": []
-  "name": "cd_get_track"
+- "name": "cd_get_track"
   "params":
   - "name": ""
     "type": "bool "
@@ -31,8 +27,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "Track * cd_get_track(const Cd *, int)"
-- "exceptions": []
-  "name": "cdtext_get"
+- "name": "cdtext_get"
   "params":
   - "name": ""
     "type": "int"

--- a/benchmark-sets/all/libdwarf.yaml
+++ b/benchmark-sets/all/libdwarf.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "dwarf_find_die_given_sig8"
+- "name": "dwarf_find_die_given_sig8"
   "params":
   - "name": "dbg"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int dwarf_find_die_given_sig8(Dwarf_Debug, Dwarf_Sig8 *, Dwarf_Die *, Dwarf_Bool *, Dwarf_Error *)"
-- "exceptions": []
-  "name": "dwarf_debug_addr_index_to_addr"
+- "name": "dwarf_debug_addr_index_to_addr"
   "params":
   - "name": "die"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int dwarf_debug_addr_index_to_addr(Dwarf_Die, Dwarf_Unsigned, Dwarf_Addr *, Dwarf_Error *)"
-- "exceptions": []
-  "name": "dwarf_get_pubtypes"
+- "name": "dwarf_get_pubtypes"
   "params":
   - "name": "dbg"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int dwarf_get_pubtypes(Dwarf_Debug, Dwarf_Global **, Dwarf_Signed *, Dwarf_Error *)"
-- "exceptions": []
-  "name": "dwarf_init_path_a"
+- "name": "dwarf_init_path_a"
   "params":
   - "name": "path"
     "type": "bool "
@@ -63,8 +59,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int dwarf_init_path_a(const char *, char *, unsigned int, unsigned int, unsigned int, Dwarf_Handler, Dwarf_Ptr, Dwarf_Debug *, Dwarf_Error *)"
-- "exceptions": []
-  "name": "dwarf_rnglists_get_rle_head"
+- "name": "dwarf_rnglists_get_rle_head"
   "params":
   - "name": "attr"
     "type": "bool "

--- a/benchmark-sets/all/libevent.yaml
+++ b/benchmark-sets/all/libevent.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "evhttp_accept_socket"
+- "name": "evhttp_accept_socket"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int evhttp_accept_socket(struct evhttp *, int)"
-- "exceptions": []
-  "name": "evhttp_bind_socket_with_handle"
+- "name": "evhttp_bind_socket_with_handle"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "short"
   "return_type": "void"
   "signature": "struct evhttp_bound_socket * evhttp_bind_socket_with_handle(struct evhttp *, const char *, uint16_t)"
-- "exceptions": []
-  "name": "evhttp_accept_socket_with_handle"
+- "name": "evhttp_accept_socket_with_handle"
   "params":
   - "name": ""
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "struct evhttp_bound_socket * evhttp_accept_socket_with_handle(struct evhttp *, int)"
-- "exceptions": []
-  "name": "evhttp_start"
+- "name": "evhttp_start"
   "params":
   - "name": ""
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "short"
   "return_type": "void"
   "signature": "struct evhttp * evhttp_start(const char *, uint16_t)"
-- "exceptions": []
-  "name": "evhttp_bind_socket"
+- "name": "evhttp_bind_socket"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libfdk-aac.yaml
+++ b/benchmark-sets/all/libfdk-aac.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sbrEncoder_Init"
+- "name": "sbrEncoder_Init"
   "params":
   - "name": "hSbrEncoder"
     "type": "bool "
@@ -38,8 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "INT sbrEncoder_Init(HANDLE_SBR_ENCODER, SBR_ELEMENT_INFO *, int, INT_PCM *, UINT, INT *, INT *, INT *, const UINT, INT *, UINT *, INT *, AUDIO_OBJECT_TYPE, int *, int, const int, UINT)"
-- "exceptions": []
-  "name": "aacEncEncode"
+- "name": "aacEncEncode"
   "params":
   - "name": "hAacEncoder"
     "type": "bool "
@@ -53,8 +51,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "AACENC_ERROR aacEncEncode(const HANDLE_AACENCODER, const AACENC_BufDesc *, const AACENC_BufDesc *, const AACENC_InArgs *, AACENC_OutArgs *)"
-- "exceptions": []
-  "name": "sbrEncoder_EncodeFrame"
+- "name": "sbrEncoder_EncodeFrame"
   "params":
   - "name": "hSbrEncoder"
     "type": "bool "
@@ -68,8 +65,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "INT sbrEncoder_EncodeFrame(HANDLE_SBR_ENCODER, INT_PCM *, UINT, UINT *, DW_TAG_array_typeUCHAR *)"
-- "exceptions": []
-  "name": "FDK_drcDec_ReadUniDrc"
+- "name": "FDK_drcDec_ReadUniDrc"
   "params":
   - "name": "hDrcDec"
     "type": "bool "
@@ -77,8 +73,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DRC_DEC_ERROR FDK_drcDec_ReadUniDrc(HANDLE_DRC_DECODER, HANDLE_FDK_BITSTREAM)"
-- "exceptions": []
-  "name": "FDKaacEnc_EncodeFrame"
+- "name": "FDKaacEnc_EncodeFrame"
   "params":
   - "name": "hAacEnc"
     "type": "bool "

--- a/benchmark-sets/all/libfido2.yaml
+++ b/benchmark-sets/all/libfido2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mutate"
+- "name": "mutate"
   "params":
   - "name": "p"
     "type": "bool "
@@ -10,15 +9,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void mutate(struct param *, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "mutate_blob"
+- "name": "mutate_blob"
   "params":
   - "name": "blob"
     "type": "bool "
   "return_type": "void"
   "signature": "void mutate_blob(struct blob *)"
-- "exceptions": []
-  "name": "pack_dummy"
+- "name": "pack_dummy"
   "params":
   - "name": "ptr"
     "type": "bool "
@@ -26,15 +23,13 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "size_t pack_dummy(uint8_t *, size_t)"
-- "exceptions": []
-  "name": "mutate_string"
+- "name": "mutate_string"
   "params":
   - "name": "s"
     "type": "bool "
   "return_type": "void"
   "signature": "void mutate_string(char *)"
-- "exceptions": []
-  "name": "mutate_int"
+- "name": "mutate_int"
   "params":
   - "name": "i"
     "type": "bool "

--- a/benchmark-sets/all/libfuse.yaml
+++ b/benchmark-sets/all/libfuse.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "fuse_opt_match"
+- "name": "fuse_opt_match"
   "params":
   - "name": "opts"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int fuse_opt_match(const struct fuse_opt *, const char *)"
-- "exceptions": []
-  "name": "af_gb_alloc_data"
+- "name": "af_gb_alloc_data"
   "params":
   - "name": "len"
     "type": "size_t"
   "return_type": "void"
   "signature": "char * af_gb_alloc_data(size_t)"
-- "exceptions": []
-  "name": "fuse_opt_add_opt_escaped"
+- "name": "fuse_opt_add_opt_escaped"
   "params":
   - "name": "opts"
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int fuse_opt_add_opt_escaped(char **, const char *)"
-- "exceptions": []
-  "name": "fuse_opt_add_opt"
+- "name": "fuse_opt_add_opt"
   "params":
   - "name": "opts"
     "type": "bool "

--- a/benchmark-sets/all/libhevc.yaml
+++ b/benchmark-sets/all/libhevc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ihevce_put_sei_msg"
+- "name": "ihevce_put_sei_msg"
   "params":
   - "name": "e_payload_type"
     "type": "int"
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "WORD32 ihevce_put_sei_msg(IHEVCE_SEI_TYPE, sei_params_t *, vui_t *, bitstrm_t *, UWORD32, UWORD8 *)"
-- "exceptions": []
-  "name": "ihevce_generate_sei"
+- "name": "ihevce_generate_sei"
   "params":
   - "name": "ps_bitstrm"
     "type": "bool "
@@ -35,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "WORD32 ihevce_generate_sei(bitstrm_t *, sei_params_t *, vui_t *, WORD32, WORD32, UWORD32, sei_payload_t *)"
-- "exceptions": []
-  "name": "add_picture_to_stack"
+- "name": "add_picture_to_stack"
   "params":
   - "name": "rate_control_api"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void add_picture_to_stack(rate_control_api_t *, WORD32, WORD32)"
-- "exceptions": []
-  "name": "add_pic_to_stack"
+- "name": "add_pic_to_stack"
   "params":
   - "name": "ps_pic_handling"
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void add_pic_to_stack(pic_handling_t *, WORD32, WORD32)"
-- "exceptions": []
-  "name": "ihevce_get_i_to_avg_ratio"
+- "name": "ihevce_get_i_to_avg_ratio"
   "params":
   - "name": "pv_rc_ctxt"
     "type": "bool "

--- a/benchmark-sets/all/libical.yaml
+++ b/benchmark-sets/all/libical.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "icalcomponent_foreach_recurrence"
+- "name": "icalcomponent_foreach_recurrence"
   "params":
   - "name": "comp"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icalcomponent_foreach_recurrence(icalcomponent *, struct icaltimetype, struct icaltimetype, DW_TAG_subroutine_typeInfinite loop *, void *)"
-- "exceptions": []
-  "name": "icalcomponent_set_due"
+- "name": "icalcomponent_set_due"
   "params":
   - "name": "comp"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icalcomponent_set_due(icalcomponent *, struct icaltimetype)"
-- "exceptions": []
-  "name": "icaltimezone_truncate_vtimezone"
+- "name": "icaltimezone_truncate_vtimezone"
   "params":
   - "name": "vtz"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void icaltimezone_truncate_vtimezone(icalcomponent *, icaltimetype, icaltimetype, int)"
-- "exceptions": []
-  "name": "icalcomponent_merge_component"
+- "name": "icalcomponent_merge_component"
   "params":
   - "name": "comp"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icalcomponent_merge_component(icalcomponent *, icalcomponent *)"
-- "exceptions": []
-  "name": "icalcomponent_get_span"
+- "name": "icalcomponent_get_span"
   "params":
   - "name": "comp"
     "type": "bool "

--- a/benchmark-sets/all/libiec61850.yaml
+++ b/benchmark-sets/all/libiec61850.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "MmsValue_newDefaultValue"
+- "name": "MmsValue_newDefaultValue"
   "params":
   - "name": "typeSpec"
     "type": "bool "
   "return_type": "void"
   "signature": "MmsValue * MmsValue_newDefaultValue(const MmsVariableSpecification *)"
-- "exceptions": []
-  "name": "MmsValue_encodeMmsData"
+- "name": "MmsValue_encodeMmsData"
   "params":
   - "name": "self"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "int MmsValue_encodeMmsData(MmsValue *, uint8_t *, int, bool)"
-- "exceptions": []
-  "name": "MmsValue_createArray"
+- "name": "MmsValue_createArray"
   "params":
   - "name": "elementType"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "MmsValue * MmsValue_createArray(const MmsVariableSpecification *, int)"
-- "exceptions": []
-  "name": "MmsValue_printToBuffer"
+- "name": "MmsValue_printToBuffer"
   "params":
   - "name": "self"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "const char * MmsValue_printToBuffer(const MmsValue *, char *, int)"
-- "exceptions": []
-  "name": "MmsValue_newStructure"
+- "name": "MmsValue_newStructure"
   "params":
   - "name": "typeSpec"
     "type": "bool "

--- a/benchmark-sets/all/libjpeg-turbo.yaml
+++ b/benchmark-sets/all/libjpeg-turbo.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "tjEncodeYUV"
+- "name": "tjEncodeYUV"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -22,8 +21,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int tjEncodeYUV(tjhandle, unsigned char *, int, int, int, int, unsigned char *, int, int)"
-- "exceptions": []
-  "name": "tjCompress"
+- "name": "tjCompress"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -49,8 +47,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int tjCompress(tjhandle, unsigned char *, int, int, int, int, unsigned char *, unsigned long *, int, int, int)"
-- "exceptions": []
-  "name": "tjDecompressToYUV"
+- "name": "tjDecompressToYUV"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -64,8 +61,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int tjDecompressToYUV(tjhandle, unsigned char *, unsigned long, unsigned char *, int)"
-- "exceptions": []
-  "name": "tj3SaveImage16"
+- "name": "tj3SaveImage16"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -83,8 +79,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int tj3SaveImage16(tjhandle, const char *, const J16SAMPLE *, int, int, int, int)"
-- "exceptions": []
-  "name": "tjDecompress"
+- "name": "tjDecompress"
   "params":
   - "name": "handle"
     "type": "bool "

--- a/benchmark-sets/all/libjxl.yaml
+++ b/benchmark-sets/all/libjxl.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "JxlEncoderFlushInput"
+- "name": "JxlEncoderFlushInput"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "JxlEncoderStatus JxlEncoderFlushInput(JxlEncoder *)"
-- "exceptions": []
-  "name": "_ZN3jxl6extras14EncodeImageJXLERKNS0_17JXLCompressParamsERKNS0_15PackedPixelFileEPKNSt3__16vectorIhNS7_9allocatorIhEEEEPSB_"
+- "name": "_ZN3jxl6extras14EncodeImageJXLERKNS0_17JXLCompressParamsERKNS0_15PackedPixelFileEPKNSt3__16vectorIhNS7_9allocatorIhEEEEPSB_"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool jxl::extras::EncodeImageJXL(const struct JXLCompressParams &, const PackedPixelFile &, const vector<unsigned char, std::__1::allocator<unsigned char> > *, vector<unsigned char, std::__1::allocator<unsigned char> > *)"
-- "exceptions": []
-  "name": "JxlEncoderAddChunkedFrame"
+- "name": "JxlEncoderAddChunkedFrame"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "JxlEncoderStatus JxlEncoderAddChunkedFrame(const JxlEncoderFrameSettings *, int, struct JxlChunkedFrameInputSource)"
-- "exceptions": []
-  "name": "_ZN3jxl4test9RoundtripEPNS_10CodecInOutERKNS_14CompressParamsENS_6extras19JXLDecompressParamsES2_RNSt3__118basic_stringstreamIcNS8_11char_traitsIcEENS8_9allocatorIcEEEEPmPNS_10ThreadPoolE"
+- "name": "_ZN3jxl4test9RoundtripEPNS_10CodecInOutERKNS_14CompressParamsENS_6extras19JXLDecompressParamsES2_RNSt3__118basic_stringstreamIcNS8_11char_traitsIcEENS8_9allocatorIcEEEEPmPNS_10ThreadPoolE"
   "params":
   - "name": ""
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool jxl::test::Roundtrip(CodecInOut *, const struct CompressParams &, struct JXLDecompressParams, DW_TAG_restrict_typeCodecInOut *, stringstream &, size_t *, ThreadPool *)"
-- "exceptions": []
-  "name": "_ZN3jxl4test9RoundtripERKNS_6extras15PackedPixelFileERKNS1_17JXLCompressParamsENS1_19JXLDecompressParamsEPNS_10ThreadPoolEPS2_"
+- "name": "_ZN3jxl4test9RoundtripERKNS_6extras15PackedPixelFileERKNS1_17JXLCompressParamsENS1_19JXLDecompressParamsEPNS_10ThreadPoolEPS2_"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libldac.yaml
+++ b/benchmark-sets/all/libldac.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ldacBT_set_eqmid_core"
+- "name": "ldacBT_set_eqmid_core"
   "params":
   - "name": "hLdacBT"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void ldacBT_set_eqmid_core(HANDLE_LDAC_BT, int)"
-- "exceptions": []
-  "name": "ldaclib_check_nlnn_shift"
+- "name": "ldaclib_check_nlnn_shift"
   "params":
   - "name": "smplrate_id"
     "type": "int"
@@ -17,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "LDAC_RESULT ldaclib_check_nlnn_shift(int, int)"
-- "exceptions": []
-  "name": "ldacBT_alter_eqmid_priority"
+- "name": "ldacBT_alter_eqmid_priority"
   "params":
   - "name": "hLdacBT"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int ldacBT_alter_eqmid_priority(HANDLE_LDAC_BT, int)"
-- "exceptions": []
-  "name": "ldacBT_set_eqmid"
+- "name": "ldacBT_set_eqmid"
   "params":
   - "name": "hLdacBT"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int ldacBT_set_eqmid(HANDLE_LDAC_BT, int)"
-- "exceptions": []
-  "name": "ldacBT_get_error_code"
+- "name": "ldacBT_get_error_code"
   "params":
   - "name": "hLdacBT"
     "type": "bool "

--- a/benchmark-sets/all/liblouis.yaml
+++ b/benchmark-sets/all/liblouis.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_lou_defaultTableResolver"
+- "name": "_lou_defaultTableResolver"
   "params":
   - "name": "tableList"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char ** _lou_defaultTableResolver(const char *, const char *)"
-- "exceptions": []
-  "name": "lou_getEmphClasses"
+- "name": "lou_getEmphClasses"
   "params":
   - "name": "tableList"
     "type": "bool "
   "return_type": "void"
   "signature": "const char ** lou_getEmphClasses(const char *)"
-- "exceptions": []
-  "name": "lou_getTypeformForEmphClass"
+- "name": "lou_getTypeformForEmphClass"
   "params":
   - "name": "tableList"
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "short"
   "signature": "formtype lou_getTypeformForEmphClass(const char *, const char *)"
-- "exceptions": []
-  "name": "lou_translatePrehyphenated"
+- "name": "lou_translatePrehyphenated"
   "params":
   - "name": "tableList"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int lou_translatePrehyphenated(const char *, const widechar *, int *, widechar *, int *, formtype *, char *, int *, int *, int *, char *, char *, int)"
-- "exceptions": []
-  "name": "lou_hyphenate"
+- "name": "lou_hyphenate"
   "params":
   - "name": "tableList"
     "type": "bool "

--- a/benchmark-sets/all/libmodbus.yaml
+++ b/benchmark-sets/all/libmodbus.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "modbus_read_input_registers"
+- "name": "modbus_read_input_registers"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int modbus_read_input_registers(modbus_t *, int, int, uint16_t *)"
-- "exceptions": []
-  "name": "modbus_write_bits"
+- "name": "modbus_write_bits"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int modbus_write_bits(modbus_t *, int, int, const uint8_t *)"
-- "exceptions": []
-  "name": "modbus_write_and_read_registers"
+- "name": "modbus_write_and_read_registers"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int modbus_write_and_read_registers(modbus_t *, int, int, const uint16_t *, int, int, uint16_t *)"
-- "exceptions": []
-  "name": "modbus_reply"
+- "name": "modbus_reply"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int modbus_reply(modbus_t *, const uint8_t *, int, modbus_mapping_t *)"
-- "exceptions": []
-  "name": "modbus_read_input_bits"
+- "name": "modbus_read_input_bits"
   "params":
   - "name": "ctx"
     "type": "bool "

--- a/benchmark-sets/all/libmpeg2.yaml
+++ b/benchmark-sets/all/libmpeg2.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "impeg2_buf_mgr_get_num_active_buf"
+- "name": "impeg2_buf_mgr_get_num_active_buf"
   "params":
   - "name": "ps_buf_mgr"
     "type": "bool "
   "return_type": "int"
   "signature": "UWORD32 impeg2_buf_mgr_get_num_active_buf(buf_mgr_t *)"
-- "exceptions": []
-  "name": "impeg2_jobq_free"
+- "name": "impeg2_jobq_free"
   "params":
   - "name": "ps_jobq"
     "type": "bool "
   "return_type": "int"
   "signature": "IV_API_CALL_STATUS_T impeg2_jobq_free(jobq_t *)"
-- "exceptions": []
-  "name": "impeg2_buf_mgr_get_buf"
+- "name": "impeg2_buf_mgr_get_buf"
   "params":
   - "name": "ps_buf_mgr"
     "type": "bool "
@@ -22,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void * impeg2_buf_mgr_get_buf(buf_mgr_t *, WORD32)"
-- "exceptions": []
-  "name": "impeg2_buf_mgr_get_status"
+- "name": "impeg2_buf_mgr_get_status"
   "params":
   - "name": "ps_buf_mgr"
     "type": "bool "

--- a/benchmark-sets/all/libpcap.yaml
+++ b/benchmark-sets/all/libpcap.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "pcap_findalldevs_ex"
+- "name": "pcap_findalldevs_ex"
   "params":
   - "name": "source"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int pcap_findalldevs_ex(const char *, struct pcap_rmtauth *, pcap_if_t **, char *)"
-- "exceptions": []
-  "name": "pcap_compile_nopcap"
+- "name": "pcap_compile_nopcap"
   "params":
   - "name": "snaplen_arg"
     "type": "int"
@@ -29,8 +27,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int pcap_compile_nopcap(int, int, struct bpf_program *, const char *, int, bpf_u_int32)"
-- "exceptions": []
-  "name": "pcap_open"
+- "name": "pcap_open"
   "params":
   - "name": "source"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "pcap_t * pcap_open(const char *, int, int, int, struct pcap_rmtauth *, char *)"
-- "exceptions": []
-  "name": "pcap_findalldevs"
+- "name": "pcap_findalldevs"
   "params":
   - "name": "alldevsp"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int pcap_findalldevs(pcap_if_t **, char *)"
-- "exceptions": []
-  "name": "pcap_lookupdev"
+- "name": "pcap_lookupdev"
   "params":
   - "name": "errbuf"
     "type": "bool "

--- a/benchmark-sets/all/libpg_query.yaml
+++ b/benchmark-sets/all/libpg_query.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "pg_query_parse_protobuf_opts"
+- "name": "pg_query_parse_protobuf_opts"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "PgQueryProtobufParseResult pg_query_parse_protobuf_opts(const char *, int)"
-- "exceptions": []
-  "name": "raw_expression_tree_walker_impl"
+- "name": "raw_expression_tree_walker_impl"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool raw_expression_tree_walker_impl(Node *, tree_walker_callback, void *)"
-- "exceptions": []
-  "name": "GenerationRealloc"
+- "name": "GenerationRealloc"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void * GenerationRealloc(void *, Size)"
-- "exceptions": []
-  "name": "pg_query_parse_protobuf"
+- "name": "pg_query_parse_protobuf"
   "params":
   - "name": ""
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "PgQueryProtobufParseResult pg_query_parse_protobuf(const char *)"
-- "exceptions": []
-  "name": "SlabAlloc"
+- "name": "SlabAlloc"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libphonenumber.yaml
+++ b/benchmark-sets/all/libphonenumber.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6icu_6612RegexMatcherC2ERKNS_13UnicodeStringES3_jR10UErrorCode"
+- "name": "_ZN6icu_6612RegexMatcherC2ERKNS_13UnicodeStringES3_jR10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icu_66::RegexMatcher::RegexMatcher(const UnicodeString &, const UnicodeString &, uint32_t, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZN6icu_6612RegexPattern7matchesERKNS_13UnicodeStringES3_R11UParseErrorR10UErrorCode"
+- "name": "_ZN6icu_6612RegexPattern7matchesERKNS_13UnicodeStringES3_R11UParseErrorR10UErrorCode"
   "params":
   - "name": "regex"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "char"
   "signature": "UBool icu_66::RegexPattern::matches(const UnicodeString &, const UnicodeString &, UParseError &, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZN6icu_6612RegexPattern7matchesEP5UTextS2_R11UParseErrorR10UErrorCode"
+- "name": "_ZN6icu_6612RegexPattern7matchesEP5UTextS2_R11UParseErrorR10UErrorCode"
   "params":
   - "name": "regex"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "char"
   "signature": "UBool icu_66::RegexPattern::matches(UText *, UText *, UParseError &, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZN6icu_6612RegexMatcherC2EP5UTextjR10UErrorCode"
+- "name": "_ZN6icu_6612RegexMatcherC2EP5UTextjR10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void icu_66::RegexMatcher::RegexMatcher(UText *, uint32_t, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZN6icu_6612RegexMatcherC2ERKNS_13UnicodeStringEjR10UErrorCode"
+- "name": "_ZN6icu_6612RegexMatcherC2ERKNS_13UnicodeStringEjR10UErrorCode"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/libplist.yaml
+++ b/benchmark-sets/all/libplist.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "plist_read_from_file"
+- "name": "plist_read_from_file"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -10,15 +9,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "plist_err_t plist_read_from_file(const char *, plist_t *, plist_format_t *)"
-- "exceptions": []
-  "name": "plist_print"
+- "name": "plist_print"
   "params":
   - "name": "plist"
     "type": "bool "
   "return_type": "void"
   "signature": "void plist_print(plist_t)"
-- "exceptions": []
-  "name": "plist_from_memory"
+- "name": "plist_from_memory"
   "params":
   - "name": "plist_data"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "plist_err_t plist_from_memory(const char *, uint32_t, plist_t *, plist_format_t *)"
-- "exceptions": []
-  "name": "plist_write_to_file"
+- "name": "plist_write_to_file"
   "params":
   - "name": "plist"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "plist_err_t plist_write_to_file(plist_t, const char *, plist_format_t, plist_write_options_t)"
-- "exceptions": []
-  "name": "plist_write_to_stream"
+- "name": "plist_write_to_stream"
   "params":
   - "name": "plist"
     "type": "bool "

--- a/benchmark-sets/all/libpsl.yaml
+++ b/benchmark-sets/all/libpsl.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6icu_597CaseMap7toLowerEPKcjPKDsiPDsiPNS_5EditsER10UErrorCode"
+- "name": "_ZN6icu_597CaseMap7toLowerEPKcjPKDsiPDsiPNS_5EditsER10UErrorCode"
   "params":
   - "name": "locale"
     "type": "bool "
@@ -20,15 +19,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int32_t icu_59::CaseMap::toLower(const char *, uint32_t, const UChar *, int32_t, UChar *, int32_t, Edits *, UErrorCode &)"
-- "exceptions": []
-  "name": "_ZNK6icu_596Locale7getLCIDEv"
+- "name": "_ZNK6icu_596Locale7getLCIDEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "int"
   "signature": "uint32_t icu_59::Locale::getLCID()"
-- "exceptions": []
-  "name": "_ZNK6icu_5920UnicodeSetStringSpan12spanBackUTF8EPKhi17USetSpanCondition"
+- "name": "_ZNK6icu_5920UnicodeSetStringSpan12spanBackUTF8EPKhi17USetSpanCondition"
   "params":
   - "name": "this"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int32_t icu_59::UnicodeSetStringSpan::spanBackUTF8(const uint8_t *, int32_t, USetSpanCondition)"
-- "exceptions": []
-  "name": "_ZN6icu_597CaseMap7toUpperEPKcjPKDsiPDsiPNS_5EditsER10UErrorCode"
+- "name": "_ZN6icu_597CaseMap7toUpperEPKcjPKDsiPDsiPNS_5EditsER10UErrorCode"
   "params":
   - "name": "locale"
     "type": "bool "

--- a/benchmark-sets/all/libraw.yaml
+++ b/benchmark-sets/all/libraw.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6LibRaw14selectCRXTrackEv"
+- "name": "_ZN6LibRaw14selectCRXTrackEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void LibRaw::selectCRXTrack()"
-- "exceptions": []
-  "name": "_ZN6LibRaw17crxLoadDecodeLoopEPvi"
+- "name": "_ZN6LibRaw17crxLoadDecodeLoopEPvi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void LibRaw::crxLoadDecodeLoop(void *, int)"
-- "exceptions": []
-  "name": "_ZN6LibRaw13parseCR3_CTMDEs"
+- "name": "_ZN6LibRaw13parseCR3_CTMDEs"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,15 +23,13 @@
     "type": "short"
   "return_type": "int"
   "signature": "int LibRaw::parseCR3_CTMD(short)"
-- "exceptions": []
-  "name": "_ZN6LibRaw13sraw_midpointEv"
+- "name": "_ZN6LibRaw13sraw_midpointEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "int"
   "signature": "int LibRaw::sraw_midpoint()"
-- "exceptions": []
-  "name": "_ZN6LibRaw14crxDecodePlaneEPvj"
+- "name": "_ZN6LibRaw14crxDecodePlaneEPvj"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/librawspeed.yaml
+++ b/benchmark-sets/all/librawspeed.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8rawspeed15VC5Decompressor7Wavelet18combineLowHighPassENS_10Array2DRefIKsEES4_ibb"
+- "name": "_ZN8rawspeed15VC5Decompressor7Wavelet18combineLowHighPassENS_10Array2DRefIKsEES4_ibb"
   "params":
   - "name": "low"
     "type": "bool "
@@ -16,15 +15,13 @@
     "type": "bool"
   "return_type": "void"
   "signature": "struct BandData rawspeed::VC5Decompressor::Wavelet::combineLowHighPass(const Array2DRef<const short>, const Array2DRef<const short>, int, bool, bool)"
-- "exceptions": []
-  "name": "_ZN8rawspeed15RawImageDataU1615scaleBlackWhiteEv"
+- "name": "_ZN8rawspeed15RawImageDataU1615scaleBlackWhiteEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void rawspeed::RawImageDataU16::scaleBlackWhite()"
-- "exceptions": []
-  "name": "_ZN8rawspeed10DngDecoder17decodeRawInternalEv"
+- "name": "_ZN8rawspeed10DngDecoder17decodeRawInternalEv"
   "params":
   - "name": ""
     "type": "bool "
@@ -32,15 +29,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "RawImage rawspeed::DngDecoder::decodeRawInternal()"
-- "exceptions": []
-  "name": "_ZN8rawspeed10Cr2Decoder15sRawInterpolateEv"
+- "name": "_ZN8rawspeed10Cr2Decoder15sRawInterpolateEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void rawspeed::Cr2Decoder::sRawInterpolate()"
-- "exceptions": []
-  "name": "_ZN8rawspeed15VC5Decompressor7Wavelet15reconstructPassENS_10Array2DRefIKsEES4_"
+- "name": "_ZN8rawspeed15VC5Decompressor7Wavelet15reconstructPassENS_10Array2DRefIKsEES4_"
   "params":
   - "name": "high"
     "type": "bool "

--- a/benchmark-sets/all/librdkafka.yaml
+++ b/benchmark-sets/all/librdkafka.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "re_regexec"
+- "name": "re_regexec"
   "params":
   - "name": "prog"
     "type": "bool "

--- a/benchmark-sets/all/libsndfile.yaml
+++ b/benchmark-sets/all/libsndfile.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sf_open"
+- "name": "sf_open"
   "params":
   - "name": "path"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "SNDFILE * sf_open(const char *, int, SF_INFO *)"
-- "exceptions": []
-  "name": "sf_command"
+- "name": "sf_command"
   "params":
   - "name": "sndfile"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sf_command(SNDFILE *, int, void *, int)"
-- "exceptions": []
-  "name": "sf_open_fd"
+- "name": "sf_open_fd"
   "params":
   - "name": "fd"
     "type": "int"
@@ -36,8 +33,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "SNDFILE * sf_open_fd(int, int, SF_INFO *, int)"
-- "exceptions": []
-  "name": "sf_get_chunk_iterator"
+- "name": "sf_get_chunk_iterator"
   "params":
   - "name": "sndfile"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "SF_CHUNK_ITERATOR * sf_get_chunk_iterator(SNDFILE *, const SF_CHUNK_INFO *)"
-- "exceptions": []
-  "name": "sf_set_string"
+- "name": "sf_set_string"
   "params":
   - "name": "sndfile"
     "type": "bool "

--- a/benchmark-sets/all/libsodium.yaml
+++ b/benchmark-sets/all/libsodium.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "blake2b_compress_sse41"
+- "name": "blake2b_compress_sse41"
   "params":
   - "name": "S"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int blake2b_compress_sse41(blake2b_state *, const uint8_t *)"
-- "exceptions": []
-  "name": "argon2_initialize"
+- "name": "argon2_initialize"
   "params":
   - "name": "instance"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int argon2_initialize(argon2_instance_t *, argon2_context *)"
-- "exceptions": []
-  "name": "blake2b_compress_avx2"
+- "name": "blake2b_compress_avx2"
   "params":
   - "name": "S"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int blake2b_compress_avx2(blake2b_state *, const uint8_t *)"
-- "exceptions": []
-  "name": "argon2_finalize"
+- "name": "argon2_finalize"
   "params":
   - "name": "context"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void argon2_finalize(const argon2_context *, argon2_instance_t *)"
-- "exceptions": []
-  "name": "ge25519_from_hash"
+- "name": "ge25519_from_hash"
   "params":
   - "name": "s"
     "type": "bool "

--- a/benchmark-sets/all/libspng.yaml
+++ b/benchmark-sets/all/libspng.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "spng_set_splt"
+- "name": "spng_set_splt"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int spng_set_splt(spng_ctx *, struct spng_splt *, uint32_t)"
-- "exceptions": []
-  "name": "spng_set_text"
+- "name": "spng_set_text"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int spng_set_text(spng_ctx *, struct spng_text *, uint32_t)"
-- "exceptions": []
-  "name": "LLVMFuzzerCustomCrossOver"
+- "name": "LLVMFuzzerCustomCrossOver"
   "params":
   - "name": "Data1"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "size_t LLVMFuzzerCustomCrossOver(const uint8_t *, size_t, const uint8_t *, size_t, uint8_t *, size_t, unsigned int)"
-- "exceptions": []
-  "name": "LLVMFuzzerCustomMutator"
+- "name": "LLVMFuzzerCustomMutator"
   "params":
   - "name": "Data"
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "size_t LLVMFuzzerCustomMutator(uint8_t *, size_t, size_t, unsigned int)"
-- "exceptions": []
-  "name": "_ZN10PngMutatorC2ERNSt3__113basic_istreamIcNS0_11char_traitsIcEEEE"
+- "name": "_ZN10PngMutatorC2ERNSt3__113basic_istreamIcNS0_11char_traitsIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/libssh.yaml
+++ b/benchmark-sets/all/libssh.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ssh_userauth_agent_pubkey"
+- "name": "ssh_userauth_agent_pubkey"
   "params":
   - "name": "session"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ssh_userauth_agent_pubkey(ssh_session, const char *, ssh_public_key)"
-- "exceptions": []
-  "name": "ssh_agent_get_first_ident"
+- "name": "ssh_agent_get_first_ident"
   "params":
   - "name": "session"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "ssh_key ssh_agent_get_first_ident(struct ssh_session_struct *, char **)"
-- "exceptions": []
-  "name": "ssh_userauth_publickey"
+- "name": "ssh_userauth_publickey"
   "params":
   - "name": "session"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ssh_userauth_publickey(ssh_session, const char *, const ssh_key)"
-- "exceptions": []
-  "name": "ssh_userauth_agent"
+- "name": "ssh_userauth_agent"
   "params":
   - "name": "session"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ssh_userauth_agent(ssh_session, const char *)"
-- "exceptions": []
-  "name": "ssh_userauth_publickey_auto"
+- "name": "ssh_userauth_publickey_auto"
   "params":
   - "name": "session"
     "type": "bool "

--- a/benchmark-sets/all/libssh2.yaml
+++ b/benchmark-sets/all/libssh2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "libssh2_session_startup"
+- "name": "libssh2_session_startup"
   "params":
   - "name": "session"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "int"
   "return_type": "int"
   "signature": "int libssh2_session_startup(LIBSSH2_SESSION *, int)"
-- "exceptions": []
-  "name": "libssh2_channel_forward_cancel"
+- "name": "libssh2_channel_forward_cancel"
   "params":
   - "name": "listener"
     "type": "bool "
   "return_type": "int"
   "signature": "int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *)"
-- "exceptions": []
-  "name": "libssh2_channel_read_ex"
+- "name": "libssh2_channel_read_ex"
   "params":
   - "name": "channel"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *, int, char *, size_t)"
-- "exceptions": []
-  "name": "libssh2_channel_direct_tcpip_ex"
+- "name": "libssh2_channel_direct_tcpip_ex"
   "params":
   - "name": "session"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "LIBSSH2_CHANNEL * libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *, const char *, int, const char *, int)"
-- "exceptions": []
-  "name": "libssh2_channel_direct_streamlocal_ex"
+- "name": "libssh2_channel_direct_streamlocal_ex"
   "params":
   - "name": "session"
     "type": "bool "

--- a/benchmark-sets/all/libstdcpp.yaml
+++ b/benchmark-sets/all/libstdcpp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6assignEPKc"
+- "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6assignEPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "basic_string<char, std::char_traits<char>, std::allocator<char> > & std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::assign(basic_string<char, std::char_traits<char>, std::allocator<char> > *, const char *)"
-- "exceptions": []
-  "name": "_ZNSt9__unicode9__v15_1_022_Grapheme_cluster_viewISt17basic_string_viewIcSt11char_traitsIcEEE9_IteratorppEv"
+- "name": "_ZNSt9__unicode9__v15_1_022_Grapheme_cluster_viewISt17basic_string_viewIcSt11char_traitsIcEEE9_IteratorppEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "struct _Iterator & std::__unicode::__v15_1_0::_Grapheme_cluster_view<std::basic_string_view<char, std::char_traits<char> > >::_Iterator::operator++(struct _Iterator *)"
-- "exceptions": []
-  "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEaSEPKc"
+- "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEaSEPKc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "basic_string<char, std::char_traits<char>, std::allocator<char> > & std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator=(basic_string<char, std::char_traits<char>, std::allocator<char> > *, const char *)"
-- "exceptions": []
-  "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6insertEmmc"
+- "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6insertEmmc"
   "params":
   - "name": "this"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "char"
   "return_type": "void"
   "signature": "basic_string<char, std::char_traits<char>, std::allocator<char> > & std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::insert(basic_string<char, std::char_traits<char>, std::allocator<char> > *, size_type, size_type, char)"
-- "exceptions": []
-  "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEmc"
+- "name": "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEmc"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/libtasn1.yaml
+++ b/benchmark-sets/all/libtasn1.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "asn1_delete_structure2"
+- "name": "asn1_delete_structure2"
   "params":
   - "name": "structure"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int asn1_delete_structure2(asn1_node *, unsigned int)"
-- "exceptions": []
-  "name": "asn1_parser2array"
+- "name": "asn1_parser2array"
   "params":
   - "name": "inputFileName"
     "type": "bool "

--- a/benchmark-sets/all/libteken.yaml
+++ b/benchmark-sets/all/libteken.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "teken_get_sequence"
+- "name": "teken_get_sequence"
   "params":
   - "name": "t"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "const char * teken_get_sequence(const teken_t *, unsigned int)"
-- "exceptions": []
-  "name": "teken_set_winsize_noreset"
+- "name": "teken_set_winsize_noreset"
   "params":
   - "name": "t"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void teken_set_winsize_noreset(teken_t *, const teken_pos_t *)"
-- "exceptions": []
-  "name": "teken_set_cursor"
+- "name": "teken_set_cursor"
   "params":
   - "name": "t"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void teken_set_cursor(teken_t *, const teken_pos_t *)"
-- "exceptions": []
-  "name": "teken_state_2"
+- "name": "teken_state_2"
   "params":
   - "name": "t"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void teken_state_2(teken_t *, teken_char_t)"
-- "exceptions": []
-  "name": "teken_get_defattr_cons25"
+- "name": "teken_get_defattr_cons25"
   "params":
   - "name": "t"
     "type": "bool "

--- a/benchmark-sets/all/libtheora.yaml
+++ b/benchmark-sets/all/libtheora.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "th_decode_ctl"
+- "name": "th_decode_ctl"
   "params":
   - "name": "_dec"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int th_decode_ctl(th_dec_ctx *, int, void *, size_t)"
-- "exceptions": []
-  "name": "oc_state_frag_recon_c"
+- "name": "oc_state_frag_recon_c"
   "params":
   - "name": "_state"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "short"
   "return_type": "void"
   "signature": "void oc_state_frag_recon_c(const oc_theora_state *, ptrdiff_t, int, ogg_int16_t *, int, ogg_uint16_t)"
-- "exceptions": []
-  "name": "_ZN7fuzzing10datasource10Datasource3getEmmm"
+- "name": "_ZN7fuzzing10datasource10Datasource3getEmmm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "vector<unsigned char, std::__1::allocator<unsigned char> > fuzzing::datasource::Datasource::get(const size_t, const size_t, const uint64_t)"
-- "exceptions": []
-  "name": "oc_state_loop_filter_frag_rows_c"
+- "name": "oc_state_loop_filter_frag_rows_c"
   "params":
   - "name": "_state"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void oc_state_loop_filter_frag_rows_c(const oc_theora_state *, signed char *, int, int, int, int)"
-- "exceptions": []
-  "name": "th_comment_query"
+- "name": "th_comment_query"
   "params":
   - "name": "_tc"
     "type": "bool "

--- a/benchmark-sets/all/libtiff.yaml
+++ b/benchmark-sets/all/libtiff.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "TIFFOpenExt"
+- "name": "TIFFOpenExt"
   "params":
   - "name": "name"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "TIFF * TIFFOpenExt(const char *, const char *, TIFFOpenOptions *)"
-- "exceptions": []
-  "name": "TIFFFdOpenExt"
+- "name": "TIFFFdOpenExt"
   "params":
   - "name": "fd"
     "type": "int"
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "TIFF * TIFFFdOpenExt(int, const char *, const char *, TIFFOpenOptions *)"
-- "exceptions": []
-  "name": "TIFFSetSubDirectory"
+- "name": "TIFFSetSubDirectory"
   "params":
   - "name": "tif"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int TIFFSetSubDirectory(TIFF *, uint64_t)"
-- "exceptions": []
-  "name": "TIFFOpen"
+- "name": "TIFFOpen"
   "params":
   - "name": "name"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "TIFF * TIFFOpen(const char *, const char *)"
-- "exceptions": []
-  "name": "TIFFFdOpen"
+- "name": "TIFFFdOpen"
   "params":
   - "name": "fd"
     "type": "int"

--- a/benchmark-sets/all/libtpms.yaml
+++ b/benchmark-sets/all/libtpms.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "TPM_Process_SetCapability"
+- "name": "TPM_Process_SetCapability"
   "params":
   - "name": "tpm_state"
     "type": "bool "
@@ -18,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RESULT TPM_Process_SetCapability(tpm_state_t *, TPM_STORE_BUFFER *, TPM_TAG, uint32_t, TPM_COMMAND_CODE, unsigned char *, TPM_TRANSPORT_INTERNAL *)"
-- "exceptions": []
-  "name": "TPM2_Create"
+- "name": "TPM2_Create"
   "params":
   - "name": "in"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Create(Create_In *, Create_Out *)"
-- "exceptions": []
-  "name": "TPM_Process_GetCapabilitySigned"
+- "name": "TPM_Process_GetCapabilitySigned"
   "params":
   - "name": "tpm_state"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RESULT TPM_Process_GetCapabilitySigned(tpm_state_t *, TPM_STORE_BUFFER *, TPM_TAG, uint32_t, TPM_COMMAND_CODE, unsigned char *, TPM_TRANSPORT_INTERNAL *)"
-- "exceptions": []
-  "name": "TPM_Process_GetCapability"
+- "name": "TPM_Process_GetCapability"
   "params":
   - "name": "tpm_state"
     "type": "bool "

--- a/benchmark-sets/all/libtsm.yaml
+++ b/benchmark-sets/all/libtsm.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "tsm_symbol_append"
+- "name": "tsm_symbol_append"
   "params":
   - "name": "tbl"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "tsm_symbol_t tsm_symbol_append(struct tsm_symbol_table *, tsm_symbol_t, uint32_t)"
-- "exceptions": []
-  "name": "tsm_vte_set_palette"
+- "name": "tsm_vte_set_palette"
   "params":
   - "name": "vte"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int tsm_vte_set_palette(struct tsm_vte *, const char *)"
-- "exceptions": []
-  "name": "shl_htable_insert"
+- "name": "shl_htable_insert"
   "params":
   - "name": "htable"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int shl_htable_insert(struct shl_htable *, const void *, size_t)"
-- "exceptions": []
-  "name": "tsm_vte_handle_keyboard"
+- "name": "tsm_vte_handle_keyboard"
   "params":
   - "name": "vte"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool tsm_vte_handle_keyboard(struct tsm_vte *, uint32_t, uint32_t, unsigned int, uint32_t)"
-- "exceptions": []
-  "name": "shl_htable_remove"
+- "name": "shl_htable_remove"
   "params":
   - "name": "htable"
     "type": "bool "

--- a/benchmark-sets/all/libunwind.yaml
+++ b/benchmark-sets/all/libunwind.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "access_mem"
+- "name": "access_mem"
   "params":
   - "name": "as"
     "type": "bool "

--- a/benchmark-sets/all/libusb.yaml
+++ b/benchmark-sets/all/libusb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "libusb_interrupt_transfer"
+- "name": "libusb_interrupt_transfer"
   "params":
   - "name": "dev_handle"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int libusb_interrupt_transfer(libusb_device_handle *, unsigned char, unsigned char *, int, int *, unsigned int)"
-- "exceptions": []
-  "name": "libusb_control_transfer"
+- "name": "libusb_control_transfer"
   "params":
   - "name": "dev_handle"
     "type": "bool "
@@ -37,8 +35,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int libusb_control_transfer(libusb_device_handle *, uint8_t, uint8_t, uint16_t, uint16_t, unsigned char *, uint16_t, unsigned int)"
-- "exceptions": []
-  "name": "libusb_get_string_descriptor_ascii"
+- "name": "libusb_get_string_descriptor_ascii"
   "params":
   - "name": "dev_handle"
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int libusb_get_string_descriptor_ascii(libusb_device_handle *, uint8_t, unsigned char *, int)"
-- "exceptions": []
-  "name": "libusb_get_bos_descriptor"
+- "name": "libusb_get_bos_descriptor"
   "params":
   - "name": "dev_handle"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int libusb_get_bos_descriptor(libusb_device_handle *, struct libusb_bos_descriptor **)"
-- "exceptions": []
-  "name": "libusb_get_configuration"
+- "name": "libusb_get_configuration"
   "params":
   - "name": "dev_handle"
     "type": "bool "

--- a/benchmark-sets/all/libvnc.yaml
+++ b/benchmark-sets/all/libvnc.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "rfbStartOnHoldClient"
+- "name": "rfbStartOnHoldClient"
   "params":
   - "name": "cl"
     "type": "bool "
   "return_type": "void"
   "signature": "void rfbStartOnHoldClient(rfbClientPtr)"
-- "exceptions": []
-  "name": "rfbReverseConnection"
+- "name": "rfbReverseConnection"
   "params":
   - "name": "rfbScreen"
     "type": "bool "
@@ -17,15 +15,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "rfbClientPtr rfbReverseConnection(rfbScreenInfoPtr, char *, int)"
-- "exceptions": []
-  "name": "rfbUpdateClient"
+- "name": "rfbUpdateClient"
   "params":
   - "name": "cl"
     "type": "bool "
   "return_type": "char"
   "signature": "rfbBool rfbUpdateClient(rfbClientPtr)"
-- "exceptions": []
-  "name": "rfbProcessEvents"
+- "name": "rfbProcessEvents"
   "params":
   - "name": "screen"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "size_t"
   "return_type": "char"
   "signature": "rfbBool rfbProcessEvents(rfbScreenInfoPtr, long)"
-- "exceptions": []
-  "name": "rfbRunEventLoop"
+- "name": "rfbRunEventLoop"
   "params":
   - "name": "screen"
     "type": "bool "

--- a/benchmark-sets/all/libvpx.yaml
+++ b/benchmark-sets/all/libvpx.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "vp9_loopfilter_job"
+- "name": "vp9_loopfilter_job"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void vp9_loopfilter_job(LFWorkerData *, VP9LfSync *)"
-- "exceptions": []
-  "name": "vpx_highbd_convolve8_avg_sse2"
+- "name": "vpx_highbd_convolve8_avg_sse2"
   "params":
   - "name": ""
     "type": "bool "
@@ -37,8 +35,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void vpx_highbd_convolve8_avg_sse2(const uint16_t *, ptrdiff_t, uint16_t *, ptrdiff_t, const InterpKernel *, int, int, int, int, int, int, int)"
-- "exceptions": []
-  "name": "vpx_highbd_convolve8_sse2"
+- "name": "vpx_highbd_convolve8_sse2"
   "params":
   - "name": ""
     "type": "bool "
@@ -66,8 +63,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void vpx_highbd_convolve8_sse2(const uint16_t *, ptrdiff_t, uint16_t *, ptrdiff_t, const InterpKernel *, int, int, int, int, int, int, int)"
-- "exceptions": []
-  "name": "vp9_loop_filter_frame"
+- "name": "vp9_loop_filter_frame"
   "params":
   - "name": ""
     "type": "bool "
@@ -83,8 +79,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void vp9_loop_filter_frame(YV12_BUFFER_CONFIG *, VP9_COMMON *, MACROBLOCKD *, int, int, int)"
-- "exceptions": []
-  "name": "vp8_post_proc_frame"
+- "name": "vp8_post_proc_frame"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libxaac.yaml
+++ b/benchmark-sets/all/libxaac.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ixheaacd_hbe_apply_ifft_336"
+- "name": "ixheaacd_hbe_apply_ifft_336"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "VOID ixheaacd_hbe_apply_ifft_336(FLOAT32 *, FLOAT32 *, WORD32, WORD32)"
-- "exceptions": []
-  "name": "ixheaacd_hbe_apply_ifft_224"
+- "name": "ixheaacd_hbe_apply_ifft_224"
   "params":
   - "name": ""
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "VOID ixheaacd_hbe_apply_ifft_224(FLOAT32 *, FLOAT32 *, WORD32, WORD32)"
-- "exceptions": []
-  "name": "ixheaacd_hbe_apply_fft_288"
+- "name": "ixheaacd_hbe_apply_fft_288"
   "params":
   - "name": ""
     "type": "bool "
@@ -38,15 +35,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "VOID ixheaacd_hbe_apply_fft_288(FLOAT32 *, FLOAT32 *, WORD32, WORD32)"
-- "exceptions": []
-  "name": "ixheaacd_mps_apply_mix_matrix"
+- "name": "ixheaacd_mps_apply_mix_matrix"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "VOID ixheaacd_mps_apply_mix_matrix(ia_mps_dec_state_struct *)"
-- "exceptions": []
-  "name": "ixheaacd_apply_rot_dec"
+- "name": "ixheaacd_apply_rot_dec"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/libxls.yaml
+++ b/benchmark-sets/all/libxls.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "xls_open"
+- "name": "xls_open"
   "params":
   - "name": "file"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "xlsWorkBook * xls_open(const char *, const char *)"
-- "exceptions": []
-  "name": "ole2_open_file"
+- "name": "ole2_open_file"
   "params":
   - "name": "file"
     "type": "bool "
   "return_type": "void"
   "signature": "OLE2 * ole2_open_file(const char *)"
-- "exceptions": []
-  "name": "xls_open_file"
+- "name": "xls_open_file"
   "params":
   - "name": "file"
     "type": "bool "
@@ -26,15 +23,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "xlsWorkBook * xls_open_file(const char *, const char *, xls_error_t *)"
-- "exceptions": []
-  "name": "xls_close_summaryInfo"
+- "name": "xls_close_summaryInfo"
   "params":
   - "name": "pSI"
     "type": "bool "
   "return_type": "void"
   "signature": "void xls_close_summaryInfo(xlsSummaryInfo *)"
-- "exceptions": []
-  "name": "xls_summaryInfo"
+- "name": "xls_summaryInfo"
   "params":
   - "name": "pWB"
     "type": "bool "

--- a/benchmark-sets/all/libxlsxwriter.yaml
+++ b/benchmark-sets/all/libxlsxwriter.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "worksheet_add_table"
+- "name": "worksheet_add_table"
   "params":
   - "name": "self"
     "type": "bool "
@@ -16,15 +15,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "lxw_error worksheet_add_table(lxw_worksheet *, lxw_row_t, lxw_col_t, lxw_row_t, lxw_col_t, lxw_table_options *)"
-- "exceptions": []
-  "name": "lxw_chartsheet_new"
+- "name": "lxw_chartsheet_new"
   "params":
   - "name": "init_data"
     "type": "bool "
   "return_type": "void"
   "signature": "lxw_chartsheet * lxw_chartsheet_new(lxw_worksheet_init_data *)"
-- "exceptions": []
-  "name": "worksheet_write_rich_string"
+- "name": "worksheet_write_rich_string"
   "params":
   - "name": "self"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "lxw_error worksheet_write_rich_string(lxw_worksheet *, lxw_row_t, lxw_col_t, lxw_rich_string_tuple **, lxw_format *)"
-- "exceptions": []
-  "name": "workbook_add_chartsheet"
+- "name": "workbook_add_chartsheet"
   "params":
   - "name": "self"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "lxw_chartsheet * workbook_add_chartsheet(lxw_workbook *, const char *)"
-- "exceptions": []
-  "name": "new_workbook"
+- "name": "new_workbook"
   "params":
   - "name": "filename"
     "type": "bool "

--- a/benchmark-sets/all/libxml2.yaml
+++ b/benchmark-sets/all/libxml2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "xmlXIncludeProcessTreeFlags"
+- "name": "xmlXIncludeProcessTreeFlags"
   "params":
   - "name": "tree"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int xmlXIncludeProcessTreeFlags(xmlNodePtr, int)"
-- "exceptions": []
-  "name": "htmlCreateFileParserCtxt"
+- "name": "htmlCreateFileParserCtxt"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "htmlParserCtxtPtr htmlCreateFileParserCtxt(const char *, const char *)"
-- "exceptions": []
-  "name": "xmlTextReaderRelaxNGValidateCtxt"
+- "name": "xmlTextReaderRelaxNGValidateCtxt"
   "params":
   - "name": "reader"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int xmlTextReaderRelaxNGValidateCtxt(xmlTextReaderPtr, xmlRelaxNGValidCtxtPtr, int)"
-- "exceptions": []
-  "name": "htmlSAXParseFile"
+- "name": "htmlSAXParseFile"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "htmlDocPtr htmlSAXParseFile(const char *, const char *, htmlSAXHandlerPtr, void *)"
-- "exceptions": []
-  "name": "xmlTextReaderSchemaValidateCtxt"
+- "name": "xmlTextReaderSchemaValidateCtxt"
   "params":
   - "name": "reader"
     "type": "bool "

--- a/benchmark-sets/all/libxslt.yaml
+++ b/benchmark-sets/all/libxslt.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "xmlXIncludeProcessTreeFlags"
+- "name": "xmlXIncludeProcessTreeFlags"
   "params":
   - "name": "tree"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int xmlXIncludeProcessTreeFlags(xmlNodePtr, int)"
-- "exceptions": []
-  "name": "xmlReadDoc"
+- "name": "xmlReadDoc"
   "params":
   - "name": "cur"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "xmlDocPtr xmlReadDoc(const xmlChar *, const char *, const char *, int)"
-- "exceptions": []
-  "name": "htmlSAXParseFile"
+- "name": "htmlSAXParseFile"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "htmlDocPtr htmlSAXParseFile(const char *, const char *, htmlSAXHandlerPtr, void *)"
-- "exceptions": []
-  "name": "htmlCreateFileParserCtxt"
+- "name": "htmlCreateFileParserCtxt"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "htmlParserCtxtPtr htmlCreateFileParserCtxt(const char *, const char *)"
-- "exceptions": []
-  "name": "xmlACatalogResolvePublic"
+- "name": "xmlACatalogResolvePublic"
   "params":
   - "name": "catal"
     "type": "bool "

--- a/benchmark-sets/all/libyal.yaml
+++ b/benchmark-sets/all/libyal.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "libesedb_index_get_record"
+- "name": "libesedb_index_get_record"
   "params":
   - "name": "index"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int libesedb_index_get_record(libesedb_index_t *, int, libesedb_record_t **, libcerror_error_t **)"
-- "exceptions": []
-  "name": "libewf_handle_open"
+- "name": "libewf_handle_open"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int libewf_handle_open(libewf_handle_t *, const char **, int, int, libcerror_error_t **)"
-- "exceptions": []
-  "name": "libfsapfs_volume_get_file_entry_by_utf16_path"
+- "name": "libfsapfs_volume_get_file_entry_by_utf16_path"
   "params":
   - "name": "volume"
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int libfsapfs_volume_get_file_entry_by_utf16_path(libfsapfs_volume_t *, const uint16_t *, size_t, libfsapfs_file_entry_t **, libcerror_error_t **)"
-- "exceptions": []
-  "name": "libscca_file_open"
+- "name": "libscca_file_open"
   "params":
   - "name": "file"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int libscca_file_open(libscca_file_t *, const char *, int, libcerror_error_t **)"
-- "exceptions": []
-  "name": "libwrc_resource_get_value_by_language_identifier"
+- "name": "libwrc_resource_get_value_by_language_identifier"
   "params":
   - "name": "resource"
     "type": "bool "

--- a/benchmark-sets/all/libyaml.yaml
+++ b/benchmark-sets/all/libyaml.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "yaml_emitter_set_width"
+- "name": "yaml_emitter_set_width"
   "params":
   - "name": "emitter"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void yaml_emitter_set_width(yaml_emitter_t *, int)"
-- "exceptions": []
-  "name": "yaml_emitter_set_output_file"
+- "name": "yaml_emitter_set_output_file"
   "params":
   - "name": "emitter"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void yaml_emitter_set_output_file(yaml_emitter_t *, FILE *)"
-- "exceptions": []
-  "name": "yaml_emitter_set_indent"
+- "name": "yaml_emitter_set_indent"
   "params":
   - "name": "emitter"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void yaml_emitter_set_indent(yaml_emitter_t *, int)"
-- "exceptions": []
-  "name": "yaml_emitter_set_encoding"
+- "name": "yaml_emitter_set_encoding"
   "params":
   - "name": "emitter"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void yaml_emitter_set_encoding(yaml_emitter_t *, yaml_encoding_t)"
-- "exceptions": []
-  "name": "yaml_emitter_set_break"
+- "name": "yaml_emitter_set_break"
   "params":
   - "name": "emitter"
     "type": "bool "

--- a/benchmark-sets/all/libyang.yaml
+++ b/benchmark-sets/all/libyang.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "lyd_parse_op"
+- "name": "lyd_parse_op"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -18,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "LY_ERR lyd_parse_op(const struct ly_ctx *, struct lyd_node *, struct ly_in *, LYD_FORMAT, DW_TAG_enumeration_typelyd_type, struct lyd_node **, struct lyd_node **)"
-- "exceptions": []
-  "name": "lyplg_ext_print_info_extension_instance"
+- "name": "lyplg_ext_print_info_extension_instance"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void lyplg_ext_print_info_extension_instance(struct lyspr_ctx *, const struct lysc_ext_instance *, ly_bool *)"
-- "exceptions": []
-  "name": "yang_print_compiled"
+- "name": "yang_print_compiled"
   "params":
   - "name": "out"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "LY_ERR yang_print_compiled(struct ly_out *, const struct lys_module *, uint32_t)"
-- "exceptions": []
-  "name": "ly_ctx_get_yanglib_data"
+- "name": "ly_ctx_get_yanglib_data"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "LY_ERR ly_ctx_get_yanglib_data(const struct ly_ctx *, struct lyd_node **, const char *, void)"
-- "exceptions": []
-  "name": "lyd_parse_ext_op"
+- "name": "lyd_parse_ext_op"
   "params":
   - "name": "ext"
     "type": "bool "

--- a/benchmark-sets/all/libzip.yaml
+++ b/benchmark-sets/all/libzip.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "zip_source_winzip_aes_encode"
+- "name": "zip_source_winzip_aes_encode"
   "params":
   - "name": "za"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "zip_source_t * zip_source_winzip_aes_encode(zip_t *, zip_source_t *, zip_uint16_t, int, const char *)"
-- "exceptions": []
-  "name": "zip_file_extra_field_set"
+- "name": "zip_file_extra_field_set"
   "params":
   - "name": "za"
     "type": "bool "
@@ -33,8 +31,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int zip_file_extra_field_set(zip_t *, zip_uint64_t, zip_uint16_t, zip_uint16_t, const zip_uint8_t *, zip_uint16_t, zip_flags_t)"
-- "exceptions": []
-  "name": "zip_file_extra_field_delete_by_id"
+- "name": "zip_file_extra_field_delete_by_id"
   "params":
   - "name": "za"
     "type": "bool "
@@ -48,8 +45,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int zip_file_extra_field_delete_by_id(zip_t *, zip_uint64_t, zip_uint16_t, zip_uint16_t, zip_flags_t)"
-- "exceptions": []
-  "name": "zip_file_replace"
+- "name": "zip_file_replace"
   "params":
   - "name": "za"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int zip_file_replace(zip_t *, zip_uint64_t, zip_source_t *, zip_flags_t)"
-- "exceptions": []
-  "name": "zip_source_window_create"
+- "name": "zip_source_window_create"
   "params":
   - "name": "src"
     "type": "bool "

--- a/benchmark-sets/all/lighttpd.yaml
+++ b/benchmark-sets/all/lighttpd.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "buffer_copy_path_len2"
+- "name": "buffer_copy_path_len2"
   "params":
   - "name": "b"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void buffer_copy_path_len2(const DW_TAG_restrict_typebuffer *, const const DW_TAG_restrict_typechar *, size_t, const const DW_TAG_restrict_typechar *, size_t)"
-- "exceptions": []
-  "name": "buffer_append_int"
+- "name": "buffer_append_int"
   "params":
   - "name": "b"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void buffer_append_int(buffer *, intmax_t)"
-- "exceptions": []
-  "name": "buffer_append_base64_decode"
+- "name": "buffer_append_base64_decode"
   "params":
   - "name": "out"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "unsigned char * buffer_append_base64_decode(buffer *, const char *, size_t, base64_charset)"
-- "exceptions": []
-  "name": "buffer_append_strftime"
+- "name": "buffer_append_strftime"
   "params":
   - "name": "b"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void buffer_append_strftime(const DW_TAG_restrict_typebuffer *, const const DW_TAG_restrict_typechar *, const const struct DW_TAG_restrict_typetm *)"
-- "exceptions": []
-  "name": "buffer_append_base64_enc"
+- "name": "buffer_append_base64_enc"
   "params":
   - "name": "out"
     "type": "bool "

--- a/benchmark-sets/all/lldpd.yaml
+++ b/benchmark-sets/all/lldpd.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "lldpd_loop"
+- "name": "lldpd_loop"
   "params":
   - "name": "cfg"
     "type": "bool "
   "return_type": "void"
   "signature": "void lldpd_loop(struct lldpd *)"
-- "exceptions": []
-  "name": "netlink_get_interfaces"
+- "name": "netlink_get_interfaces"
   "params":
   - "name": "cfg"
     "type": "bool "
   "return_type": "void"
   "signature": "struct interfaces_device_list * netlink_get_interfaces(struct lldpd *)"
-- "exceptions": []
-  "name": "levent_iface_subscribe"
+- "name": "levent_iface_subscribe"
   "params":
   - "name": "cfg"
     "type": "bool "
@@ -22,15 +19,13 @@
     "type": "int"
   "return_type": "int"
   "signature": "int levent_iface_subscribe(struct lldpd *, int)"
-- "exceptions": []
-  "name": "interfaces_update"
+- "name": "interfaces_update"
   "params":
   - "name": "cfg"
     "type": "bool "
   "return_type": "void"
   "signature": "void interfaces_update(struct lldpd *)"
-- "exceptions": []
-  "name": "levent_loop"
+- "name": "levent_loop"
   "params":
   - "name": "cfg"
     "type": "bool "

--- a/benchmark-sets/all/llvm_libcxx.yaml
+++ b/benchmark-sets/all/llvm_libcxx.yaml
@@ -1,27 +1,23 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNOSt3__123__optional_storage_baseINS_6localeELb0EE5__getB8ne190000Ev"
+- "name": "_ZNOSt3__123__optional_storage_baseINS_6localeELb0EE5__getB8ne190000Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "DW_TAG_rvalue_reference_typevalue_type std::__1::__optional_storage_base<std::__1::locale, false>::__get(struct __optional_storage_base<std::__1::locale, false> *)"
-- "exceptions": []
-  "name": "_ZNRSt3__18optionalINS_6localeEEdeB8ne190000Ev"
+- "name": "_ZNRSt3__18optionalINS_6localeEEdeB8ne190000Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "value_type & std::__1::optional<std::__1::locale>::operator*(optional<std::__1::locale> *)"
-- "exceptions": []
-  "name": "_ZNOSt3__18__format15__format_bufferINS_20back_insert_iteratorINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEEcE8__out_itB8ne190000Ev"
+- "name": "_ZNOSt3__18__format15__format_bufferINS_20back_insert_iteratorINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEEcE8__out_itB8ne190000Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "back_insert_iterator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > std::__1::__format::__format_buffer<std::__1::back_insert_iterator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, char>::__out_it(__format_buffer<std::__1::back_insert_iterator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, char> *)"
-- "exceptions": []
-  "name": "_ZZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC1B8ne190000EOS5_ENKUlRS5_E_clES7_"
+- "name": "_ZZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC1B8ne190000EOS5_ENKUlRS5_E_clES7_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -29,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "DW_TAG_rvalue_reference_type__compressed_pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char> > std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::operator()(const void *, basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > &)"
-- "exceptions": []
-  "name": "_ZNRSt3__123__optional_storage_baseINS_6localeELb0EE5__getB8ne190000Ev"
+- "name": "_ZNRSt3__123__optional_storage_baseINS_6localeELb0EE5__getB8ne190000Ev"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/llvm_libcxxabi.yaml
+++ b/benchmark-sets/all/llvm_libcxxabi.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK12_GLOBAL__N_116itanium_demangle4Node4dumpEv"
+- "name": "_ZNK12_GLOBAL__N_116itanium_demangle4Node4dumpEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void (anonymous namespace)::itanium_demangle::Node::dump()"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E22parseTemplateParamDeclEPNS0_14PODSmallVectorIPNS0_4NodeELm8EEE"
+- "name": "_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E22parseTemplateParamDeclEPNS0_14PODSmallVectorIPNS0_4NodeELm8EEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -15,15 +13,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Node * (anonymous namespace)::itanium_demangle::parseTemplateParamDecl(struct AbstractManglingParser<(anonymous namespace)::itanium_demangle::ManglingParser<(anonymous namespace)::DefaultAllocator>, (anonymous namespace)::DefaultAllocator> *, TemplateParamList *)"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E16parseSpecialNameEv"
+- "name": "_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E16parseSpecialNameEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "Node * (anonymous namespace)::itanium_demangle::parseSpecialName(struct AbstractManglingParser<(anonymous namespace)::itanium_demangle::ManglingParser<(anonymous namespace)::DefaultAllocator>, (anonymous namespace)::DefaultAllocator> *)"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_111DumpVisitor5printENS_16itanium_demangle9NodeArrayE"
+- "name": "_ZN12_GLOBAL__N_111DumpVisitor5printENS_16itanium_demangle9NodeArrayE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void (anonymous namespace)::DumpVisitor::print(struct DumpVisitor *, NodeArray)"
-- "exceptions": []
-  "name": "_ZN12_GLOBAL__N_111DumpVisitorclEPKNS_16itanium_demangle24ForwardTemplateReferenceE"
+- "name": "_ZN12_GLOBAL__N_111DumpVisitorclEPKNS_16itanium_demangle24ForwardTemplateReferenceE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/lodepng.yaml
+++ b/benchmark-sets/all/lodepng.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_Z19lodepng_encode_filePKcPKhjj16LodePNGColorTypej"
+- "name": "_Z19lodepng_encode_filePKcPKhjj16LodePNGColorTypej"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "unsigned int lodepng_encode_file(const char *, const unsigned char *, unsigned int, unsigned int, LodePNGColorType, unsigned int)"
-- "exceptions": []
-  "name": "_ZN7lodepng6encodeERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEPKhjj16LodePNGColorTypej"
+- "name": "_ZN7lodepng6encodeERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEPKhjj16LodePNGColorTypej"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -33,8 +31,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "unsigned int lodepng::encode(const string &, const unsigned char *, unsigned int, unsigned int, LodePNGColorType, unsigned int)"
-- "exceptions": []
-  "name": "_Z21lodepng_encode32_filePKcPKhjj"
+- "name": "_Z21lodepng_encode32_filePKcPKhjj"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "unsigned int lodepng_encode32_file(const char *, const unsigned char *, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "_Z21lodepng_encode24_filePKcPKhjj"
+- "name": "_Z21lodepng_encode24_filePKcPKhjj"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "unsigned int lodepng_encode24_file(const char *, const unsigned char *, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "_ZN7lodepng6encodeERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEERKNS0_6vectorIhNS4_IhEEEEjj16LodePNGColorTypej"
+- "name": "_ZN7lodepng6encodeERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEERKNS0_6vectorIhNS4_IhEEEEjj16LodePNGColorTypej"
   "params":
   - "name": "filename"
     "type": "bool "

--- a/benchmark-sets/all/lwan.yaml
+++ b/benchmark-sets/all/lwan.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "lwan_response"
+- "name": "lwan_response"
   "params":
   - "name": "request"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void lwan_response(struct lwan_request *, DW_TAG_enumeration_typelwan_http_status)"
-- "exceptions": []
-  "name": "lwan_init"
+- "name": "lwan_init"
   "params":
   - "name": "l"
     "type": "bool "
   "return_type": "void"
   "signature": "void lwan_init(struct lwan *)"
-- "exceptions": []
-  "name": "lwan_process_request"
+- "name": "lwan_process_request"
   "params":
   - "name": "l"
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void lwan_process_request(struct lwan *, struct lwan_request *)"
-- "exceptions": []
-  "name": "lwan_init_with_config"
+- "name": "lwan_init_with_config"
   "params":
   - "name": "l"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void lwan_init_with_config(struct lwan *, const struct lwan_config *)"
-- "exceptions": []
-  "name": "lwan_thread_init"
+- "name": "lwan_thread_init"
   "params":
   - "name": "l"
     "type": "bool "

--- a/benchmark-sets/all/lz4.yaml
+++ b/benchmark-sets/all/lz4.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "LZ4_compress_destSize_extState"
+- "name": "LZ4_compress_destSize_extState"
   "params":
   - "name": "state"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int LZ4_compress_destSize_extState(void *, const char *, char *, int *, int, int)"
-- "exceptions": []
-  "name": "LZ4_compressHC2_limitedOutput_withStateHC"
+- "name": "LZ4_compressHC2_limitedOutput_withStateHC"
   "params":
   - "name": "state"
     "type": "bool "
@@ -33,8 +31,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int LZ4_compressHC2_limitedOutput_withStateHC(void *, const char *, char *, int, int, int)"
-- "exceptions": []
-  "name": "LZ4_compressHC2_limitedOutput"
+- "name": "LZ4_compressHC2_limitedOutput"
   "params":
   - "name": "src"
     "type": "bool "
@@ -48,8 +45,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int LZ4_compressHC2_limitedOutput(const char *, char *, int, int, int)"
-- "exceptions": []
-  "name": "LZ4F_getFrameInfo"
+- "name": "LZ4F_getFrameInfo"
   "params":
   - "name": "dctx"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t LZ4F_getFrameInfo(LZ4F_dctx *, LZ4F_frameInfo_t *, const void *, size_t *)"
-- "exceptions": []
-  "name": "LZ4_compress_HC_continue_destSize"
+- "name": "LZ4_compress_HC_continue_destSize"
   "params":
   - "name": "LZ4_streamHCPtr"
     "type": "bool "

--- a/benchmark-sets/all/lzma.yaml
+++ b/benchmark-sets/all/lzma.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "LzmaEnc_MemEncode"
+- "name": "LzmaEnc_MemEncode"
   "params":
   - "name": "pp"
     "type": "bool "
@@ -22,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "SRes LzmaEnc_MemEncode(CLzmaEncHandle, Byte *, SizeT *, const Byte *, SizeT, int, ICompressProgress *, ISzAllocPtr, ISzAllocPtr)"
-- "exceptions": []
-  "name": "Bt3Zip_MatchFinder_GetMatches"
+- "name": "Bt3Zip_MatchFinder_GetMatches"
   "params":
   - "name": "p"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "UInt32 Bt3Zip_MatchFinder_GetMatches(CMatchFinder *, UInt32 *)"
-- "exceptions": []
-  "name": "LzmaEncode"
+- "name": "LzmaEncode"
   "params":
   - "name": "dest"
     "type": "bool "
@@ -58,8 +55,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "SRes LzmaEncode(Byte *, SizeT *, const Byte *, SizeT, const CLzmaEncProps *, Byte *, SizeT *, int, ICompressProgress *, ISzAllocPtr, ISzAllocPtr)"
-- "exceptions": []
-  "name": "Xz_Encode"
+- "name": "Xz_Encode"
   "params":
   - "name": "outStream"
     "type": "bool "
@@ -71,8 +67,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "SRes Xz_Encode(ISeqOutStream *, ISeqInStream *, const CXzProps *, ICompressProgress *)"
-- "exceptions": []
-  "name": "XzUnpacker_CodeFull"
+- "name": "XzUnpacker_CodeFull"
   "params":
   - "name": "p"
     "type": "bool "

--- a/benchmark-sets/all/mariadb.yaml
+++ b/benchmark-sets/all/mariadb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "my_charset_get_by_name"
+- "name": "my_charset_get_by_name"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "CHARSET_INFO * my_charset_get_by_name(MY_CHARSET_LOADER *, const char *, uint, myf)"
-- "exceptions": []
-  "name": "get_charset_by_csname"
+- "name": "get_charset_by_csname"
   "params":
   - "name": ""
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "CHARSET_INFO * get_charset_by_csname(const char *, uint, myf)"
-- "exceptions": []
-  "name": "resolve_collation"
+- "name": "resolve_collation"
   "params":
   - "name": ""
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "size_t"
   "return_type": "char"
   "signature": "my_bool resolve_collation(const char *, CHARSET_INFO *, CHARSET_INFO **, myf)"
-- "exceptions": []
-  "name": "resolve_charset"
+- "name": "resolve_charset"
   "params":
   - "name": ""
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "size_t"
   "return_type": "char"
   "signature": "my_bool resolve_charset(const char *, CHARSET_INFO *, CHARSET_INFO **, myf)"
-- "exceptions": []
-  "name": "get_charset_by_name"
+- "name": "get_charset_by_name"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/matio.yaml
+++ b/benchmark-sets/all/matio.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "Mat_VarWrite"
+- "name": "Mat_VarWrite"
   "params":
   - "name": "mat"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int Mat_VarWrite(mat_t *, matvar_t *, DW_TAG_enumeration_typematio_compression)"
-- "exceptions": []
-  "name": "Mat_VarReadData"
+- "name": "Mat_VarReadData"
   "params":
   - "name": "mat"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int Mat_VarReadData(mat_t *, matvar_t *, void *, const int *, const int *, const int *)"
-- "exceptions": []
-  "name": "Mat_VarWriteAppend"
+- "name": "Mat_VarWriteAppend"
   "params":
   - "name": "mat"
     "type": "bool "
@@ -40,15 +37,13 @@
     "type": "int"
   "return_type": "int"
   "signature": "int Mat_VarWriteAppend(mat_t *, matvar_t *, DW_TAG_enumeration_typematio_compression, int)"
-- "exceptions": []
-  "name": "H5D__virtual_set_extent_unlim"
+- "name": "H5D__virtual_set_extent_unlim"
   "params":
   - "name": "dset"
     "type": "bool "
   "return_type": "int"
   "signature": "herr_t H5D__virtual_set_extent_unlim(const H5D_t *)"
-- "exceptions": []
-  "name": "Mat_VarDelete"
+- "name": "Mat_VarDelete"
   "params":
   - "name": "mat"
     "type": "bool "

--- a/benchmark-sets/all/mbedtls.yaml
+++ b/benchmark-sets/all/mbedtls.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mbedtls_ssl_write"
+- "name": "mbedtls_ssl_write"
   "params":
   - "name": "ssl"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int mbedtls_ssl_write(mbedtls_ssl_context *, const unsigned char *, size_t)"
-- "exceptions": []
-  "name": "mbedtls_ssl_check_record"
+- "name": "mbedtls_ssl_check_record"
   "params":
   - "name": "ssl"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int mbedtls_ssl_check_record(const mbedtls_ssl_context *, unsigned char *, size_t)"
-- "exceptions": []
-  "name": "mbedtls_pk_parse_keyfile"
+- "name": "mbedtls_pk_parse_keyfile"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mbedtls_pk_parse_keyfile(mbedtls_pk_context *, const char *, const char *, DW_TAG_subroutine_typeInfinite loop *, void *)"
-- "exceptions": []
-  "name": "mbedtls_ssl_write_early_data"
+- "name": "mbedtls_ssl_write_early_data"
   "params":
   - "name": "ssl"
     "type": "bool "

--- a/benchmark-sets/all/mdbtools.yaml
+++ b/benchmark-sets/all/mdbtools.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "mdb_data_dump"
+- "name": "mdb_data_dump"
   "params":
   - "name": "table"
     "type": "bool "
   "return_type": "void"
   "signature": "void mdb_data_dump(MdbTableDef *)"
-- "exceptions": []
-  "name": "mdb_print_schema"
+- "name": "mdb_print_schema"
   "params":
   - "name": "mdb"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int mdb_print_schema(MdbHandle *, FILE *, char *, char *, guint32)"
-- "exceptions": []
-  "name": "mdb_dump_catalog"
+- "name": "mdb_dump_catalog"
   "params":
   - "name": "mdb"
     "type": "bool "
@@ -30,15 +27,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void mdb_dump_catalog(MdbHandle *, int)"
-- "exceptions": []
-  "name": "mdb_table_dump"
+- "name": "mdb_table_dump"
   "params":
   - "name": "entry"
     "type": "bool "
   "return_type": "void"
   "signature": "void mdb_table_dump(MdbCatalogEntry *)"
-- "exceptions": []
-  "name": "mdb_read_table_by_name"
+- "name": "mdb_read_table_by_name"
   "params":
   - "name": "mdb"
     "type": "bool "

--- a/benchmark-sets/all/miniz.yaml
+++ b/benchmark-sets/all/miniz.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mz_zip_add_mem_to_archive_file_in_place"
+- "name": "mz_zip_add_mem_to_archive_file_in_place"
   "params":
   - "name": ""
     "type": "bool "
@@ -18,8 +17,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "mz_bool mz_zip_add_mem_to_archive_file_in_place(const char *, const char *, const void *, size_t, const void *, mz_uint16, mz_uint)"
-- "exceptions": []
-  "name": "mz_zip_add_mem_to_archive_file_in_place_v2"
+- "name": "mz_zip_add_mem_to_archive_file_in_place_v2"
   "params":
   - "name": ""
     "type": "bool "
@@ -39,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "mz_bool mz_zip_add_mem_to_archive_file_in_place_v2(const char *, const char *, const void *, size_t, const void *, mz_uint16, mz_uint, mz_zip_error *)"
-- "exceptions": []
-  "name": "mz_zip_validate_file_archive"
+- "name": "mz_zip_validate_file_archive"
   "params":
   - "name": ""
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "mz_bool mz_zip_validate_file_archive(const char *, mz_uint, mz_zip_error *)"
-- "exceptions": []
-  "name": "mz_zip_writer_add_file"
+- "name": "mz_zip_writer_add_file"
   "params":
   - "name": ""
     "type": "bool "
@@ -67,8 +63,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "mz_bool mz_zip_writer_add_file(mz_zip_archive *, const char *, const char *, const void *, mz_uint16, mz_uint)"
-- "exceptions": []
-  "name": "mz_zip_writer_add_cfile"
+- "name": "mz_zip_writer_add_cfile"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/minizip.yaml
+++ b/benchmark-sets/all/minizip.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "mz_zip_entry_is_symlink"
+- "name": "mz_zip_entry_is_symlink"
   "params":
   - "name": "handle"
     "type": "bool "
   "return_type": "int"
   "signature": "int32_t mz_zip_entry_is_symlink(void *)"
-- "exceptions": []
-  "name": "mz_zip_attrib_is_symlink"
+- "name": "mz_zip_attrib_is_symlink"
   "params":
   - "name": "attrib"
     "type": "int"
@@ -15,8 +13,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int32_t mz_zip_attrib_is_symlink(uint32_t, int32_t)"
-- "exceptions": []
-  "name": "mz_zip_locate_first_entry"
+- "name": "mz_zip_locate_first_entry"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int32_t mz_zip_locate_first_entry(void *, void *, mz_zip_locate_entry_cb)"
-- "exceptions": []
-  "name": "mz_zip_goto_entry"
+- "name": "mz_zip_goto_entry"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int32_t mz_zip_goto_entry(void *, int64_t)"
-- "exceptions": []
-  "name": "mz_zip_locate_next_entry"
+- "name": "mz_zip_locate_next_entry"
   "params":
   - "name": "handle"
     "type": "bool "

--- a/benchmark-sets/all/mongoose.yaml
+++ b/benchmark-sets/all/mongoose.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mg_ws_connect"
+- "name": "mg_ws_connect"
   "params":
   - "name": "mgr"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct mg_connection * mg_ws_connect(struct mg_mgr *, const char *, mg_event_handler_t, void *, const char *, void)"
-- "exceptions": []
-  "name": "mg_mqtt_connect"
+- "name": "mg_mqtt_connect"
   "params":
   - "name": "mgr"
     "type": "bool "
@@ -29,22 +27,19 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct mg_connection * mg_mqtt_connect(struct mg_mgr *, const char *, const struct mg_mqtt_opts *, mg_event_handler_t, void *)"
-- "exceptions": []
-  "name": "mg_hello"
+- "name": "mg_hello"
   "params":
   - "name": "url"
     "type": "bool "
   "return_type": "void"
   "signature": "void mg_hello(const char *)"
-- "exceptions": []
-  "name": "mg_rpc_process"
+- "name": "mg_rpc_process"
   "params":
   - "name": "r"
     "type": "bool "
   "return_type": "void"
   "signature": "void mg_rpc_process(struct mg_rpc_req *)"
-- "exceptions": []
-  "name": "mg_sntp_connect"
+- "name": "mg_sntp_connect"
   "params":
   - "name": "mgr"
     "type": "bool "

--- a/benchmark-sets/all/mosh.yaml
+++ b/benchmark-sets/all/mosh.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8Terminal11Framebuffer6resizeEii"
+- "name": "_ZN8Terminal11Framebuffer6resizeEii"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void Terminal::Framebuffer::resize(int, int)"
-- "exceptions": []
-  "name": "_ZNK8Terminal8Complete9init_diffB5cxx11Ev"
+- "name": "_ZNK8Terminal8Complete9init_diffB5cxx11Ev"
   "params":
   - "name": "this"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "string Terminal::Complete::init_diff()"
-- "exceptions": []
-  "name": "_ZNK6Parser6Resize15act_on_terminalEPN8Terminal8EmulatorE"
+- "name": "_ZNK6Parser6Resize15act_on_terminalEPN8Terminal8EmulatorE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void Parser::Resize::act_on_terminal(Emulator *)"
-- "exceptions": []
-  "name": "_ZN8Terminal8Emulator6resizeEmm"
+- "name": "_ZN8Terminal8Emulator6resizeEmm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void Terminal::Emulator::resize(size_t, size_t)"
-- "exceptions": []
-  "name": "_ZNK8Terminal8Complete9diff_fromB5cxx11ERKS0_"
+- "name": "_ZNK8Terminal8Complete9diff_fromB5cxx11ERKS0_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/mpg123.yaml
+++ b/benchmark-sets/all/mpg123.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mpg123_feedseek"
+- "name": "mpg123_feedseek"
   "params":
   - "name": "mh"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "off_t mpg123_feedseek(mpg123_handle *, off_t, int, off_t *)"
-- "exceptions": []
-  "name": "mpg123_decode_frame"
+- "name": "mpg123_decode_frame"
   "params":
   - "name": "mh"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mpg123_decode_frame(mpg123_handle *, off_t *, unsigned char **, size_t *)"
-- "exceptions": []
-  "name": "mpg123_feedseek64"
+- "name": "mpg123_feedseek64"
   "params":
   - "name": "mh"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "int64_t mpg123_feedseek64(mpg123_handle *, int64_t, int, int64_t *)"
-- "exceptions": []
-  "name": "mpg123_open_fixed"
+- "name": "mpg123_open_fixed"
   "params":
   - "name": "mh"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int mpg123_open_fixed(mpg123_handle *, const char *, int, int)"
-- "exceptions": []
-  "name": "mpg123_decode_frame64"
+- "name": "mpg123_decode_frame64"
   "params":
   - "name": "mh"
     "type": "bool "

--- a/benchmark-sets/all/mruby.yaml
+++ b/benchmark-sets/all/mruby.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mrb_load_file_cxt"
+- "name": "mrb_load_file_cxt"
   "params":
   - "name": "mrb"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "mrb_value mrb_load_file_cxt(mrb_state *, FILE *, mrb_ccontext *)"
-- "exceptions": []
-  "name": "mrb_load_nstring"
+- "name": "mrb_load_nstring"
   "params":
   - "name": "mrb"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "mrb_value mrb_load_nstring(mrb_state *, const char *, size_t)"
-- "exceptions": []
-  "name": "mrb_load_file"
+- "name": "mrb_load_file"
   "params":
   - "name": "mrb"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "mrb_value mrb_load_file(mrb_state *, FILE *)"
-- "exceptions": []
-  "name": "mrb_load_detect_file_cxt"
+- "name": "mrb_load_detect_file_cxt"
   "params":
   - "name": "mrb"
     "type": "bool "

--- a/benchmark-sets/all/ms-tpm-20-ref.yaml
+++ b/benchmark-sets/all/ms-tpm-20-ref.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "TPM2_Load"
+- "name": "TPM2_Load"
   "params":
   - "name": "in"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Load(Load_In *, Load_Out *)"
-- "exceptions": []
-  "name": "TPM2_Import"
+- "name": "TPM2_Import"
   "params":
   - "name": "in"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Import(Import_In *, Import_Out *)"
-- "exceptions": []
-  "name": "TPM2_Create"
+- "name": "TPM2_Create"
   "params":
   - "name": "in"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_Create(Create_In *, Create_Out *)"
-- "exceptions": []
-  "name": "TPM2_NV_Certify"
+- "name": "TPM2_NV_Certify"
   "params":
   - "name": "in"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TPM_RC TPM2_NV_Certify(NV_Certify_In *, NV_Certify_Out *)"
-- "exceptions": []
-  "name": "TPM2_CertifyX509"
+- "name": "TPM2_CertifyX509"
   "params":
   - "name": "in"
     "type": "bool "

--- a/benchmark-sets/all/msgpack-c.yaml
+++ b/benchmark-sets/all/msgpack-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7msgpack2v14zone9finalizerclEv"
+- "name": "_ZN7msgpack2v14zone9finalizerclEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/muduo.yaml
+++ b/benchmark-sets/all/muduo.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN5muduo6Thread5startEv"
+- "name": "_ZN5muduo6Thread5startEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void muduo::Thread::start()"
-- "exceptions": []
-  "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEiNS0_8LogLevelE"
+- "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEiNS0_8LogLevelE"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void muduo::Logger::Logger(SourceFile, int, DW_TAG_enumeration_typeLogLevel)"
-- "exceptions": []
-  "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEiNS0_8LogLevelEPKc"
+- "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEiNS0_8LogLevelEPKc"
   "params":
   - "name": ""
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void muduo::Logger::Logger(SourceFile, int, DW_TAG_enumeration_typeLogLevel, const char *)"
-- "exceptions": []
-  "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEib"
+- "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEib"
   "params":
   - "name": ""
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void muduo::Logger::Logger(SourceFile, int, bool)"
-- "exceptions": []
-  "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEi"
+- "name": "_ZN5muduo6LoggerC2ENS0_10SourceFileEi"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/muparser.yaml
+++ b/benchmark-sets/all/muparser.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK2mu10ParserBase9StackDumpERKNSt3__15stackINS_11ParserTokenIdNS1_12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEEENS1_5dequeISA_NS7_ISA_EEEEEESG_"
+- "name": "_ZNK2mu10ParserBase9StackDumpERKNSt3__15stackINS_11ParserTokenIdNS1_12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEEENS1_5dequeISA_NS7_ISA_EEEEEESG_"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void mu::ParserBase::StackDump(const stack<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::deque<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > > &, const stack<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::deque<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > > &)"
-- "exceptions": []
-  "name": "_ZNK2mu10ParserBase12ApplyStrFuncERKNS_11ParserTokenIdNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEEERKNS2_6vectorIS9_NS6_IS9_EEEE"
+- "name": "_ZNK2mu10ParserBase12ApplyStrFuncERKNS_11ParserTokenIdNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEEERKNS2_6vectorIS9_NS6_IS9_EEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "token_type mu::ParserBase::ApplyStrFunc(const token_type &, const vector<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<mu::ParserToken<double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > &)"
-- "exceptions": []
-  "name": "_ZN2mu10ParserBase4EvalEPdi"
+- "name": "_ZN2mu10ParserBase4EvalEPdi"
   "params":
   - "name": ""
     "type": "bool "
@@ -34,15 +31,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void mu::ParserBase::Eval(value_type *, int)"
-- "exceptions": []
-  "name": "_ZNK2mu10ParserBase10GetUsedVarEv"
+- "name": "_ZNK2mu10ParserBase10GetUsedVarEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "const varmap_type & mu::ParserBase::GetUsedVar()"
-- "exceptions": []
-  "name": "_ZNK2mu10ParserBase4EvalERi"
+- "name": "_ZNK2mu10ParserBase4EvalERi"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/mupdf.yaml
+++ b/benchmark-sets/all/mupdf.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "pdf_save_document"
+- "name": "pdf_save_document"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void pdf_save_document(fz_context *, pdf_document *, const char *, const pdf_write_options *)"
-- "exceptions": []
-  "name": "pdf_update_widget"
+- "name": "pdf_update_widget"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int pdf_update_widget(fz_context *, pdf_annot *)"
-- "exceptions": []
-  "name": "fz_new_document_writer"
+- "name": "fz_new_document_writer"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "fz_document_writer * fz_new_document_writer(fz_context *, const char *, const char *, const char *)"
-- "exceptions": []
-  "name": "pdf_bake_document"
+- "name": "pdf_bake_document"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void pdf_bake_document(fz_context *, pdf_document *, int, int)"
-- "exceptions": []
-  "name": "pdf_save_snapshot"
+- "name": "pdf_save_snapshot"
   "params":
   - "name": "ctx"
     "type": "bool "

--- a/benchmark-sets/all/nanopb.yaml
+++ b/benchmark-sets/all/nanopb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "pb_get_encoded_size"
+- "name": "pb_get_encoded_size"
   "params":
   - "name": "size"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool pb_get_encoded_size(size_t *, const pb_msgdesc_t *, const void *)"
-- "exceptions": []
-  "name": "pb_encode_ex"
+- "name": "pb_encode_ex"
   "params":
   - "name": "stream"
     "type": "bool "

--- a/benchmark-sets/all/ndpi.yaml
+++ b/benchmark-sets/all/ndpi.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mbedtls_cipher_write_tag"
+- "name": "mbedtls_cipher_write_tag"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int mbedtls_cipher_write_tag(mbedtls_cipher_context_t *, unsigned char *, size_t)"
-- "exceptions": []
-  "name": "mbedtls_cipher_update_ad"
+- "name": "mbedtls_cipher_update_ad"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int mbedtls_cipher_update_ad(mbedtls_cipher_context_t *, const unsigned char *, size_t)"
-- "exceptions": []
-  "name": "mbedtls_cipher_check_tag"
+- "name": "mbedtls_cipher_check_tag"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int mbedtls_cipher_check_tag(mbedtls_cipher_context_t *, const unsigned char *, size_t)"
-- "exceptions": []
-  "name": "libinjection_sqli_get_token"
+- "name": "libinjection_sqli_get_token"
   "params":
   - "name": "sql_state"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "struct libinjection_sqli_token * libinjection_sqli_get_token(struct libinjection_sqli_state *, int)"
-- "exceptions": []
-  "name": "libinjection_sqli_lookup_word"
+- "name": "libinjection_sqli_lookup_word"
   "params":
   - "name": "sql_state"
     "type": "bool "

--- a/benchmark-sets/all/neomutt.yaml
+++ b/benchmark-sets/all/neomutt.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mutt_send_message"
+- "name": "mutt_send_message"
   "params":
   - "name": ""
     "type": "int"
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mutt_send_message(SendFlags, struct Email *, const char *, struct Mailbox *, struct EmailArray *, struct ConfigSubset *)"
-- "exceptions": []
-  "name": "mutt_send_list_unsubscribe"
+- "name": "mutt_send_list_unsubscribe"
   "params":
   - "name": ""
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool mutt_send_list_unsubscribe(struct Mailbox *, struct Email *)"
-- "exceptions": []
-  "name": "mutt_send_list_subscribe"
+- "name": "mutt_send_list_subscribe"
   "params":
   - "name": ""
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool mutt_send_list_subscribe(struct Mailbox *, struct Email *)"
-- "exceptions": []
-  "name": "mutt_resend_message"
+- "name": "mutt_resend_message"
   "params":
   - "name": ""
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mutt_resend_message(FILE *, struct Mailbox *, struct Email *, struct ConfigSubset *)"
-- "exceptions": []
-  "name": "mutt_get_postponed"
+- "name": "mutt_get_postponed"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/nestegg.yaml
+++ b/benchmark-sets/all/nestegg.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "nestegg_track_seek"
+- "name": "nestegg_track_seek"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int nestegg_track_seek(nestegg *, unsigned int, uint64_t)"
-- "exceptions": []
-  "name": "nestegg_get_cue_point"
+- "name": "nestegg_get_cue_point"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int nestegg_get_cue_point(nestegg *, unsigned int, int64_t, int64_t *, int64_t *, uint64_t *)"
-- "exceptions": []
-  "name": "nestegg_offset_seek"
+- "name": "nestegg_offset_seek"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -36,15 +33,13 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int nestegg_offset_seek(nestegg *, uint64_t)"
-- "exceptions": []
-  "name": "nestegg_read_reset"
+- "name": "nestegg_read_reset"
   "params":
   - "name": "ctx"
     "type": "bool "
   "return_type": "int"
   "signature": "int nestegg_read_reset(nestegg *)"
-- "exceptions": []
-  "name": "nestegg_sniff"
+- "name": "nestegg_sniff"
   "params":
   - "name": "buffer"
     "type": "bool "

--- a/benchmark-sets/all/net-snmp.yaml
+++ b/benchmark-sets/all/net-snmp.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "smux_accept"
+- "name": "smux_accept"
   "params":
   - "name": "sd"
     "type": "int"
   "return_type": "int"
   "signature": "int smux_accept(int)"
-- "exceptions": []
-  "name": "netsnmp_query_getnext"
+- "name": "netsnmp_query_getnext"
   "params":
   - "name": "list"
     "type": "bool "
@@ -15,15 +13,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int netsnmp_query_getnext(netsnmp_variable_list *, netsnmp_session *)"
-- "exceptions": []
-  "name": "agent_check_and_process"
+- "name": "agent_check_and_process"
   "params":
   - "name": "block"
     "type": "int"
   "return_type": "int"
   "signature": "int agent_check_and_process(int)"
-- "exceptions": []
-  "name": "netsnmp_query_walk"
+- "name": "netsnmp_query_walk"
   "params":
   - "name": "list"
     "type": "bool "
@@ -31,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int netsnmp_query_walk(netsnmp_variable_list *, netsnmp_session *)"
-- "exceptions": []
-  "name": "netsnmp_query_set"
+- "name": "netsnmp_query_set"
   "params":
   - "name": "list"
     "type": "bool "

--- a/benchmark-sets/all/nghttp2.yaml
+++ b/benchmark-sets/all/nghttp2.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "nghttp2_session_recv"
+- "name": "nghttp2_session_recv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "int nghttp2_session_recv(nghttp2_session *)"
-- "exceptions": []
-  "name": "nghttp2_session_mem_send"
+- "name": "nghttp2_session_mem_send"
   "params":
   - "name": ""
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t nghttp2_session_mem_send(nghttp2_session *, const uint8_t **)"
-- "exceptions": []
-  "name": "nghttp2_submit_request2"
+- "name": "nghttp2_submit_request2"
   "params":
   - "name": ""
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int32_t nghttp2_submit_request2(nghttp2_session *, const nghttp2_priority_spec *, const nghttp2_nv *, size_t, const nghttp2_data_provider2 *, void *)"
-- "exceptions": []
-  "name": "nghttp2_session_mem_recv"
+- "name": "nghttp2_session_mem_recv"
   "params":
   - "name": ""
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "ssize_t nghttp2_session_mem_recv(nghttp2_session *, const uint8_t *, size_t)"
-- "exceptions": []
-  "name": "nghttp2_session_send"
+- "name": "nghttp2_session_send"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/ninja.yaml
+++ b/benchmark-sets/all/ninja.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN14DependencyScan18RecomputeNodeDirtyEP4NodePNSt3__16vectorIS1_NS2_9allocatorIS1_EEEES7_PNS2_12basic_stringIcNS2_11char_traitsIcEENS4_IcEEEE"
+- "name": "_ZN14DependencyScan18RecomputeNodeDirtyEP4NodePNSt3__16vectorIS1_NS2_9allocatorIS1_EEEES7_PNS2_12basic_stringIcNS2_11char_traitsIcEENS4_IcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool DependencyScan::RecomputeNodeDirty(struct DependencyScan *, struct Node *, vector<Node *, std::__1::allocator<Node *> > *, vector<Node *, std::__1::allocator<Node *> > *, string *)"
-- "exceptions": []
-  "name": "_ZN12DyndepParser5ParseERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_PS6_"
+- "name": "_ZN12DyndepParser5ParseERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_PS6_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool DyndepParser::Parse(struct DyndepParser *, const string &, const string &, string *)"
-- "exceptions": []
-  "name": "_ZN12DyndepParser9ParseEdgeEPNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE"
+- "name": "_ZN12DyndepParser9ParseEdgeEPNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool DyndepParser::ParseEdge(struct DyndepParser *, string *)"
-- "exceptions": []
-  "name": "_ZN14DependencyScan14RecomputeDirtyEP4NodePNSt3__16vectorIS1_NS2_9allocatorIS1_EEEEPNS2_12basic_stringIcNS2_11char_traitsIcEENS4_IcEEEE"
+- "name": "_ZN14DependencyScan14RecomputeDirtyEP4NodePNSt3__16vectorIS1_NS2_9allocatorIS1_EEEEPNS2_12basic_stringIcNS2_11char_traitsIcEENS4_IcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool DependencyScan::RecomputeDirty(struct DependencyScan *, struct Node *, vector<Node *, std::__1::allocator<Node *> > *, string *)"
-- "exceptions": []
-  "name": "_ZN17ImplicitDepLoader8LoadDepsEP4EdgePNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE"
+- "name": "_ZN17ImplicitDepLoader8LoadDepsEP4EdgePNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/njs.yaml
+++ b/benchmark-sets/all/njs.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "njs_buffer_new"
+- "name": "njs_buffer_new"
   "params":
   - "name": "vm"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "njs_int_t njs_buffer_new(njs_vm_t *, njs_value_t *, const u_char *, uint32_t)"
-- "exceptions": []
-  "name": "njs_vm_query_string_parse"
+- "name": "njs_vm_query_string_parse"
   "params":
   - "name": "vm"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "njs_int_t njs_vm_query_string_parse(njs_vm_t *, u_char *, u_char *, njs_value_t *)"
-- "exceptions": []
-  "name": "njs_vm_value_string"
+- "name": "njs_vm_value_string"
   "params":
   - "name": "vm"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "njs_int_t njs_vm_value_string(njs_vm_t *, njs_str_t *, njs_value_t *)"
-- "exceptions": []
-  "name": "njs_vm_exception_string"
+- "name": "njs_vm_exception_string"
   "params":
   - "name": "vm"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "njs_int_t njs_vm_exception_string(njs_vm_t *, njs_str_t *)"
-- "exceptions": []
-  "name": "njs_vm_clone"
+- "name": "njs_vm_clone"
   "params":
   - "name": "vm"
     "type": "bool "

--- a/benchmark-sets/all/nss.yaml
+++ b/benchmark-sets/all/nss.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sqlite3_get_table"
+- "name": "sqlite3_get_table"
   "params":
   - "name": "db"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int sqlite3_get_table(sqlite3 *, const char *, char ***, int *, int *, char **)"
-- "exceptions": []
-  "name": "SSLExp_RecordLayerData"
+- "name": "SSLExp_RecordLayerData"
   "params":
   - "name": "fd"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "SECStatus SSLExp_RecordLayerData(PRFileDesc *, PRUint16, SSLContentType, const PRUint8 *, unsigned int)"
-- "exceptions": []
-  "name": "sqlite3_blob_open"
+- "name": "sqlite3_blob_open"
   "params":
   - "name": "db"
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int sqlite3_blob_open(sqlite3 *, const char *, const char *, const char *, sqlite_int64, int, sqlite3_blob **)"
-- "exceptions": []
-  "name": "SSL_ForceHandshakeWithTimeout"
+- "name": "SSL_ForceHandshakeWithTimeout"
   "params":
   - "name": "fd"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "SECStatus SSL_ForceHandshakeWithTimeout(PRFileDesc *, PRIntervalTime)"
-- "exceptions": []
-  "name": "s_open"
+- "name": "s_open"
   "params":
   - "name": "directory"
     "type": "bool "

--- a/benchmark-sets/all/ntopng.yaml
+++ b/benchmark-sets/all/ntopng.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN21ZMQCollectorInterface13collect_flowsEv"
+- "name": "_ZN21ZMQCollectorInterface13collect_flowsEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void ZMQCollectorInterface::collect_flows()"
-- "exceptions": []
-  "name": "_ZN18ZMQParserInterface12parseTLVFlowEPKcijjPv"
+- "name": "_ZN18ZMQParserInterface12parseTLVFlowEPKcijjPv"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "char"
   "signature": "u_int8_t ZMQParserInterface::parseTLVFlow(const char *, int, u_int32_t, u_int32_t, void *)"
-- "exceptions": []
-  "name": "_ZN18ZMQParserInterface19parseSingleJSONFlowEP11json_objectj"
+- "name": "_ZN18ZMQParserInterface19parseSingleJSONFlowEP11json_objectj"
   "params":
   - "name": "this"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int ZMQParserInterface::parseSingleJSONFlow(json_object *, u_int32_t)"
-- "exceptions": []
-  "name": "_ZN13PcapInterface17processNextPacketEP4pcapii"
+- "name": "_ZN13PcapInterface17processNextPacketEP4pcapii"
   "params":
   - "name": "this"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool PcapInterface::processNextPacket(pcap_t *, int32_t, int)"
-- "exceptions": []
-  "name": "_ZN18ZMQParserInterface18parseSingleTLVFlowEP15ndpi_serializerj"
+- "name": "_ZN18ZMQParserInterface18parseSingleTLVFlowEP15ndpi_serializerj"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/ntpsec.yaml
+++ b/benchmark-sets/all/ntpsec.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "nts_make_cookie"
+- "name": "nts_make_cookie"
   "params":
   - "name": "cookie"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int nts_make_cookie(uint8_t *, uint16_t, uint8_t *, uint8_t *, int)"
-- "exceptions": []
-  "name": "nts_ke_setup_send"
+- "name": "nts_ke_setup_send"
   "params":
   - "name": "buf"
     "type": "bool "

--- a/benchmark-sets/all/numactl.yaml
+++ b/benchmark-sets/all/numactl.yaml
@@ -1,34 +1,29 @@
 "functions":
-- "exceptions": []
-  "name": "numa_node_of_cpu"
+- "name": "numa_node_of_cpu"
   "params":
   - "name": "cpu"
     "type": "int"
   "return_type": "int"
   "signature": "int numa_node_of_cpu(int)"
-- "exceptions": []
-  "name": "numa_run_on_node"
+- "name": "numa_run_on_node"
   "params":
   - "name": "node"
     "type": "int"
   "return_type": "int"
   "signature": "int numa_run_on_node(int)"
-- "exceptions": []
-  "name": "numa_set_preferred_many"
+- "name": "numa_set_preferred_many"
   "params":
   - "name": "bitmask"
     "type": "bool "
   "return_type": "void"
   "signature": "void numa_set_preferred_many(struct bitmask *)"
-- "exceptions": []
-  "name": "numa_parse_nodestring_all"
+- "name": "numa_parse_nodestring_all"
   "params":
   - "name": "s"
     "type": "bool "
   "return_type": "void"
   "signature": "struct bitmask * numa_parse_nodestring_all(const char *)"
-- "exceptions": []
-  "name": "numa_run_on_node_mask_all"
+- "name": "numa_run_on_node_mask_all"
   "params":
   - "name": "bmp"
     "type": "bool "

--- a/benchmark-sets/all/ogre.yaml
+++ b/benchmark-sets/all/ogre.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4Ogre12SceneManager12_renderSceneEPNS_6CameraEPNS_8ViewportEb"
+- "name": "_ZN4Ogre12SceneManager12_renderSceneEPNS_6CameraEPNS_8ViewportEb"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void Ogre::SceneManager::_renderScene(Camera *, Viewport *, bool)"
-- "exceptions": []
-  "name": "_ZN4Ogre12TerrainGroup17loadLegacyTerrainERKNS_10ConfigFileEllb"
+- "name": "_ZN4Ogre12TerrainGroup17loadLegacyTerrainERKNS_10ConfigFileEllb"
   "params":
   - "name": ""
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void Ogre::TerrainGroup::loadLegacyTerrain(const ConfigFile &, long, long, bool)"
-- "exceptions": []
-  "name": "_ZN4Ogre14DotSceneLoader4loadERNS_9SharedPtrINS_10DataStreamEEERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEPNS_9SceneNodeE"
+- "name": "_ZN4Ogre14DotSceneLoader4loadERNS_9SharedPtrINS_10DataStreamEEERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEPNS_9SceneNodeE"
   "params":
   - "name": ""
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void Ogre::DotSceneLoader::load(DataStreamPtr &, const String &, SceneNode *)"
-- "exceptions": []
-  "name": "_ZNK12_GLOBAL__N_113DotSceneCodec6decodeERKN4Ogre9SharedPtrINS1_10DataStreamEEERKNS1_3AnyE"
+- "name": "_ZNK12_GLOBAL__N_113DotSceneCodec6decodeERKN4Ogre9SharedPtrINS1_10DataStreamEEERKNS1_3AnyE"
   "params":
   - "name": ""
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void (anonymous namespace)::DotSceneCodec::decode(const struct DotSceneCodec *, const DataStreamPtr &, const Any &)"
-- "exceptions": []
-  "name": "_ZN4Ogre12TerrainGroup17loadLegacyTerrainERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEllb"
+- "name": "_ZN4Ogre12TerrainGroup17loadLegacyTerrainERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEllb"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/oniguruma.yaml
+++ b/benchmark-sets/all/oniguruma.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "onig_set_meta_char"
+- "name": "onig_set_meta_char"
   "params":
   - "name": "enc"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int onig_set_meta_char(OnigSyntaxType *, unsigned int, OnigCodePoint)"
-- "exceptions": []
-  "name": "onig_scan"
+- "name": "onig_scan"
   "params":
   - "name": "reg"
     "type": "bool "

--- a/benchmark-sets/all/open5gs.yaml
+++ b/benchmark-sets/all/open5gs.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ogs_nas_esm_decode"
+- "name": "ogs_nas_esm_decode"
   "params":
   - "name": "message"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ogs_nas_esm_decode(ogs_nas_eps_message_t *, ogs_pkbuf_t *)"
-- "exceptions": []
-  "name": "ogs_gtp_context_parse_config"
+- "name": "ogs_gtp_context_parse_config"
   "params":
   - "name": "local"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ogs_gtp_context_parse_config(const char *, const char *)"
-- "exceptions": []
-  "name": "ogs_gtp2_send_echo_request"
+- "name": "ogs_gtp2_send_echo_request"
   "params":
   - "name": "gnode"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "char"
   "return_type": "void"
   "signature": "void ogs_gtp2_send_echo_request(ogs_gtp_node_t *, uint8_t, uint8_t)"
-- "exceptions": []
-  "name": "ogs_gtp2_send_error_message"
+- "name": "ogs_gtp2_send_error_message"
   "params":
   - "name": "xact"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "char"
   "return_type": "void"
   "signature": "void ogs_gtp2_send_error_message(ogs_gtp_xact_t *, uint32_t, uint8_t, uint8_t)"
-- "exceptions": []
-  "name": "ogs_gtp2_send_echo_response"
+- "name": "ogs_gtp2_send_echo_response"
   "params":
   - "name": "xact"
     "type": "bool "

--- a/benchmark-sets/all/open62541.yaml
+++ b/benchmark-sets/all/open62541.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "UA_Server_addReaderGroup"
+- "name": "UA_Server_addReaderGroup"
   "params":
   - "name": "server"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "UA_StatusCode UA_Server_addReaderGroup(UA_Server *, const UA_NodeId, const UA_ReaderGroupConfig *, UA_NodeId *)"
-- "exceptions": []
-  "name": "UA_Server_addPubSubConnection"
+- "name": "UA_Server_addPubSubConnection"
   "params":
   - "name": "server"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "UA_StatusCode UA_Server_addPubSubConnection(UA_Server *, const UA_PubSubConnectionConfig *, UA_NodeId *)"
-- "exceptions": []
-  "name": "UA_Server_addWriterGroup"
+- "name": "UA_Server_addWriterGroup"
   "params":
   - "name": "server"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "UA_StatusCode UA_Server_addWriterGroup(UA_Server *, const UA_NodeId, const UA_WriterGroupConfig *, UA_NodeId *)"
-- "exceptions": []
-  "name": "UA_ServerConfig_setDefaultWithFilestore"
+- "name": "UA_ServerConfig_setDefaultWithFilestore"
   "params":
   - "name": "conf"
     "type": "bool "

--- a/benchmark-sets/all/openbabel.yaml
+++ b/benchmark-sets/all/openbabel.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN9OpenBabel18GAMESSOutputFormat12ReadMoleculeEPNS_6OBBaseEPNS_12OBConversionE"
+- "name": "_ZN9OpenBabel18GAMESSOutputFormat12ReadMoleculeEPNS_6OBBaseEPNS_12OBConversionE"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool OpenBabel::GAMESSOutputFormat::ReadMolecule(OBBase *, OBConversion *)"
-- "exceptions": []
-  "name": "_ZN9OpenBabel21ChemDrawBinaryXFormat12ReadMoleculeEPNS_6OBBaseEPNS_12OBConversionE"
+- "name": "_ZN9OpenBabel21ChemDrawBinaryXFormat12ReadMoleculeEPNS_6OBBaseEPNS_12OBConversionE"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool OpenBabel::ChemDrawBinaryXFormat::ReadMolecule(OBBase *, OBConversion *)"
-- "exceptions": []
-  "name": "_ZN9OpenBabel7OpGen3D2DoEPNS_6OBBaseEPKcPKNSt3__13mapINS5_12basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEESC_NS5_4lessISC_EENSA_INS5_4pairIKSC_SC_EEEEEEPNS_12OBConversionE"
+- "name": "_ZN9OpenBabel7OpGen3D2DoEPNS_6OBBaseEPKcPKNSt3__13mapINS5_12basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEESC_NS5_4lessISC_EENSA_INS5_4pairIKSC_SC_EEEEEEPNS_12OBConversionE"
   "params":
   - "name": ""
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool OpenBabel::OpGen3D::Do(OBBase *, const char *, OpMap *, OBConversion *)"
-- "exceptions": []
-  "name": "_ZN9OpenBabel10VASPFormat12ReadMoleculeEPNS_6OBBaseEPNS_12OBConversionE"
+- "name": "_ZN9OpenBabel10VASPFormat12ReadMoleculeEPNS_6OBBaseEPNS_12OBConversionE"
   "params":
   - "name": ""
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool OpenBabel::VASPFormat::ReadMolecule(OBBase *, OBConversion *)"
-- "exceptions": []
-  "name": "_ZN9OpenBabel9AliasData14FromNameLookupERNS_5OBMolEj"
+- "name": "_ZN9OpenBabel9AliasData14FromNameLookupERNS_5OBMolEj"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/opendnp3.yaml
+++ b/benchmark-sets/all/opendnp3.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8opendnp38OContext9OnTxReadyEv"
+- "name": "_ZN8opendnp38OContext9OnTxReadyEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "bool"
   "signature": "bool opendnp3::OContext::OnTxReady()"
-- "exceptions": []
-  "name": "_ZZN8opendnp38OContext22RestartSolConfirmTimerEvENK3$_0clEv"
+- "name": "_ZZN8opendnp38OContext22RestartSolConfirmTimerEvENK3$_0clEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void opendnp3::OContext::operator()(const void *)"
-- "exceptions": []
-  "name": "_ZN8opendnp325StateSolicitedConfirmWait19OnNewNonReadRequestERNS_8OContextERKNS_13ParsedRequestE"
+- "name": "_ZN8opendnp325StateSolicitedConfirmWait19OnNewNonReadRequestERNS_8OContextERKNS_13ParsedRequestE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "OutstationState & opendnp3::StateSolicitedConfirmWait::OnNewNonReadRequest(OContext &, const struct ParsedRequest &)"
-- "exceptions": []
-  "name": "_ZN8opendnp320FreezeRequestHandler13ProcessHeaderERKNS_11RangeHeaderE"
+- "name": "_ZN8opendnp320FreezeRequestHandler13ProcessHeaderERKNS_11RangeHeaderE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "bool "
   "return_type": "short"
   "signature": "IINField opendnp3::FreezeRequestHandler::ProcessHeader(const RangeHeader &)"
-- "exceptions": []
-  "name": "_ZN8opendnp327StateUnsolicitedConfirmWait19OnNewNonReadRequestERNS_8OContextERKNS_13ParsedRequestE"
+- "name": "_ZN8opendnp327StateUnsolicitedConfirmWait19OnNewNonReadRequestERNS_8OContextERKNS_13ParsedRequestE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/openexr.yaml
+++ b/benchmark-sets/all/openexr.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7Imf_3_318DeepTiledInputFile8readTileEiii"
+- "name": "_ZN7Imf_3_318DeepTiledInputFile8readTileEiii"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void Imf_3_3::DeepTiledInputFile::readTile(int, int, int)"
-- "exceptions": []
-  "name": "_ZN7Imf_3_314RgbaOutputFile11writePixelsEi"
+- "name": "_ZN7Imf_3_314RgbaOutputFile11writePixelsEi"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void Imf_3_3::RgbaOutputFile::writePixels(int)"
-- "exceptions": []
-  "name": "_ZN7Imf_3_314RgbaOutputFile5ToYca11writePixelsEi"
+- "name": "_ZN7Imf_3_314RgbaOutputFile5ToYca11writePixelsEi"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void Imf_3_3::RgbaOutputFile::ToYca::writePixels(int)"
-- "exceptions": []
-  "name": "_ZN7Imf_3_318DeepTiledInputPart8readTileEiii"
+- "name": "_ZN7Imf_3_318DeepTiledInputPart8readTileEiii"
   "params":
   - "name": ""
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void Imf_3_3::DeepTiledInputPart::readTile(int, int, int)"
-- "exceptions": []
-  "name": "_ZN7Imf_3_310OutputFile10initializeERKNS_6HeaderE"
+- "name": "_ZN7Imf_3_310OutputFile10initializeERKNS_6HeaderE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/openh264.yaml
+++ b/benchmark-sets/all/openh264.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7WelsDec12CWelsDecoder18OpenDecoderThreadsEv"
+- "name": "_ZN7WelsDec12CWelsDecoder18OpenDecoderThreadsEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void WelsDec::CWelsDecoder::OpenDecoderThreads()"
-- "exceptions": []
-  "name": "_ZN7WelsDec12CWelsDecoder18DecodeFrameNoDelayEPKhiPPhP13TagBufferInfo"
+- "name": "_ZN7WelsDec12CWelsDecoder18DecodeFrameNoDelayEPKhiPPhP13TagBufferInfo"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DECODING_STATE WelsDec::CWelsDecoder::DecodeFrameNoDelay(const unsigned char *, const int, unsigned char **, SBufferInfo *)"
-- "exceptions": []
-  "name": "SemWait"
+- "name": "SemWait"
   "params":
   - "name": "s"
     "type": "bool "
@@ -30,15 +27,13 @@
     "type": "int"
   "return_type": "int"
   "signature": "int SemWait(SWelsDecSemphore *, int32_t)"
-- "exceptions": []
-  "name": "_ZN7WelsDec12CWelsDecoder19CloseDecoderThreadsEv"
+- "name": "_ZN7WelsDec12CWelsDecoder19CloseDecoderThreadsEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void WelsDec::CWelsDecoder::CloseDecoderThreads()"
-- "exceptions": []
-  "name": "_ZN7WelsDec12CWelsDecoder12DecodeParserEPKhiP15TagParserBsInfo"
+- "name": "_ZN7WelsDec12CWelsDecoder12DecodeParserEPKhiP15TagParserBsInfo"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/openjpeg.yaml
+++ b/benchmark-sets/all/openjpeg.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "opj_jp2_get_tile"
+- "name": "opj_jp2_get_tile"
   "params":
   - "name": ""
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "OPJ_BOOL opj_jp2_get_tile(opj_jp2_t *, opj_stream_private_t *, opj_image_t *, opj_event_mgr_t *, OPJ_UINT32)"
-- "exceptions": []
-  "name": "opj_jp2_decode_tile"
+- "name": "opj_jp2_decode_tile"
   "params":
   - "name": ""
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OPJ_BOOL opj_jp2_decode_tile(opj_jp2_t *, OPJ_UINT32, OPJ_BYTE *, OPJ_UINT32, opj_stream_private_t *, opj_event_mgr_t *)"
-- "exceptions": []
-  "name": "opj_j2k_encode"
+- "name": "opj_j2k_encode"
   "params":
   - "name": ""
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OPJ_BOOL opj_j2k_encode(opj_j2k_t *, opj_stream_private_t *, opj_event_mgr_t *)"
-- "exceptions": []
-  "name": "opj_jp2_encode"
+- "name": "opj_jp2_encode"
   "params":
   - "name": ""
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "OPJ_BOOL opj_jp2_encode(opj_jp2_t *, opj_stream_private_t *, opj_event_mgr_t *)"
-- "exceptions": []
-  "name": "opj_j2k_get_tile"
+- "name": "opj_j2k_get_tile"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/opennavsurf-bag.yaml
+++ b/benchmark-sets/all/opennavsurf-bag.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNR3BAG7Dataset25createGeorefMetadataLayerE13BAG_DATA_TYPE23GEOREF_METADATA_PROFILERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEERKNS3_6vectorI15FieldDefinitionNS7_ISD_EEEEmi"
+- "name": "_ZNR3BAG7Dataset25createGeorefMetadataLayerE13BAG_DATA_TYPE23GEOREF_METADATA_PROFILERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEERKNS3_6vectorI15FieldDefinitionNS7_ISD_EEEEmi"
   "params":
   - "name": ""
     "type": "bool "
@@ -18,8 +17,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "GeorefMetadataLayer & BAG::Dataset::createGeorefMetadataLayer(DataType, GeorefMetadataProfile, const string &, const RecordDefinition &, uint64_t, int)"
-- "exceptions": []
-  "name": "_ZN3BAG7Dataset6createERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEONS_8MetadataEmi"
+- "name": "_ZN3BAG7Dataset6createERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEONS_8MetadataEmi"
   "params":
   - "name": ""
     "type": "bool "
@@ -33,8 +31,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "shared_ptr<BAG::Dataset> BAG::Dataset::create(const string &, DW_TAG_rvalue_reference_typeMetadata, uint64_t, int)"
-- "exceptions": []
-  "name": "_ZNR3BAG7Dataset25createGeorefMetadataLayerE23GEOREF_METADATA_PROFILERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEmi13BAG_DATA_TYPE"
+- "name": "_ZNR3BAG7Dataset25createGeorefMetadataLayerE23GEOREF_METADATA_PROFILERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEmi13BAG_DATA_TYPE"
   "params":
   - "name": ""
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "GeorefMetadataLayer & BAG::Dataset::createGeorefMetadataLayer(GeorefMetadataProfile, const string &, uint64_t, int, DataType)"
-- "exceptions": []
-  "name": "_ZN3BAG8MetadataC2ENSt3__110shared_ptrINS_7DatasetEEE"
+- "name": "_ZN3BAG8MetadataC2ENSt3__110shared_ptrINS_7DatasetEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void BAG::Metadata::Metadata(shared_ptr<BAG::Dataset>)"
-- "exceptions": []
-  "name": "_ZN3BAG8Metadata12loadFromFileERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE"
+- "name": "_ZN3BAG8Metadata12loadFromFileERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/opensc.yaml
+++ b/benchmark-sets/all/opensc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sc_pkcs15init_change_attrib"
+- "name": "sc_pkcs15init_change_attrib"
   "params":
   - "name": "p15card"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sc_pkcs15init_change_attrib(struct sc_pkcs15_card *, struct sc_profile *, struct sc_pkcs15_object *, int, void *, int)"
-- "exceptions": []
-  "name": "awp_update_df_delete"
+- "name": "awp_update_df_delete"
   "params":
   - "name": "p15card"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int awp_update_df_delete(struct sc_pkcs15_card *, struct sc_profile *, struct sc_pkcs15_object *)"
-- "exceptions": []
-  "name": "sc_pkcs15init_update_certificate"
+- "name": "sc_pkcs15init_update_certificate"
   "params":
   - "name": "p15card"
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int sc_pkcs15init_update_certificate(struct sc_pkcs15_card *, struct sc_profile *, struct sc_pkcs15_object *, const unsigned char *, size_t)"
-- "exceptions": []
-  "name": "sc_pkcs15init_delete_object"
+- "name": "sc_pkcs15init_delete_object"
   "params":
   - "name": "p15card"
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int sc_pkcs15init_delete_object(struct sc_pkcs15_card *, struct sc_profile *, struct sc_pkcs15_object *)"
-- "exceptions": []
-  "name": "sc_pkcs15init_store_private_key"
+- "name": "sc_pkcs15init_store_private_key"
   "params":
   - "name": "p15card"
     "type": "bool "

--- a/benchmark-sets/all/opensips.yaml
+++ b/benchmark-sets/all/opensips.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "receive_msg"
+- "name": "receive_msg"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -14,22 +13,19 @@
     "type": "int"
   "return_type": "int"
   "signature": "int receive_msg(char *, unsigned int, struct receive_info *, context_p, unsigned int)"
-- "exceptions": []
-  "name": "start_timer_extra_processes"
+- "name": "start_timer_extra_processes"
   "params":
   - "name": "chd_rank"
     "type": "bool "
   "return_type": "int"
   "signature": "int start_timer_extra_processes(int *)"
-- "exceptions": []
-  "name": "parse_sdp"
+- "name": "parse_sdp"
   "params":
   - "name": "_m"
     "type": "bool "
   "return_type": "void"
   "signature": "sdp_info_t * parse_sdp(struct sip_msg *)"
-- "exceptions": []
-  "name": "parse_opensips_cfg"
+- "name": "parse_opensips_cfg"
   "params":
   - "name": "cfg_file"
     "type": "bool "

--- a/benchmark-sets/all/openssh.yaml
+++ b/benchmark-sets/all/openssh.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "kex_setup"
+- "name": "kex_setup"
   "params":
   - "name": "ssh"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int kex_setup(struct ssh *, char **)"
-- "exceptions": []
-  "name": "ssh_packet_read"
+- "name": "ssh_packet_read"
   "params":
   - "name": "ssh"
     "type": "bool "
   "return_type": "int"
   "signature": "int ssh_packet_read(struct ssh *)"
-- "exceptions": []
-  "name": "ssh_dispatch_run_fatal"
+- "name": "ssh_dispatch_run_fatal"
   "params":
   - "name": "ssh"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void ssh_dispatch_run_fatal(struct ssh *, int, DW_TAG_volatile_typesig_atomic_t *)"
-- "exceptions": []
-  "name": "ssh_dispatch_run"
+- "name": "ssh_dispatch_run"
   "params":
   - "name": "ssh"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ssh_dispatch_run(struct ssh *, int, DW_TAG_volatile_typesig_atomic_t *)"
-- "exceptions": []
-  "name": "kex_gen_client"
+- "name": "kex_gen_client"
   "params":
   - "name": "ssh"
     "type": "bool "

--- a/benchmark-sets/all/openthread.yaml
+++ b/benchmark-sets/all/openthread.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN2ot3Srp6Server17SetAutoEnableModeEb"
+- "name": "_ZN2ot3Srp6Server17SetAutoEnableModeEb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void ot::Srp::Server::SetAutoEnableMode(bool)"
-- "exceptions": []
-  "name": "otSrpServerSetAutoEnableMode"
+- "name": "otSrpServerSetAutoEnableMode"
   "params":
   - "name": "aInstance"
     "type": "bool "
@@ -17,15 +15,13 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void otSrpServerSetAutoEnableMode(otInstance *, bool)"
-- "exceptions": []
-  "name": "_ZN2ot12BorderRouter14RoutingManager4StopEv"
+- "name": "_ZN2ot12BorderRouter14RoutingManager4StopEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void ot::BorderRouter::RoutingManager::Stop()"
-- "exceptions": []
-  "name": "otPlatRadioEnergyScanDone"
+- "name": "otPlatRadioEnergyScanDone"
   "params":
   - "name": "aInstance"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "char"
   "return_type": "void"
   "signature": "void otPlatRadioEnergyScanDone(otInstance *, int8_t)"
-- "exceptions": []
-  "name": "_ZN2ot7MeshCoP6Joiner7ConnectERNS1_12JoinerRouterE"
+- "name": "_ZN2ot7MeshCoP6Joiner7ConnectERNS1_12JoinerRouterE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/openvswitch.yaml
+++ b/benchmark-sets/all/openvswitch.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "parse_ofp_flow_stats_request_str"
+- "name": "parse_ofp_flow_stats_request_str"
   "params":
   - "name": "fsr"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * parse_ofp_flow_stats_request_str(struct ofputil_flow_stats_request *, bool, const char *, const struct ofputil_port_map *, const struct ofputil_table_map *, DW_TAG_enumeration_typeofputil_protocol *)"
-- "exceptions": []
-  "name": "parse_ofp_bundle_file"
+- "name": "parse_ofp_bundle_file"
   "params":
   - "name": "file_name"
     "type": "bool "
@@ -33,15 +31,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * parse_ofp_bundle_file(const char *, const struct ofputil_port_map *, const struct ofputil_table_map *, struct ofputil_bundle_msg **, size_t *, DW_TAG_enumeration_typeofputil_protocol *)"
-- "exceptions": []
-  "name": "ovsdb_idl_txn_commit_block"
+- "name": "ovsdb_idl_txn_commit_block"
   "params":
   - "name": "txn"
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeovsdb_idl_txn_status ovsdb_idl_txn_commit_block(struct ovsdb_idl_txn *)"
-- "exceptions": []
-  "name": "parse_ofp_flow_mod_file"
+- "name": "parse_ofp_flow_mod_file"
   "params":
   - "name": "file_name"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * parse_ofp_flow_mod_file(const char *, const struct ofputil_port_map *, const struct ofputil_table_map *, int, struct ofputil_flow_mod **, size_t *, DW_TAG_enumeration_typeofputil_protocol *)"
-- "exceptions": []
-  "name": "dp_netdev_input"
+- "name": "dp_netdev_input"
   "params":
   - "name": "pmd"
     "type": "bool "

--- a/benchmark-sets/all/openweave.yaml
+++ b/benchmark-sets/all/openweave.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_Z14InitWeaveStackbb"
+- "name": "_Z14InitWeaveStackbb"
   "params":
   - "name": "listen"
     "type": "bool"
@@ -8,8 +7,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void InitWeaveStack(bool, bool)"
-- "exceptions": []
-  "name": "_ZN2nl5Weave20WeaveSecurityManager24HandleUnsolicitedMessageEPNS0_15ExchangeContextEPKNS_4Inet12IPPacketInfoEPKNS0_16WeaveMessageInfoEjhPNS0_6System12PacketBufferE"
+- "name": "_ZN2nl5Weave20WeaveSecurityManager24HandleUnsolicitedMessageEPNS0_15ExchangeContextEPKNS_4Inet12IPPacketInfoEPKNS0_16WeaveMessageInfoEjhPNS0_6System12PacketBufferE"
   "params":
   - "name": "ec"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void nl::Weave::WeaveSecurityManager::HandleUnsolicitedMessage(ExchangeContext *, const IPPacketInfo *, const struct WeaveMessageInfo *, uint32_t, uint8_t, PacketBuffer *)"
-- "exceptions": []
-  "name": "_ZN2nl5Weave20WeaveSecurityManager22HandleCASESessionStartEPNS0_15ExchangeContextEPKNS_4Inet12IPPacketInfoEPKNS0_16WeaveMessageInfoEPNS0_6System12PacketBufferE"
+- "name": "_ZN2nl5Weave20WeaveSecurityManager22HandleCASESessionStartEPNS0_15ExchangeContextEPKNS_4Inet12IPPacketInfoEPKNS0_16WeaveMessageInfoEPNS0_6System12PacketBufferE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void nl::Weave::WeaveSecurityManager::HandleCASESessionStart(ExchangeContext *, const IPPacketInfo *, const struct WeaveMessageInfo *, PacketBuffer *)"
-- "exceptions": []
-  "name": "_ZN2nl5Weave20WeaveSecurityManager4InitERNS0_20WeaveExchangeManagerERNS0_6System5LayerE"
+- "name": "_ZN2nl5Weave20WeaveSecurityManager4InitERNS0_20WeaveExchangeManagerERNS0_6System5LayerE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "WEAVE_ERROR nl::Weave::WeaveSecurityManager::Init(WeaveExchangeManager &, Layer &)"
-- "exceptions": []
-  "name": "_ZN2nl5Weave20WeaveSecurityManager31HandleKeyExportMessageInitiatorEPNS0_15ExchangeContextEPKNS_4Inet12IPPacketInfoEPKNS0_16WeaveMessageInfoEjhPNS0_6System12PacketBufferE"
+- "name": "_ZN2nl5Weave20WeaveSecurityManager31HandleKeyExportMessageInitiatorEPNS0_15ExchangeContextEPKNS_4Inet12IPPacketInfoEPKNS0_16WeaveMessageInfoEjhPNS0_6System12PacketBufferE"
   "params":
   - "name": "ec"
     "type": "bool "

--- a/benchmark-sets/all/opus.yaml
+++ b/benchmark-sets/all/opus.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "opus_decode"
+- "name": "opus_decode"
   "params":
   - "name": "st"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int opus_decode(OpusDecoder *, const unsigned char *, opus_int32, opus_int16 *, int, int)"
-- "exceptions": []
-  "name": "opus_encode_float"
+- "name": "opus_encode_float"
   "params":
   - "name": "st"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "opus_int32 opus_encode_float(OpusEncoder *, const float *, int, unsigned char *, opus_int32)"
-- "exceptions": []
-  "name": "opus_multistream_encode_float"
+- "name": "opus_multistream_encode_float"
   "params":
   - "name": "st"
     "type": "bool "
@@ -46,8 +43,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int opus_multistream_encode_float(OpusMSEncoder *, const opus_val16 *, int, unsigned char *, opus_int32)"
-- "exceptions": []
-  "name": "opus_projection_encode_float"
+- "name": "opus_projection_encode_float"
   "params":
   - "name": "st"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int opus_projection_encode_float(OpusProjectionEncoder *, const float *, int, unsigned char *, opus_int32)"
-- "exceptions": []
-  "name": "opus_decode_float"
+- "name": "opus_decode_float"
   "params":
   - "name": "st"
     "type": "bool "

--- a/benchmark-sets/all/opusfile.yaml
+++ b/benchmark-sets/all/opusfile.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "op_read"
+- "name": "op_read"
   "params":
   - "name": "_of"
     "type": "bool "
@@ -12,15 +11,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int op_read(OggOpusFile *, opus_int16 *, int, int *)"
-- "exceptions": []
-  "name": "op_test_open"
+- "name": "op_test_open"
   "params":
   - "name": "_of"
     "type": "bool "
   "return_type": "int"
   "signature": "int op_test_open(OggOpusFile *)"
-- "exceptions": []
-  "name": "op_read_float"
+- "name": "op_read_float"
   "params":
   - "name": "_of"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int op_read_float(OggOpusFile *, float *, int, int *)"
-- "exceptions": []
-  "name": "op_read_float_stereo"
+- "name": "op_read_float_stereo"
   "params":
   - "name": "_of"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int op_read_float_stereo(OggOpusFile *, float *, int)"
-- "exceptions": []
-  "name": "op_open_file"
+- "name": "op_open_file"
   "params":
   - "name": "_path"
     "type": "bool "

--- a/benchmark-sets/all/pcre2.yaml
+++ b/benchmark-sets/all/pcre2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sljit_allocate_stack"
+- "name": "sljit_allocate_stack"
   "params":
   - "name": "start_size"
     "type": "size_t"
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct sljit_stack * sljit_allocate_stack(sljit_uw, sljit_uw, void *)"
-- "exceptions": []
-  "name": "sljit_free_stack"
+- "name": "sljit_free_stack"
   "params":
   - "name": "stack"
     "type": "bool "

--- a/benchmark-sets/all/phmap.yaml
+++ b/benchmark-sets/all/phmap.yaml
@@ -1,27 +1,23 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyIjiEENS_4HashIjEENS_7EqualToIjEENSt3__19allocatorINS8_4pairIKjiEEEEE27drop_deletes_without_resizeEv"
+- "name": "_ZN5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyIjiEENS_4HashIjEENS_7EqualToIjEENSt3__19allocatorINS8_4pairIKjiEEEEE27drop_deletes_without_resizeEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<unsigned int, int>, phmap::Hash<unsigned int>, phmap::EqualTo<unsigned int>, std::__1::allocator<std::__1::pair<unsigned int const, int> > >::drop_deletes_without_resize(raw_hash_set<phmap::priv::FlatHashMapPolicy<unsigned int, int>, phmap::Hash<unsigned int>, phmap::EqualTo<unsigned int>, std::__1::allocator<std::__1::pair<const unsigned int, int> > > *)"
-- "exceptions": []
-  "name": "_ZN5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyINSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEES9_EENS0_13StringHashEqTIcE4HashENSC_2EqENS7_INS3_4pairIKS9_S9_EEEEE8iteratorppEv"
+- "name": "_ZN5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyINSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEES9_EENS0_13StringHashEqTIcE4HashENSC_2EqENS7_INS3_4pairIKS9_S9_EEEEE8iteratorppEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "iterator & phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, phmap::priv::StringHashEqT<char>::Hash, phmap::priv::StringHashEqT<char>::Eq, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >::iterator::operator++()"
-- "exceptions": []
-  "name": "_ZNK5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyINSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEES9_EENS0_13StringHashEqTIcE4HashENSC_2EqENS7_INS3_4pairIKS9_S9_EEEEE8iteratordeEv"
+- "name": "_ZNK5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyINSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEES9_EENS0_13StringHashEqTIcE4HashENSC_2EqENS7_INS3_4pairIKS9_S9_EEEEE8iteratordeEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "reference phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, phmap::priv::StringHashEqT<char>::Hash, phmap::priv::StringHashEqT<char>::Eq, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >::iterator::operator*()"
-- "exceptions": []
-  "name": "_ZN5phmap4priv37ConvertDeletedToEmptyAndFullToDeletedEPam"
+- "name": "_ZN5phmap4priv37ConvertDeletedToEmptyAndFullToDeletedEPam"
   "params":
   - "name": "ctrl"
     "type": "bool "
@@ -29,8 +25,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void phmap::priv::ConvertDeletedToEmptyAndFullToDeleted(ctrl_t *, size_t)"
-- "exceptions": []
-  "name": "_ZZN5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyIjiEENS_4HashIjEENS_7EqualToIjEENSt3__19allocatorINS8_4pairIKjiEEEEE27drop_deletes_without_resizeEvENKUlmE_clEm"
+- "name": "_ZZN5phmap4priv12raw_hash_setINS0_17FlatHashMapPolicyIjiEENS_4HashIjEENS_7EqualToIjEENSt3__19allocatorINS8_4pairIKjiEEEEE27drop_deletes_without_resizeEvENKUlmE_clEm"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/picotls.yaml
+++ b/benchmark-sets/all/picotls.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ptls_send"
+- "name": "ptls_send"
   "params":
   - "name": "tls"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ptls_send(ptls_t *, ptls_buffer_t *, const void *, size_t)"
-- "exceptions": []
-  "name": "ptls_server_handle_message"
+- "name": "ptls_server_handle_message"
   "params":
   - "name": "tls"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ptls_server_handle_message(ptls_t *, ptls_buffer_t *, size_t *, size_t, const void *, size_t, ptls_handshake_properties_t *)"
-- "exceptions": []
-  "name": "ptls_import"
+- "name": "ptls_import"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ptls_import(ptls_context_t *, ptls_t **, ptls_iovec_t)"
-- "exceptions": []
-  "name": "ptls_client_handle_message"
+- "name": "ptls_client_handle_message"
   "params":
   - "name": "tls"
     "type": "bool "
@@ -63,8 +59,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ptls_client_handle_message(ptls_t *, ptls_buffer_t *, size_t *, size_t, const void *, size_t, ptls_handshake_properties_t *)"
-- "exceptions": []
-  "name": "ptls_handle_message"
+- "name": "ptls_handle_message"
   "params":
   - "name": "tls"
     "type": "bool "

--- a/benchmark-sets/all/piex.yaml
+++ b/benchmark-sets/all/piex.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK4piex14tiff_directory13TiffDirectory3GetEjPNSt3__16vectorINS0_9SRationalENS2_9allocatorIS4_EEEE"
+- "name": "_ZNK4piex14tiff_directory13TiffDirectory3GetEjPNSt3__16vectorINS0_9SRationalENS2_9allocatorIS4_EEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool piex::tiff_directory::TiffDirectory::Get(const Tag, vector<piex::tiff_directory::SRational, std::__1::allocator<piex::tiff_directory::SRational> > *)"
-- "exceptions": []
-  "name": "_ZNK4piex14tiff_directory13TiffDirectory3GetEjPNS0_9SRationalE"
+- "name": "_ZNK4piex14tiff_directory13TiffDirectory3GetEjPNS0_9SRationalE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool piex::tiff_directory::TiffDirectory::Get(const Tag, struct SRational *)"
-- "exceptions": []
-  "name": "_ZNK4piex14tiff_directory13TiffDirectory3GetEjPNS0_8RationalE"
+- "name": "_ZNK4piex14tiff_directory13TiffDirectory3GetEjPNS0_8RationalE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,15 +29,13 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool piex::tiff_directory::TiffDirectory::Get(const Tag, struct Rational *)"
-- "exceptions": []
-  "name": "_ZN4piex5IsRawEPNS_15StreamInterfaceE"
+- "name": "_ZN4piex5IsRawEPNS_15StreamInterfaceE"
   "params":
   - "name": "data"
     "type": "bool "
   "return_type": "bool"
   "signature": "bool piex::IsRaw(StreamInterface *)"
-- "exceptions": []
-  "name": "_ZN4piex18GetExifOrientationEPNS_15StreamInterfaceEjPj"
+- "name": "_ZN4piex18GetExifOrientationEPNS_15StreamInterfaceEjPj"
   "params":
   - "name": "stream"
     "type": "bool "

--- a/benchmark-sets/all/pigweed.yaml
+++ b/benchmark-sets/all/pigweed.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZN2pw6string12FormatVaListERNS_17InlineBasicStringIcLm65535EEEPKcP13__va_list_tagENK3$_0clEPcm"
+- "name": "_ZZN2pw6string12FormatVaListERNS_17InlineBasicStringIcLm65535EEEPKcP13__va_list_tagENK3$_0clEPcm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,29 +9,25 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "size_t pw::string::operator()(const void *, char *, size_t)"
-- "exceptions": []
-  "name": "_ZNK2pw6VectorIKSt4byteLm18446744073709551615EE4dataEv"
+- "name": "_ZNK2pw6VectorIKSt4byteLm18446744073709551615EE4dataEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "const unsigned long * pw::Vector<std::byte const, 18446744073709551615ul>::data(const Vector<const unsigned long, 18446744073709551615UL> *)"
-- "exceptions": []
-  "name": "_ZN3fit8internal11null_targetIvE6invokeEPv"
+- "name": "_ZN3fit8internal11null_targetIvE6invokeEPv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void fit::internal::null_target<void>::invoke(void *)"
-- "exceptions": []
-  "name": "_ZN2pw17InlineBasicStringIcLm65535EE4dataEv"
+- "name": "_ZN2pw17InlineBasicStringIcLm65535EE4dataEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "pointer pw::InlineBasicString<char, 65535ul>::data(InlineBasicString<char, 65535UL> *)"
-- "exceptions": []
-  "name": "_ZZN2pw6base646EncodeENS_4spanIKSt4byteLm18446744073709551615EEERNS_17InlineBasicStringIcLm65535EEEENK3$_0clEPcm"
+- "name": "_ZZN2pw6base646EncodeENS_4spanIKSt4byteLm18446744073709551615EEERNS_17InlineBasicStringIcLm65535EEEENK3$_0clEPcm"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/pjsip.yaml
+++ b/benchmark-sets/all/pjsip.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "pjsip_endpt_send_request_stateless"
+- "name": "pjsip_endpt_send_request_stateless"
   "params":
   - "name": "endpt"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "pj_status_t pjsip_endpt_send_request_stateless(pjsip_endpoint *, pjsip_tx_data *, void *, pjsip_send_callback)"
-- "exceptions": []
-  "name": "pjsip_endpt_send_raw_to_uri"
+- "name": "pjsip_endpt_send_raw_to_uri"
   "params":
   - "name": "endpt"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "pj_status_t pjsip_endpt_send_raw_to_uri(pjsip_endpoint *, const pj_str_t *, const pjsip_tpselector *, const void *, pj_size_t, void *, pjsip_tp_send_callback)"
-- "exceptions": []
-  "name": "pjsip_tsx_retransmit_no_state"
+- "name": "pjsip_tsx_retransmit_no_state"
   "params":
   - "name": "tsx"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "pj_status_t pjsip_tsx_retransmit_no_state(pjsip_transaction *, pjsip_tx_data *)"
-- "exceptions": []
-  "name": "pjsip_endpt_respond_stateless"
+- "name": "pjsip_endpt_respond_stateless"
   "params":
   - "name": "endpt"
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "pj_status_t pjsip_endpt_respond_stateless(pjsip_endpoint *, pjsip_rx_data *, int, const pj_str_t *, const pjsip_hdr *, const pjsip_msg_body *)"
-- "exceptions": []
-  "name": "pjmedia_endpt_create_sdp"
+- "name": "pjmedia_endpt_create_sdp"
   "params":
   - "name": "endpt"
     "type": "bool "

--- a/benchmark-sets/all/plan9port.yaml
+++ b/benchmark-sets/all/plan9port.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "X509gen"
+- "name": "X509gen"
   "params":
   - "name": "priv"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "uchar * X509gen(RSApriv *, char *, ulong *, int *)"
-- "exceptions": []
-  "name": "X509toRSApub"
+- "name": "X509toRSApub"
   "params":
   - "name": "cert"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "RSApub * X509toRSApub(uchar *, int, char *, int)"
-- "exceptions": []
-  "name": "X509req"
+- "name": "X509req"
   "params":
   - "name": "priv"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "uchar * X509req(RSApriv *, char *, int *)"
-- "exceptions": []
-  "name": "rsadecrypt"
+- "name": "rsadecrypt"
   "params":
   - "name": "rsa"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "mpint * rsadecrypt(RSApriv *, mpint *, mpint *)"
-- "exceptions": []
-  "name": "__efgfmt"
+- "name": "__efgfmt"
   "params":
   - "name": "fmt"
     "type": "bool "

--- a/benchmark-sets/all/postfix.yaml
+++ b/benchmark-sets/all/postfix.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "get_mail_conf_time_table"
+- "name": "get_mail_conf_time_table"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void get_mail_conf_time_table(const CONFIG_TIME_TABLE *)"
-- "exceptions": []
-  "name": "get_mail_conf_time2"
+- "name": "get_mail_conf_time2"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/powerdns.yaml
+++ b/benchmark-sets/all/powerdns.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6YaHTTPlsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_8ResponseE"
+- "name": "_ZN6YaHTTPlsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_8ResponseE"
   "params":
   - "name": "os"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "ostream & YaHTTP::operator<<(ostream &, const Response &)"
-- "exceptions": []
-  "name": "_ZN18DNSDistPacketCache10CacheValueC2EOS0_"
+- "name": "_ZN18DNSDistPacketCache10CacheValueC2EOS0_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct CacheValue & DNSDistPacketCache::CacheValue::operator=(struct CacheValue *, const struct CacheValue &)"
-- "exceptions": []
-  "name": "_ZN6YaHTTPlsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_7RequestE"
+- "name": "_ZN6YaHTTPlsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_7RequestE"
   "params":
   - "name": "os"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "ostream & YaHTTP::operator<<(ostream &, const Request &)"
-- "exceptions": []
-  "name": "_ZN18DNSDistPacketCache3getER11DNSQuestiontPjRN5boost8optionalI7NetmaskEEbbjbbb"
+- "name": "_ZN18DNSDistPacketCache3getER11DNSQuestiontPjRN5boost8optionalI7NetmaskEEbbjbbb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool DNSDistPacketCache::get(struct DNSQuestion &, uint16_t, uint32_t *, optional<Netmask> &, bool, bool, uint32_t, bool, bool, bool)"
-- "exceptions": []
-  "name": "_ZNK6YaHTTP8HTTPBase5writeERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEE"
+- "name": "_ZNK6YaHTTP8HTTPBase5writeERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/proftpd.yaml
+++ b/benchmark-sets/all/proftpd.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "dir_check"
+- "name": "dir_check"
   "params":
   - "name": "pp"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int dir_check(pool *, cmd_rec *, const char *, const char *, int *)"
-- "exceptions": []
-  "name": "dir_check_canon"
+- "name": "dir_check_canon"
   "params":
   - "name": "pp"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int dir_check_canon(pool *, cmd_rec *, const char *, const char *, int *)"
-- "exceptions": []
-  "name": "core_chmod"
+- "name": "core_chmod"
   "params":
   - "name": "cmd"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int core_chmod(cmd_rec *, const char *, mode_t)"
-- "exceptions": []
-  "name": "core_chgrp"
+- "name": "core_chgrp"
   "params":
   - "name": "cmd"
     "type": "bool "
@@ -53,8 +49,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int core_chgrp(cmd_rec *, const char *, uid_t, gid_t)"
-- "exceptions": []
-  "name": "pr_data_xfer"
+- "name": "pr_data_xfer"
   "params":
   - "name": "cl_buf"
     "type": "bool "

--- a/benchmark-sets/all/proj4.yaml
+++ b/benchmark-sets/all/proj4.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "proj_get_suggested_operation"
+- "name": "proj_get_suggested_operation"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int proj_get_suggested_operation(PJ_CONTEXT *, PJ_OBJ_LIST *, PJ_DIRECTION, PJ_COORD)"
-- "exceptions": []
-  "name": "_ZNK5osgeo4proj3crs8BoundCRS9_identifyERKNSt3__110shared_ptrINS0_2io16AuthorityFactoryEEE"
+- "name": "_ZNK5osgeo4proj3crs8BoundCRS9_identifyERKNSt3__110shared_ptrINS0_2io16AuthorityFactoryEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "list<std::__1::pair<dropbox::oxygen::nn<std::__1::shared_ptr<osgeo::proj::crs::CRS> >, int>, std::__1::allocator<std::__1::pair<dropbox::oxygen::nn<std::__1::shared_ptr<osgeo::proj::crs::CRS> >, int> > > osgeo::proj::crs::BoundCRS::_identify(const AuthorityFactoryPtr &)"
-- "exceptions": []
-  "name": "proj_factors"
+- "name": "proj_factors"
   "params":
   - "name": ""
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "PJ_FACTORS proj_factors(PJ *, PJ_COORD)"
-- "exceptions": []
-  "name": "_ZN5osgeo4proj14CurlFileHandle4openEP6pj_ctxPKcymPvPmmPcS6_"
+- "name": "_ZN5osgeo4proj14CurlFileHandle4openEP6pj_ctxPKcymPvPmmPcS6_"
   "params":
   - "name": ""
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "PROJ_NETWORK_HANDLE * osgeo::proj::CurlFileHandle::open(PJ_CONTEXT *, const char *, unsigned long long, size_t, void *, size_t *, size_t, char *, void *)"
-- "exceptions": []
-  "name": "proj_crs_create_bound_crs_to_WGS84"
+- "name": "proj_crs_create_bound_crs_to_WGS84"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/protobuf-c.yaml
+++ b/benchmark-sets/all/protobuf-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "protobuf_c_message_pack_to_buffer"
+- "name": "protobuf_c_message_pack_to_buffer"
   "params":
   - "name": "message"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t protobuf_c_message_pack_to_buffer(const ProtobufCMessage *, ProtobufCBuffer *)"
-- "exceptions": []
-  "name": "protobuf_c_message_check"
+- "name": "protobuf_c_message_check"
   "params":
   - "name": "message"
     "type": "bool "
   "return_type": "int"
   "signature": "protobuf_c_boolean protobuf_c_message_check(const ProtobufCMessage *)"
-- "exceptions": []
-  "name": "protobuf_c_buffer_simple_append"
+- "name": "protobuf_c_buffer_simple_append"
   "params":
   - "name": "buffer"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void protobuf_c_buffer_simple_append(ProtobufCBuffer *, size_t, const uint8_t *)"
-- "exceptions": []
-  "name": "protobuf_c_service_descriptor_get_method_by_name"
+- "name": "protobuf_c_service_descriptor_get_method_by_name"
   "params":
   - "name": "desc"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const ProtobufCMethodDescriptor * protobuf_c_service_descriptor_get_method_by_name(const ProtobufCServiceDescriptor *, const char *)"
-- "exceptions": []
-  "name": "protobuf_c_message_descriptor_get_field"
+- "name": "protobuf_c_message_descriptor_get_field"
   "params":
   - "name": "desc"
     "type": "bool "

--- a/benchmark-sets/all/pugixml.yaml
+++ b/benchmark-sets/all/pugixml.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK4pugi8xml_node5printERNSt3__113basic_ostreamIwNS1_11char_traitsIwEEEEPKcjj"
+- "name": "_ZNK4pugi8xml_node5printERNSt3__113basic_ostreamIwNS1_11char_traitsIwEEEEPKcjj"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void pugi::xml_node::print(basic_ostream<wchar_t, std::__1::char_traits<wchar_t> > &, const char_t *, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "_ZN4pugi14xpath_node_set4sortEb"
+- "name": "_ZN4pugi14xpath_node_set4sortEb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void pugi::xpath_node_set::sort(bool)"
-- "exceptions": []
-  "name": "_ZNK4pugi8xml_node5printERNS_10xml_writerEPKcjNS_12xml_encodingEj"
+- "name": "_ZNK4pugi8xml_node5printERNS_10xml_writerEPKcjNS_12xml_encodingEj"
   "params":
   - "name": "this"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void pugi::xml_node::print(xml_writer &, const char_t *, unsigned int, DW_TAG_enumeration_typexml_encoding, unsigned int)"
-- "exceptions": []
-  "name": "_ZN4pugi18xpath_variable_setaSERKS0_"
+- "name": "_ZN4pugi18xpath_variable_setaSERKS0_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "xpath_variable_set & pugi::xpath_variable_set::operator=(const xpath_variable_set &)"
-- "exceptions": []
-  "name": "_ZNK4pugi8xml_node5printERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEPKcjNS_12xml_encodingEj"
+- "name": "_ZNK4pugi8xml_node5printERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEPKcjNS_12xml_encodingEj"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/pupnp.yaml
+++ b/benchmark-sets/all/pupnp.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "ixmlParseBuffer"
+- "name": "ixmlParseBuffer"
   "params":
   - "name": "buffer"
     "type": "bool "
   "return_type": "void"
   "signature": "IXML_Document * ixmlParseBuffer(const char *)"
-- "exceptions": []
-  "name": "ixmlParseBufferEx"
+- "name": "ixmlParseBufferEx"
   "params":
   - "name": "buffer"
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ixmlParseBufferEx(const char *, IXML_Document **)"
-- "exceptions": []
-  "name": "ixmlNode_cloneNode"
+- "name": "ixmlNode_cloneNode"
   "params":
   - "name": "nodeptr"
     "type": "bool "
@@ -24,15 +21,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "IXML_Node * ixmlNode_cloneNode(IXML_Node *, int)"
-- "exceptions": []
-  "name": "ixmlLoadDocument"
+- "name": "ixmlLoadDocument"
   "params":
   - "name": "xmlFile"
     "type": "bool "
   "return_type": "void"
   "signature": "IXML_Document * ixmlLoadDocument(const char *)"
-- "exceptions": []
-  "name": "ixmlDocument_importNode"
+- "name": "ixmlDocument_importNode"
   "params":
   - "name": "doc"
     "type": "bool "

--- a/benchmark-sets/all/pybind11.yaml
+++ b/benchmark-sets/all/pybind11.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8pybind116detail14clear_instanceEP7_object"
+- "name": "_ZN8pybind116detail14clear_instanceEP7_object"
   "params":
   - "name": "self"
     "type": "bool "
   "return_type": "void"
   "signature": "void pybind11::detail::clear_instance(PyObject *)"
-- "exceptions": []
-  "name": "pybind11_object_dealloc"
+- "name": "pybind11_object_dealloc"
   "params":
   - "name": "self"
     "type": "bool "
   "return_type": "void"
   "signature": "void pybind11_object_dealloc(PyObject *)"
-- "exceptions": []
-  "name": "_ZN8pybind1112cpp_function10dispatcherEP7_objectS2_S2_"
+- "name": "_ZN8pybind1112cpp_function10dispatcherEP7_objectS2_S2_"
   "params":
   - "name": "self"
     "type": "bool "
@@ -24,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "PyObject * pybind11::cpp_function::dispatcher(PyObject *, PyObject *, PyObject *)"
-- "exceptions": []
-  "name": "_ZN8pybind116detail8instance20get_value_and_holderEPKNS0_9type_infoEb"
+- "name": "_ZN8pybind116detail8instance20get_value_and_holderEPKNS0_9type_infoEb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "struct value_and_holder pybind11::detail::instance::get_value_and_holder(struct instance *, const struct type_info *, bool)"
-- "exceptions": []
-  "name": "_ZN8pybind116detail21traverse_offset_basesEPvPKNS0_9type_infoEPNS0_8instanceEPFbS1_S6_E"
+- "name": "_ZN8pybind116detail21traverse_offset_basesEPvPKNS0_9type_infoEPNS0_8instanceEPFbS1_S6_E"
   "params":
   - "name": "valueptr"
     "type": "bool "

--- a/benchmark-sets/all/qpdf.yaml
+++ b/benchmark-sets/all/qpdf.yaml
@@ -1,34 +1,29 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN24QPDFNameTreeObjectHelper8iteratormmEv"
+- "name": "_ZN24QPDFNameTreeObjectHelper8iteratormmEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "iterator & QPDFNameTreeObjectHelper::iterator::operator--()"
-- "exceptions": []
-  "name": "_ZZN26QPDFAcroFormDocumentHelper20transformAnnotationsE16QPDFObjectHandleRNSt3__16vectorIS0_NS1_9allocatorIS0_EEEES6_RNS1_3setI10QPDFObjGenNS1_4lessIS8_EENS3_IS8_EEEERK10QPDFMatrixP4QPDFPS_ENK3$_2clEv"
+- "name": "_ZZN26QPDFAcroFormDocumentHelper20transformAnnotationsE16QPDFObjectHandleRNSt3__16vectorIS0_NS1_9allocatorIS0_EEEES6_RNS1_3setI10QPDFObjGenNS1_4lessIS8_EENS3_IS8_EEEERK10QPDFMatrixP4QPDFPS_ENK3$_2clEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void QPDFAcroFormDocumentHelper::operator()(const void *)"
-- "exceptions": []
-  "name": "_ZN26QPDFNumberTreeObjectHelper8iteratorppEv"
+- "name": "_ZN26QPDFNumberTreeObjectHelper8iteratorppEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "iterator & QPDFNumberTreeObjectHelper::iterator::operator++()"
-- "exceptions": []
-  "name": "_ZN26QPDFNumberTreeObjectHelper8iteratormmEv"
+- "name": "_ZN26QPDFNumberTreeObjectHelper8iteratormmEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "iterator & QPDFNumberTreeObjectHelper::iterator::operator--()"
-- "exceptions": []
-  "name": "_ZN24QPDFNameTreeObjectHelper8iteratorppEv"
+- "name": "_ZN24QPDFNameTreeObjectHelper8iteratorppEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/qpid-proton.yaml
+++ b/benchmark-sets/all/qpid-proton.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "pn_data_vfill"
+- "name": "pn_data_vfill"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int pn_data_vfill(pn_data_t *, const char *, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "pn_message_data"
+- "name": "pn_message_data"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int pn_message_data(pn_message_t *, pn_data_t *)"
-- "exceptions": []
-  "name": "pn_data_scan"
+- "name": "pn_data_scan"
   "params":
   - "name": ""
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int pn_data_scan(pn_data_t *, const char *, void)"
-- "exceptions": []
-  "name": "pn_message_send"
+- "name": "pn_message_send"
   "params":
   - "name": ""
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t pn_message_send(pn_message_t *, pn_link_t *, pn_rwbytes_t *)"
-- "exceptions": []
-  "name": "pn_data_fill"
+- "name": "pn_data_fill"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/quantlib.yaml
+++ b/benchmark-sets/all/quantlib.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK8QuantLib6HandleINS_5QuoteEEptEv"
+- "name": "_ZNK8QuantLib6HandleINS_5QuoteEEptEv"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "const shared_ptr<QuantLib::Quote> & QuantLib::Handle<QuantLib::Quote>::operator->(const Handle<QuantLib::Quote> *)"
-- "exceptions": []
-  "name": "_ZN5boost10shared_ptrIN8QuantLib6PayoffEEaSERKS3_"
+- "name": "_ZN5boost10shared_ptrIN8QuantLib6PayoffEEaSERKS3_"
   "params":
   - "name": ""
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "shared_ptr<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > & boost::shared_ptr<QuantLib::Payoff>::operator=(shared_ptr<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > *, const shared_ptr<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > &)"
-- "exceptions": []
-  "name": "_ZN8QuantLib6HandleINS_5QuoteEE4LinkD2Ev"
+- "name": "_ZN8QuantLib6HandleINS_5QuoteEE4LinkD2Ev"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/qubes-os.yaml
+++ b/benchmark-sets/all/qubes-os.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "process_io"
+- "name": "process_io"
   "params":
   - "name": "req"
     "type": "bool "
   "return_type": "int"
   "signature": "int process_io(const struct process_io_request *)"
-- "exceptions": []
-  "name": "init"
+- "name": "init"
   "params":
   - "name": "xid"
     "type": "int"
@@ -15,8 +13,7 @@
     "type": "bool"
   "return_type": "void"
   "signature": "void init(int, bool)"
-- "exceptions": []
-  "name": "handle_client_data"
+- "name": "handle_client_data"
   "params":
   - "name": "d"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int handle_client_data(struct db_daemon_data *, struct client *, char *, int)"
-- "exceptions": []
-  "name": "load_service_config"
+- "name": "load_service_config"
   "params":
   - "name": "cmd"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int load_service_config(struct qrexec_parsed_command *, int *, char **)"
-- "exceptions": []
-  "name": "execute_qubes_rpc_command"
+- "name": "execute_qubes_rpc_command"
   "params":
   - "name": "cmdline"
     "type": "bool "

--- a/benchmark-sets/all/quickjs.yaml
+++ b/benchmark-sets/all/quickjs.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "JS_NewTypedArray"
+- "name": "JS_NewTypedArray"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "JSValue JS_NewTypedArray(JSContext *, int, JSValue *, JSTypedArrayEnum)"
-- "exceptions": []
-  "name": "JS_ParseJSON"
+- "name": "JS_ParseJSON"
   "params":
   - "name": ""
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "JSValue JS_ParseJSON(JSContext *, const char *, size_t, const char *)"
-- "exceptions": []
-  "name": "JS_JSONStringify"
+- "name": "JS_JSONStringify"
   "params":
   - "name": ""
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "JSValue JS_JSONStringify(JSContext *, JSValue, JSValue, JSValue)"
-- "exceptions": []
-  "name": "JS_NewArrayBuffer"
+- "name": "JS_NewArrayBuffer"
   "params":
   - "name": ""
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "JSValue JS_NewArrayBuffer(JSContext *, uint8_t *, size_t, JSFreeArrayBufferDataFunc *, void *, BOOL)"
-- "exceptions": []
-  "name": "JS_ParseJSON2"
+- "name": "JS_ParseJSON2"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/rabbitmq-c.yaml
+++ b/benchmark-sets/all/rabbitmq-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "amqp_login_with_properties"
+- "name": "amqp_login_with_properties"
   "params":
   - "name": "state"
     "type": "bool "
@@ -20,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "amqp_rpc_reply_t amqp_login_with_properties(amqp_connection_state_t, const char *, int, int, int, const amqp_table_t *, amqp_sasl_method_enum, void)"
-- "exceptions": []
-  "name": "amqp_confirm_select"
+- "name": "amqp_confirm_select"
   "params":
   - "name": "state"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "short"
   "return_type": "void"
   "signature": "amqp_confirm_select_ok_t * amqp_confirm_select(amqp_connection_state_t, amqp_channel_t)"
-- "exceptions": []
-  "name": "amqp_channel_close"
+- "name": "amqp_channel_close"
   "params":
   - "name": "state"
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "amqp_rpc_reply_t amqp_channel_close(amqp_connection_state_t, amqp_channel_t, int)"
-- "exceptions": []
-  "name": "amqp_tx_rollback"
+- "name": "amqp_tx_rollback"
   "params":
   - "name": "state"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "short"
   "return_type": "void"
   "signature": "amqp_tx_rollback_ok_t * amqp_tx_rollback(amqp_connection_state_t, amqp_channel_t)"
-- "exceptions": []
-  "name": "amqp_connection_close"
+- "name": "amqp_connection_close"
   "params":
   - "name": "state"
     "type": "bool "

--- a/benchmark-sets/all/rapidjson.yaml
+++ b/benchmark-sets/all/rapidjson.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN9rapidjson12GenericValueINS_4UTF8IcEENS_19MemoryPoolAllocatorINS_12CrtAllocatorEEEE14DoAllocMembersEjRS5_"
+- "name": "_ZN9rapidjson12GenericValueINS_4UTF8IcEENS_19MemoryPoolAllocatorINS_12CrtAllocatorEEEE14DoAllocMembersEjRS5_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Member * rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::DoAllocMembers(GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > *, SizeType, MemoryPoolAllocator<rapidjson::CrtAllocator> &)"
-- "exceptions": []
-  "name": "_ZN9rapidjson12GenericValueINS_4UTF8IcEENS_19MemoryPoolAllocatorINS_12CrtAllocatorEEEE12SetObjectRawEPNS_13GenericMemberIS2_S5_EEjRS5_"
+- "name": "_ZN9rapidjson12GenericValueINS_4UTF8IcEENS_19MemoryPoolAllocatorINS_12CrtAllocatorEEEE12SetObjectRawEPNS_13GenericMemberIS2_S5_EEjRS5_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/re2.yaml
+++ b/benchmark-sets/all/re2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3re26Regexp14SimplifyRegexpENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEENS0_10ParseFlagsEPNS1_12basic_stringIcS4_NS1_9allocatorIcEEEEPNS_12RegexpStatusE"
+- "name": "_ZN3re26Regexp14SimplifyRegexpENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEENS0_10ParseFlagsEPNS1_12basic_stringIcS4_NS1_9allocatorIcEEEEPNS_12RegexpStatusE"
   "params":
   - "name": ""
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool re2::Regexp::SimplifyRegexp(string_view, DW_TAG_enumeration_typeParseFlags, string *, RegexpStatus *)"
-- "exceptions": []
-  "name": "_ZN4absl10SimpleAtodENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEPd"
+- "name": "_ZN4absl10SimpleAtodENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEPd"
   "params":
   - "name": "str"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool absl::SimpleAtod(string_view, Nonnull<double *>)"
-- "exceptions": []
-  "name": "_ZNK3re211FilteredRE214SlowFirstMatchENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEE"
+- "name": "_ZNK3re211FilteredRE214SlowFirstMatchENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int re2::FilteredRE2::SlowFirstMatch(string_view)"
-- "exceptions": []
-  "name": "_ZNK3re211FilteredRE210FirstMatchENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERKNS1_6vectorIiNS1_9allocatorIiEEEE"
+- "name": "_ZNK3re211FilteredRE210FirstMatchENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERKNS1_6vectorIiNS1_9allocatorIiEEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int re2::FilteredRE2::FirstMatch(string_view, const vector<int, std::__1::allocator<int> > &)"
-- "exceptions": []
-  "name": "_ZN3re23RE27ExtractENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERKS0_S5_PNS1_12basic_stringIcS4_NS1_9allocatorIcEEEE"
+- "name": "_ZN3re23RE27ExtractENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERKS0_S5_PNS1_12basic_stringIcS4_NS1_9allocatorIcEEEE"
   "params":
   - "name": "text"
     "type": "bool "

--- a/benchmark-sets/all/readstat.yaml
+++ b/benchmark-sets/all/readstat.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ck_double_hash_insert"
+- "name": "ck_double_hash_insert"
   "params":
   - "name": "key"
     "type": "double"
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ck_double_hash_insert(double, const void *, ck_hash_table_t *)"
-- "exceptions": []
-  "name": "readstat_value_is_missing"
+- "name": "readstat_value_is_missing"
   "params":
   - "name": "value"
     "type": "size_t"
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int readstat_value_is_missing(readstat_value_t, readstat_variable_t *)"
-- "exceptions": []
-  "name": "ck_double_hash_lookup"
+- "name": "ck_double_hash_lookup"
   "params":
   - "name": "key"
     "type": "double"
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const void * ck_double_hash_lookup(double, ck_hash_table_t *)"
-- "exceptions": []
-  "name": "ck_float_hash_insert"
+- "name": "ck_float_hash_insert"
   "params":
   - "name": "key"
     "type": "float"
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ck_float_hash_insert(float, const void *, ck_hash_table_t *)"
-- "exceptions": []
-  "name": "readstat_value_is_defined_missing"
+- "name": "readstat_value_is_defined_missing"
   "params":
   - "name": "value"
     "type": "size_t"

--- a/benchmark-sets/all/resiprocate.yaml
+++ b/benchmark-sets/all/resiprocate.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK5resip15ContentsFactoryINS_28MultipartAlternativeContentsEE6createERKNS_16HeaderFieldValueERKNS_4MimeE"
+- "name": "_ZNK5resip15ContentsFactoryINS_28MultipartAlternativeContentsEE6createERKNS_16HeaderFieldValueERKNS_4MimeE"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Contents * resip::ContentsFactory<resip::MultipartAlternativeContents>::create(const ContentsFactory<resip::MultipartSignedContents> *, const HeaderFieldValue &, const Mime &)"
-- "exceptions": []
-  "name": "_ZN5resip11SdpContentsaSERKS0_"
+- "name": "_ZN5resip11SdpContentsaSERKS0_"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "SdpContents & resip::SdpContents::operator=(const SdpContents &)"
-- "exceptions": []
-  "name": "_ZNK5resip15ContentsFactoryINS_22MultipartMixedContentsEE6createERKNS_16HeaderFieldValueERKNS_4MimeE"
+- "name": "_ZNK5resip15ContentsFactoryINS_22MultipartMixedContentsEE6createERKNS_16HeaderFieldValueERKNS_4MimeE"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Contents * resip::ContentsFactory<resip::MultipartMixedContents>::create(const ContentsFactory<resip::MultipartSignedContents> *, const HeaderFieldValue &, const Mime &)"
-- "exceptions": []
-  "name": "_ZN5resip19GenericPidfContentsaSERKS0_"
+- "name": "_ZN5resip19GenericPidfContentsaSERKS0_"
   "params":
   - "name": ""
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "GenericPidfContents & resip::GenericPidfContents::operator=(const GenericPidfContents &)"
-- "exceptions": []
-  "name": "_ZNK5resip15ContentsFactoryINS_23MultipartSignedContentsEE6createERKNS_16HeaderFieldValueERKNS_4MimeE"
+- "name": "_ZNK5resip15ContentsFactoryINS_23MultipartSignedContentsEE6createERKNS_16HeaderFieldValueERKNS_4MimeE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/rnp.yaml
+++ b/benchmark-sets/all/rnp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3rnp8KeyStore4loadEPKNS_11KeyProviderE"
+- "name": "_ZN3rnp8KeyStore4loadEPKNS_11KeyProviderE"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool rnp::KeyStore::load(const KeyProvider *)"
-- "exceptions": []
-  "name": "_ZN9pgp_key_t12add_uid_certER23rnp_selfsig_cert_info_t14pgp_hash_alg_tRN3rnp15SecurityContextEPS_"
+- "name": "_ZN9pgp_key_t12add_uid_certER23rnp_selfsig_cert_info_t14pgp_hash_alg_tRN3rnp15SecurityContextEPS_"
   "params":
   - "name": ""
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void pgp_key_t::add_uid_cert(struct pgp_key_t *, rnp_selfsig_cert_info_t &, pgp_hash_alg_t, SecurityContext &, struct pgp_key_t *)"
-- "exceptions": []
-  "name": "_ZN3rnp8KeyStore16import_signatureER9pgp_key_tRK15pgp_signature_t"
+- "name": "_ZN3rnp8KeyStore16import_signatureER9pgp_key_tRK15pgp_signature_t"
   "params":
   - "name": ""
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "pgp_sig_import_status_t rnp::KeyStore::import_signature(pgp_key_t &, const pgp_signature_t &)"
-- "exceptions": []
-  "name": "_ZN3rnp8KeyStore23import_subkey_signatureER9pgp_key_tRK15pgp_signature_t"
+- "name": "_ZN3rnp8KeyStore23import_subkey_signatureER9pgp_key_tRK15pgp_signature_t"
   "params":
   - "name": ""
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "pgp_sig_import_status_t rnp::KeyStore::import_subkey_signature(pgp_key_t &, const pgp_signature_t &)"
-- "exceptions": []
-  "name": "_ZN9pgp_key_t9unprotectERK23pgp_password_provider_tRN3rnp15SecurityContextE"
+- "name": "_ZN9pgp_key_t9unprotectERK23pgp_password_provider_tRN3rnp15SecurityContextE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/rocksdb.yaml
+++ b/benchmark-sets/all/rocksdb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7rocksdb13TransactionDB4OpenERKNS_7OptionsERKNS_20TransactionDBOptionsERKNSt3__112basic_stringIcNS7_11char_traitsIcEENS7_9allocatorIcEEEEPPS0_"
+- "name": "_ZN7rocksdb13TransactionDB4OpenERKNS_7OptionsERKNS_20TransactionDBOptionsERKNSt3__112basic_stringIcNS7_11char_traitsIcEENS7_9allocatorIcEEEEPPS0_"
   "params":
   - "name": ""
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Status rocksdb::TransactionDB::Open(const struct Options &, const struct TransactionDBOptions &, const string &, TransactionDB **)"
-- "exceptions": []
-  "name": "_ZN7rocksdb2DB18OpenAndTrimHistoryERKNS_9DBOptionsERKNSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEERKNS4_6vectorINS_22ColumnFamilyDescriptorENS8_ISE_EEEEPNSD_IPNS_18ColumnFamilyHandleENS8_ISK_EEEEPPS0_SA_"
+- "name": "_ZN7rocksdb2DB18OpenAndTrimHistoryERKNS_9DBOptionsERKNSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEERKNS4_6vectorINS_22ColumnFamilyDescriptorENS8_ISE_EEEEPNSD_IPNS_18ColumnFamilyHandleENS8_ISK_EEEEPPS0_SA_"
   "params":
   - "name": ""
     "type": "bool "
@@ -33,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Status rocksdb::DB::OpenAndTrimHistory(const struct DBOptions &, const string &, const vector<rocksdb::ColumnFamilyDescriptor, std::__1::allocator<rocksdb::ColumnFamilyDescriptor> > &, vector<rocksdb::ColumnFamilyHandle *, std::__1::allocator<rocksdb::ColumnFamilyHandle *> > *, DB **, string)"
-- "exceptions": []
-  "name": "_ZN7rocksdb13TransactionDB4OpenERKNS_9DBOptionsERKNS_20TransactionDBOptionsERKNSt3__112basic_stringIcNS7_11char_traitsIcEENS7_9allocatorIcEEEERKNS7_6vectorINS_22ColumnFamilyDescriptorENSB_ISH_EEEEPNSG_IPNS_18ColumnFamilyHandleENSB_ISN_EEEEPPS0_"
+- "name": "_ZN7rocksdb13TransactionDB4OpenERKNS_9DBOptionsERKNS_20TransactionDBOptionsERKNSt3__112basic_stringIcNS7_11char_traitsIcEENS7_9allocatorIcEEEERKNS7_6vectorINS_22ColumnFamilyDescriptorENSB_ISH_EEEEPNSG_IPNS_18ColumnFamilyHandleENSB_ISN_EEEEPPS0_"
   "params":
   - "name": ""
     "type": "bool "
@@ -52,8 +49,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Status rocksdb::TransactionDB::Open(const struct DBOptions &, const struct TransactionDBOptions &, const string &, const vector<rocksdb::ColumnFamilyDescriptor, std::__1::allocator<rocksdb::ColumnFamilyDescriptor> > &, vector<rocksdb::ColumnFamilyHandle *, std::__1::allocator<rocksdb::ColumnFamilyHandle *> > *, TransactionDB **)"
-- "exceptions": []
-  "name": "_ZN7rocksdb6DBImpl19IngestExternalFilesERKNSt3__16vectorINS_21IngestExternalFileArgENS1_9allocatorIS3_EEEE"
+- "name": "_ZN7rocksdb6DBImpl19IngestExternalFilesERKNSt3__16vectorINS_21IngestExternalFileArgENS1_9allocatorIS3_EEEE"
   "params":
   - "name": ""
     "type": "bool "
@@ -63,8 +59,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "Status rocksdb::DBImpl::IngestExternalFiles(const vector<rocksdb::IngestExternalFileArg, std::__1::allocator<rocksdb::IngestExternalFileArg> > &)"
-- "exceptions": []
-  "name": "_ZN7rocksdb18WriteUnpreparedTxn19RollbackToSavePointEv"
+- "name": "_ZN7rocksdb18WriteUnpreparedTxn19RollbackToSavePointEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/rtpproxy.yaml
+++ b/benchmark-sets/all/rtpproxy.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ucl_object_insert_key"
+- "name": "ucl_object_insert_key"
   "params":
   - "name": "top"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool ucl_object_insert_key(ucl_object_t *, ucl_object_t *, const char *, size_t, bool)"
-- "exceptions": []
-  "name": "process_rtp_only"
+- "name": "process_rtp_only"
   "params":
   - "name": "cfsp"
     "type": "bool "
@@ -35,8 +33,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void process_rtp_only(const struct rtpp_cfg *, struct rtpp_polltbl *, const struct rtpp_timestamp *, int, struct sthread_args *, struct rtpp_proc_rstats *, struct epoll_event *, int)"
-- "exceptions": []
-  "name": "rtpp_command_stream_get"
+- "name": "rtpp_command_stream_get"
   "params":
   - "name": "cfsp"
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct rtpp_command * rtpp_command_stream_get(const struct rtpp_cfg *, struct rtpp_cmd_connection *, int *, const struct rtpp_timestamp *, struct rtpp_command_stats *)"
-- "exceptions": []
-  "name": "get_command"
+- "name": "get_command"
   "params":
   - "name": "cfsp"
     "type": "bool "
@@ -69,8 +65,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct rtpp_command * get_command(const struct rtpp_cfg *, struct rtpp_ctrl_sock *, int, int *, const struct rtpp_timestamp *, struct rtpp_command_stats *, struct rtpp_cmd_rcache *)"
-- "exceptions": []
-  "name": "rtp_resizer_get"
+- "name": "rtp_resizer_get"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/s2geometry.yaml
+++ b/benchmark-sets/all/s2geometry.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN9S2Polygon16InitToSimplifiedERKS_RKN9S2Builder12SnapFunctionE"
+- "name": "_ZN9S2Polygon16InitToSimplifiedERKS_RKN9S2Builder12SnapFunctionE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void S2Polygon::InitToSimplified(const S2Polygon &, const SnapFunction &)"
-- "exceptions": []
-  "name": "_ZN9S2Polygon13InitToSnappedERKS_i"
+- "name": "_ZN9S2Polygon13InitToSnappedERKS_i"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void S2Polygon::InitToSnapped(const S2Polygon &, int)"
-- "exceptions": []
-  "name": "_ZN9S2Polygon21InitToCellUnionBorderERK11S2CellUnion"
+- "name": "_ZN9S2Polygon21InitToCellUnionBorderERK11S2CellUnion"
   "params":
   - "name": "this"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void S2Polygon::InitToCellUnionBorder(const S2CellUnion &)"
-- "exceptions": []
-  "name": "_ZN9S2Polygon22InitToSimplifiedInCellERKS_RK6S2Cell7S1AngleS5_"
+- "name": "_ZN9S2Polygon22InitToSimplifiedInCellERKS_RK6S2Cell7S1AngleS5_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "double"
   "return_type": "void"
   "signature": "void S2Polygon::InitToSimplifiedInCell(const S2Polygon &, const S2Cell &, S1Angle, S1Angle)"
-- "exceptions": []
-  "name": "_ZN18S2BooleanOperation4Impl5BuildEP7S2Error"
+- "name": "_ZN18S2BooleanOperation4Impl5BuildEP7S2Error"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/s2opc.yaml
+++ b/benchmark-sets/all/s2opc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "SOPC_SecureChannels_OnInternalEvent"
+- "name": "SOPC_SecureChannels_OnInternalEvent"
   "params":
   - "name": ""
     "type": "bool "
@@ -14,29 +13,25 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void SOPC_SecureChannels_OnInternalEvent(SOPC_EventHandler *, int32_t, uint32_t, uintptr_t, uintptr_t)"
-- "exceptions": []
-  "name": "SOPC_SecureChannelsInternalContext_Initialize"
+- "name": "SOPC_SecureChannelsInternalContext_Initialize"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void SOPC_SecureChannelsInternalContext_Initialize(SOPC_SetListenerFunc *)"
-- "exceptions": []
-  "name": "SOPC_Toolkit_Initialize"
+- "name": "SOPC_Toolkit_Initialize"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "SOPC_ReturnStatus SOPC_Toolkit_Initialize(SOPC_ComEvent_Fct *)"
-- "exceptions": []
-  "name": "SOPC_Services_Initialize"
+- "name": "SOPC_Services_Initialize"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "void SOPC_Services_Initialize(SOPC_SetListenerFunc *)"
-- "exceptions": []
-  "name": "SOPC_SecureChannels_Initialize"
+- "name": "SOPC_SecureChannels_Initialize"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/selinux.yaml
+++ b/benchmark-sets/all/selinux.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "cil_write_resolve_ast"
+- "name": "cil_write_resolve_ast"
   "params":
   - "name": "out"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cil_write_resolve_ast(FILE *, cil_db_t *)"
-- "exceptions": []
-  "name": "sepol_policydb_to_image"
+- "name": "sepol_policydb_to_image"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int sepol_policydb_to_image(sepol_handle_t *, sepol_policydb_t *, void **, size_t *)"
-- "exceptions": []
-  "name": "cil_write_build_ast"
+- "name": "cil_write_build_ast"
   "params":
   - "name": "out"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cil_write_build_ast(FILE *, cil_db_t *)"
-- "exceptions": []
-  "name": "cil_write_post_ast"
+- "name": "cil_write_post_ast"
   "params":
   - "name": "out"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int cil_write_post_ast(FILE *, cil_db_t *)"
-- "exceptions": []
-  "name": "policydb_to_image"
+- "name": "policydb_to_image"
   "params":
   - "name": "handle"
     "type": "bool "

--- a/benchmark-sets/all/sentencepiece.yaml
+++ b/benchmark-sets/all/sentencepiece.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN13sentencepiece10ModelProto14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
+- "name": "_ZN13sentencepiece10ModelProto14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * sentencepiece::ModelProto::_InternalParse(const char *, ParseContext *)"
-- "exceptions": []
-  "name": "_ZN13sentencepiece22NBestSentencePieceText14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
+- "name": "_ZN13sentencepiece22NBestSentencePieceText14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * sentencepiece::NBestSentencePieceText::_InternalParse(const char *, ParseContext *)"
-- "exceptions": []
-  "name": "_ZN13sentencepiece17SentencePieceText14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
+- "name": "_ZN13sentencepiece17SentencePieceText14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * sentencepiece::SentencePieceText::_InternalParse(const char *, ParseContext *)"
-- "exceptions": []
-  "name": "_ZN13sentencepiece12SelfTestData14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
+- "name": "_ZN13sentencepiece12SelfTestData14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * sentencepiece::SelfTestData::_InternalParse(const char *, ParseContext *)"
-- "exceptions": []
-  "name": "_ZN13sentencepiece11TrainerSpec14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
+- "name": "_ZN13sentencepiece11TrainerSpec14_InternalParseEPKcPN6google8protobuf8internal12ParseContextE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/simd.yaml
+++ b/benchmark-sets/all/simd.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4Simd4Avx238SynetConvolution32fDepthwiseDotProduct7ForwardEPKfPfS4_"
+- "name": "_ZN4Simd4Avx238SynetConvolution32fDepthwiseDotProduct7ForwardEPKfPfS4_"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void Simd::Avx2::SynetConvolution32fDepthwiseDotProduct::Forward(const float *, float *, float *)"
-- "exceptions": []
-  "name": "_ZN4Simd4Avx228ConvolutionBiasAndActivationEPKfmm29SimdConvolutionActivationTypeS2_8SimdBoolPf"
+- "name": "_ZN4Simd4Avx228ConvolutionBiasAndActivationEPKfmm29SimdConvolutionActivationTypeS2_8SimdBoolPf"
   "params":
   - "name": ""
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void Simd::Avx2::ConvolutionBiasAndActivation(const float *, size_t, size_t, SimdConvolutionActivationType, const float *, SimdBool, float *)"
-- "exceptions": []
-  "name": "_ZN4Simd8Avx512bw23SynetConvolution32fInitEmPK25SimdConvolutionParameters26SimdSynetCompatibilityType"
+- "name": "_ZN4Simd8Avx512bw23SynetConvolution32fInitEmPK25SimdConvolutionParameters26SimdSynetCompatibilityType"
   "params":
   - "name": ""
     "type": "size_t"
@@ -42,8 +39,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void * Simd::Avx512bw::SynetConvolution32fInit(size_t, const SimdConvolutionParameters *, SimdSynetCompatibilityType)"
-- "exceptions": []
-  "name": "_ZN4Simd4Avx223SynetConvolution32fInitEmPK25SimdConvolutionParameters26SimdSynetCompatibilityType"
+- "name": "_ZN4Simd4Avx223SynetConvolution32fInitEmPK25SimdConvolutionParameters26SimdSynetCompatibilityType"
   "params":
   - "name": ""
     "type": "size_t"
@@ -53,8 +49,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void * Simd::Avx2::SynetConvolution32fInit(size_t, const SimdConvolutionParameters *, SimdSynetCompatibilityType)"
-- "exceptions": []
-  "name": "_ZN4Simd8Avx512bw29SynetMergedConvolution32fInitEmPK25SimdConvolutionParametersm8SimdBool26SimdSynetCompatibilityType"
+- "name": "_ZN4Simd8Avx512bw29SynetMergedConvolution32fInitEmPK25SimdConvolutionParametersm8SimdBool26SimdSynetCompatibilityType"
   "params":
   - "name": ""
     "type": "size_t"

--- a/benchmark-sets/all/simdjson.yaml
+++ b/benchmark-sets/all/simdjson.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8simdjson8westmere25dom_parser_implementation11stage2_nextERNS_3dom8documentE"
+- "name": "_ZN8simdjson8westmere25dom_parser_implementation11stage2_nextERNS_3dom8documentE"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeerror_code simdjson::westmere::dom_parser_implementation::stage2_next(document &)"
-- "exceptions": []
-  "name": "_ZN8simdjson7icelake25dom_parser_implementation5parseEPKhmRNS_3dom8documentE"
+- "name": "_ZN8simdjson7icelake25dom_parser_implementation5parseEPKhmRNS_3dom8documentE"
   "params":
   - "name": ""
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeerror_code simdjson::icelake::dom_parser_implementation::parse(const uint8_t *, size_t, document &)"
-- "exceptions": []
-  "name": "_ZN8simdjson7icelake25dom_parser_implementation6stage2ERNS_3dom8documentE"
+- "name": "_ZN8simdjson7icelake25dom_parser_implementation6stage2ERNS_3dom8documentE"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeerror_code simdjson::icelake::dom_parser_implementation::stage2(document &)"
-- "exceptions": []
-  "name": "_ZN8simdjson8fallback25dom_parser_implementation11stage2_nextERNS_3dom8documentE"
+- "name": "_ZN8simdjson8fallback25dom_parser_implementation11stage2_nextERNS_3dom8documentE"
   "params":
   - "name": ""
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typeerror_code simdjson::fallback::dom_parser_implementation::stage2_next(document &)"
-- "exceptions": []
-  "name": "_ZN8simdjson7icelake25dom_parser_implementation11stage2_nextERNS_3dom8documentE"
+- "name": "_ZN8simdjson7icelake25dom_parser_implementation11stage2_nextERNS_3dom8documentE"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/simdutf.yaml
+++ b/benchmark-sets/all/simdutf.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK7simdutf7haswell14implementation16base64_to_binaryEPKDsmPcm"
+- "name": "_ZNK7simdutf7haswell14implementation16base64_to_binaryEPKDsmPcm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "struct result simdutf::haswell::implementation::base64_to_binary(const char16_t *, size_t, char *, base64_options)"
-- "exceptions": []
-  "name": "_ZNK7simdutf8westmere14implementation16base64_to_binaryEPKDsmPcm"
+- "name": "_ZNK7simdutf8westmere14implementation16base64_to_binaryEPKDsmPcm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "struct result simdutf::westmere::implementation::base64_to_binary(const char16_t *, size_t, char *, base64_options)"
-- "exceptions": []
-  "name": "_ZNK7simdutf7icelake14implementation16base64_to_binaryEPKDsmPcm"
+- "name": "_ZNK7simdutf7icelake14implementation16base64_to_binaryEPKDsmPcm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "struct result simdutf::icelake::implementation::base64_to_binary(const char16_t *, size_t, char *, base64_options)"
-- "exceptions": []
-  "name": "_ZNK7simdutf7icelake14implementation16base64_to_binaryEPKcmPcm"
+- "name": "_ZNK7simdutf7icelake14implementation16base64_to_binaryEPKcmPcm"
   "params":
   - "name": "this"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "struct result simdutf::icelake::implementation::base64_to_binary(const char *, size_t, char *, base64_options)"
-- "exceptions": []
-  "name": "_ZNK7simdutf7icelake14implementation16detect_encodingsEPKcm"
+- "name": "_ZNK7simdutf7icelake14implementation16detect_encodingsEPKcm"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/skcms.yaml
+++ b/benchmark-sets/all/skcms.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "skcms_AreApproximateInverses"
+- "name": "skcms_AreApproximateInverses"
   "params":
   - "name": "curve"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool skcms_AreApproximateInverses(const skcms_Curve *, const skcms_TransferFunction *)"
-- "exceptions": []
-  "name": "skcms_PrimariesToXYZD50"
+- "name": "skcms_PrimariesToXYZD50"
   "params":
   - "name": "rx"
     "type": "float"
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool skcms_PrimariesToXYZD50(float, float, float, float, float, float, float, float, skcms_Matrix3x3 *)"
-- "exceptions": []
-  "name": "skcms_ApproximatelyEqualProfiles"
+- "name": "skcms_ApproximatelyEqualProfiles"
   "params":
   - "name": "A"
     "type": "bool "
@@ -40,8 +37,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool skcms_ApproximatelyEqualProfiles(const skcms_ICCProfile *, const skcms_ICCProfile *)"
-- "exceptions": []
-  "name": "skcms_TRCs_AreApproximateInverse"
+- "name": "skcms_TRCs_AreApproximateInverse"
   "params":
   - "name": "profile"
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool skcms_TRCs_AreApproximateInverse(const skcms_ICCProfile *, const skcms_TransferFunction *)"
-- "exceptions": []
-  "name": "skcms_MakeUsableAsDestinationWithSingleCurve"
+- "name": "skcms_MakeUsableAsDestinationWithSingleCurve"
   "params":
   - "name": "profile"
     "type": "bool "

--- a/benchmark-sets/all/sleuthkit.yaml
+++ b/benchmark-sets/all/sleuthkit.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "tsk_fs_open_vol"
+- "name": "tsk_fs_open_vol"
   "params":
   - "name": "a_part_info"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "TSK_FS_INFO * tsk_fs_open_vol(const TSK_VS_PART_INFO *, TSK_FS_TYPE_ENUM)"
-- "exceptions": []
-  "name": "tsk_fs_open_vol_decrypt"
+- "name": "tsk_fs_open_vol_decrypt"
   "params":
   - "name": "a_part_info"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "TSK_FS_INFO * tsk_fs_open_vol_decrypt(const TSK_VS_PART_INFO *, TSK_FS_TYPE_ENUM, const char *)"
-- "exceptions": []
-  "name": "_ZNK12APFSFSCompat5istatE22TSK_FS_ISTAT_FLAG_ENUMP8_IO_FILEmmi"
+- "name": "_ZNK12APFSFSCompat5istatE22TSK_FS_ISTAT_FLAG_ENUMP8_IO_FILEmmi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "int"
   "return_type": "char"
   "signature": "uint8_t APFSFSCompat::istat(TSK_FS_ISTAT_FLAG_ENUM, FILE *, TSK_INUM_T, TSK_DADDR_T, int32_t)"
-- "exceptions": []
-  "name": "ntfs_dir_open_meta"
+- "name": "ntfs_dir_open_meta"
   "params":
   - "name": "a_fs"
     "type": "bool "
@@ -49,8 +45,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "TSK_RETVAL_ENUM ntfs_dir_open_meta(TSK_FS_INFO *, TSK_FS_DIR **, TSK_INUM_T, int)"
-- "exceptions": []
-  "name": "ffs_dir_open_meta"
+- "name": "ffs_dir_open_meta"
   "params":
   - "name": "a_fs"
     "type": "bool "

--- a/benchmark-sets/all/snappy.yaml
+++ b/benchmark-sets/all/snappy.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6snappy26UncompressAsMuchAsPossibleEPNS_6SourceEPNS_4SinkE"
+- "name": "_ZN6snappy26UncompressAsMuchAsPossibleEPNS_6SourceEPNS_4SinkE"
   "params":
   - "name": "compressed"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t snappy::UncompressAsMuchAsPossible(Source *, Sink *)"
-- "exceptions": []
-  "name": "_ZN6snappy17CompressFromIOVecEPK5iovecmPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE"
+- "name": "_ZN6snappy17CompressFromIOVecEPK5iovecmPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE"
   "params":
   - "name": "iov"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t snappy::CompressFromIOVec(const struct iovec *, size_t, string *)"
-- "exceptions": []
-  "name": "_ZN6snappy17CompressFromIOVecEPK5iovecmPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS_18CompressionOptionsE"
+- "name": "_ZN6snappy17CompressFromIOVecEPK5iovecmPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS_18CompressionOptionsE"
   "params":
   - "name": "iov"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "size_t snappy::CompressFromIOVec(const struct iovec *, size_t, string *, struct CompressionOptions)"
-- "exceptions": []
-  "name": "_ZN6snappy8CompressEPKcmPNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE"
+- "name": "_ZN6snappy8CompressEPKcmPNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE"
   "params":
   - "name": "input"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t snappy::Compress(const char *, size_t, string *)"
-- "exceptions": []
-  "name": "_ZN6snappy10UncompressEPNS_6SourceEPNS_4SinkE"
+- "name": "_ZN6snappy10UncompressEPNS_6SourceEPNS_4SinkE"
   "params":
   - "name": "compressed"
     "type": "bool "

--- a/benchmark-sets/all/spdlog.yaml
+++ b/benchmark-sets/all/spdlog.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6spdlog5sinks14ansicolor_sinkINS_7details13console_mutexEE11set_patternERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE"
+- "name": "_ZN6spdlog5sinks14ansicolor_sinkINS_7details13console_mutexEE11set_patternERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void spdlog::sinks::ansicolor_sink<spdlog::details::console_mutex>::set_pattern(ansicolor_sink<spdlog::details::console_mutex> *, const string &)"
-- "exceptions": []
-  "name": "_ZN6spdlog5sinks9base_sinkINSt3__15mutexEE12set_pattern_ERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE"
+- "name": "_ZN6spdlog5sinks9base_sinkINSt3__15mutexEE12set_pattern_ERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,15 +15,13 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void spdlog::sinks::base_sink<std::__1::mutex>::set_pattern_(base_sink<std::__1::mutex> *, const string &)"
-- "exceptions": []
-  "name": "_ZN6spdlog5sinks15basic_file_sinkINSt3__15mutexEE6flush_Ev"
+- "name": "_ZN6spdlog5sinks15basic_file_sinkINSt3__15mutexEE6flush_Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void spdlog::sinks::basic_file_sink<std::__1::mutex>::flush_(basic_file_sink<std::__1::mutex> *)"
-- "exceptions": []
-  "name": "_ZN6spdlog5sinks15basic_file_sinkINSt3__15mutexEEC2ERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEbRKNS_19file_event_handlersE"
+- "name": "_ZN6spdlog5sinks15basic_file_sinkINSt3__15mutexEEC2ERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEbRKNS_19file_event_handlersE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void spdlog::sinks::basic_file_sink<std::__1::mutex>::basic_file_sink(basic_file_sink<std::__1::mutex> *, const filename_t &, bool, const struct file_event_handlers &)"
-- "exceptions": []
-  "name": "_ZN3fmt3v106detail13format_dragonENS1_8basic_fpIoEEjiRNS1_6bufferIcEERi"
+- "name": "_ZN3fmt3v106detail13format_dragonENS1_8basic_fpIoEEjiRNS1_6bufferIcEERi"
   "params":
   - "name": "value"
     "type": "bool "

--- a/benchmark-sets/all/speex.yaml
+++ b/benchmark-sets/all/speex.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "nb_encode"
+- "name": "nb_encode"
   "params":
   - "name": "state"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int nb_encode(void *, void *, SpeexBits *)"
-- "exceptions": []
-  "name": "vbr_analysis"
+- "name": "vbr_analysis"
   "params":
   - "name": "vbr"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "float"
   "return_type": "float"
   "signature": "float vbr_analysis(VBRState *, spx_word16_t *, int, int, float)"
-- "exceptions": []
-  "name": "sb_encode"
+- "name": "sb_encode"
   "params":
   - "name": "state"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int sb_encode(void *, void *, SpeexBits *)"
-- "exceptions": []
-  "name": "split_cb_search_shape_sign"
+- "name": "split_cb_search_shape_sign"
   "params":
   - "name": "target"
     "type": "bool "
@@ -67,8 +63,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void split_cb_search_shape_sign(spx_word16_t *, spx_coef_t *, spx_coef_t *, spx_coef_t *, const void *, int, int, spx_sig_t *, spx_word16_t *, SpeexBits *, char *, int, int)"
-- "exceptions": []
-  "name": "pitch_search_3tap"
+- "name": "pitch_search_3tap"
   "params":
   - "name": "target"
     "type": "bool "

--- a/benchmark-sets/all/spice-usbredir.yaml
+++ b/benchmark-sets/all/spice-usbredir.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "usbredirparser_send_buffered_bulk_packet"
+- "name": "usbredirparser_send_buffered_bulk_packet"
   "params":
   - "name": "parser"
     "type": "bool "
@@ -14,15 +13,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void usbredirparser_send_buffered_bulk_packet(struct usbredirparser *, uint64_t, struct usb_redir_buffered_bulk_packet_header *, uint8_t *, int)"
-- "exceptions": []
-  "name": "usbredirparser_send_filter_reject"
+- "name": "usbredirparser_send_filter_reject"
   "params":
   - "name": "parser"
     "type": "bool "
   "return_type": "void"
   "signature": "void usbredirparser_send_filter_reject(struct usbredirparser *)"
-- "exceptions": []
-  "name": "usbredirparser_send_iso_packet"
+- "name": "usbredirparser_send_iso_packet"
   "params":
   - "name": "parser"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void usbredirparser_send_iso_packet(struct usbredirparser *, uint64_t, struct usb_redir_iso_packet_header *, uint8_t *, int)"
-- "exceptions": []
-  "name": "usbredirparser_send_interrupt_packet"
+- "name": "usbredirparser_send_interrupt_packet"
   "params":
   - "name": "parser"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void usbredirparser_send_interrupt_packet(struct usbredirparser *, uint64_t, struct usb_redir_interrupt_packet_header *, uint8_t *, int)"
-- "exceptions": []
-  "name": "usbredirparser_send_filter_filter"
+- "name": "usbredirparser_send_filter_filter"
   "params":
   - "name": "parser_pub"
     "type": "bool "

--- a/benchmark-sets/all/spirv-tools.yaml
+++ b/benchmark-sets/all/spirv-tools.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "spvValidate"
+- "name": "spvValidate"
   "params":
   - "name": "context"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "spv_result_t spvValidate(const spv_const_context, const spv_const_binary, spv_diagnostic *)"
-- "exceptions": []
-  "name": "_ZNK8spvtools9Optimizer3RunEPKjmPNSt3__16vectorIjNS3_9allocatorIjEEEE"
+- "name": "_ZNK8spvtools9Optimizer3RunEPKjmPNSt3__16vectorIjNS3_9allocatorIjEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool spvtools::Optimizer::Run(const uint32_t *, const size_t, vector<unsigned int, std::__1::allocator<unsigned int> > *)"
-- "exceptions": []
-  "name": "spvOptimizerRun"
+- "name": "spvOptimizerRun"
   "params":
   - "name": "optimizer"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "spv_result_t spvOptimizerRun(spv_optimizer_t *, const uint32_t *, const size_t, spv_binary *, const spv_optimizer_options)"
-- "exceptions": []
-  "name": "_ZNK8spvtools9Optimizer3RunEPKjmPNSt3__16vectorIjNS3_9allocatorIjEEEERKNS_16ValidatorOptionsEb"
+- "name": "_ZNK8spvtools9Optimizer3RunEPKjmPNSt3__16vectorIjNS3_9allocatorIjEEEERKNS_16ValidatorOptionsEb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -55,8 +51,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool spvtools::Optimizer::Run(const uint32_t *, const size_t, vector<unsigned int, std::__1::allocator<unsigned int> > *, const ValidatorOptions &, bool)"
-- "exceptions": []
-  "name": "_ZN8spvtools3opt15LoopFissionPass7ProcessEv"
+- "name": "_ZN8spvtools3opt15LoopFissionPass7ProcessEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/spotify-json.yaml
+++ b/benchmark-sets/all/spotify-json.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK7spotify4json6detail14field_registry5beginEv"
+- "name": "_ZNK7spotify4json6detail14field_registry5beginEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "const_iterator spotify::json::detail::field_registry::begin()"
-- "exceptions": []
-  "name": "_ZNK7spotify4json6detail14field_registry3endEv"
+- "name": "_ZNK7spotify4json6detail14field_registry3endEv"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/sql-parser.yaml
+++ b/benchmark-sets/all/sql-parser.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK4hsql4Expr9isLiteralEv"
+- "name": "_ZNK4hsql4Expr9isLiteralEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "bool"
   "signature": "bool hsql::Expr::isLiteral(const struct Expr *)"
-- "exceptions": []
-  "name": "_ZN4hsql15SelectStatementD2Ev"
+- "name": "_ZN4hsql15SelectStatementD2Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void hsql::SelectStatement::~SelectStatement(struct SelectStatement *)"
-- "exceptions": []
-  "name": "_ZN4hsql15SQLParserResultC2EOS0_"
+- "name": "_ZN4hsql15SQLParserResultC2EOS0_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -22,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void hsql::SQLParserResult::SQLParserResult(DW_TAG_rvalue_reference_typeSQLParserResult)"
-- "exceptions": []
-  "name": "_ZN4hsql9SQLParser14parseSQLStringERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEPNS_15SQLParserResultE"
+- "name": "_ZN4hsql9SQLParser14parseSQLStringERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEPNS_15SQLParserResultE"
   "params":
   - "name": "sql"
     "type": "bool "
@@ -31,8 +27,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool hsql::SQLParser::parseSQLString(const string &, SQLParserResult *)"
-- "exceptions": []
-  "name": "_ZN4hsqllsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_10ColumnTypeE"
+- "name": "_ZN4hsqllsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_10ColumnTypeE"
   "params":
   - "name": "stream"
     "type": "bool "

--- a/benchmark-sets/all/stb.yaml
+++ b/benchmark-sets/all/stb.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "stbi_is_16_bit_from_file"
+- "name": "stbi_is_16_bit_from_file"
   "params":
   - "name": "f"
     "type": "bool "
   "return_type": "int"
   "signature": "int stbi_is_16_bit_from_file(FILE *)"
-- "exceptions": []
-  "name": "stbi_is_16_bit"
+- "name": "stbi_is_16_bit"
   "params":
   - "name": "filename"
     "type": "bool "
   "return_type": "int"
   "signature": "int stbi_is_16_bit(const char *)"
-- "exceptions": []
-  "name": "stbi_info"
+- "name": "stbi_info"
   "params":
   - "name": "filename"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int stbi_info(const char *, int *, int *, int *)"
-- "exceptions": []
-  "name": "stbi_info_from_file"
+- "name": "stbi_info_from_file"
   "params":
   - "name": "f"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int stbi_info_from_file(FILE *, int *, int *, int *)"
-- "exceptions": []
-  "name": "_ZL15stbi__jpeg_loadP13stbi__contextPiS1_S1_iP17stbi__result_info"
+- "name": "_ZL15stbi__jpeg_loadP13stbi__contextPiS1_S1_iP17stbi__result_info"
   "params":
   - "name": "s"
     "type": "bool "

--- a/benchmark-sets/all/strongswan.yaml
+++ b/benchmark-sets/all/strongswan.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sshkey_public_key_load"
+- "name": "sshkey_public_key_load"
   "params":
   - "name": "type"
     "type": "int"
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "sshkey_public_key_t * sshkey_public_key_load(key_type_t, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "x509_ac_load"
+- "name": "x509_ac_load"
   "params":
   - "name": "type"
     "type": "int"
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "x509_ac_t * x509_ac_load(certificate_type_t, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "validate"
+- "name": "validate"
   "params":
   - "name": "this"
     "type": "bool "
@@ -34,15 +31,13 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool validate(private_constraints_validator_t *, certificate_t *, certificate_t *, u_int, bool, auth_cfg_t *)"
-- "exceptions": []
-  "name": "settings_create_string"
+- "name": "settings_create_string"
   "params":
   - "name": "settings"
     "type": "bool "
   "return_type": "void"
   "signature": "settings_t * settings_create_string(char *)"
-- "exceptions": []
-  "name": "sshkey_certificate_load"
+- "name": "sshkey_certificate_load"
   "params":
   - "name": "type"
     "type": "int"

--- a/benchmark-sets/all/sudoers.yaml
+++ b/benchmark-sets/all/sudoers.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sudo_mkstemps"
+- "name": "sudo_mkstemps"
   "params":
   - "name": "path"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sudo_mkstemps(char *, int)"
-- "exceptions": []
-  "name": "sudo_make_grlist_item"
+- "name": "sudo_make_grlist_item"
   "params":
   - "name": "pw"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct cache_item * sudo_make_grlist_item(const struct passwd *, const char **)"
-- "exceptions": []
-  "name": "sudo_set_grlist"
+- "name": "sudo_set_grlist"
   "params":
   - "name": "pw"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int sudo_set_grlist(struct passwd *, const char **)"
-- "exceptions": []
-  "name": "sudo_mkdtempat"
+- "name": "sudo_mkdtempat"
   "params":
   - "name": "dfd"
     "type": "int"
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * sudo_mkdtempat(int, char *)"
-- "exceptions": []
-  "name": "free_cmndspec"
+- "name": "free_cmndspec"
   "params":
   - "name": "cs"
     "type": "bool "

--- a/benchmark-sets/all/tesseract-ocr.yaml
+++ b/benchmark-sets/all/tesseract-ocr.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN9tesseract11TessBaseAPI12ProcessPagesEPKcS2_iPNS_18TessResultRendererE"
+- "name": "_ZN9tesseract11TessBaseAPI12ProcessPagesEPKcS2_iPNS_18TessResultRendererE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool tesseract::TessBaseAPI::ProcessPages(const char *, const char *, int, TessResultRenderer *)"
-- "exceptions": []
-  "name": "_ZN9tesseract9Tesseract19classify_word_pass1ERKNS_8WordDataEPPNS_8WERD_RESEPNS_13PointerVectorIS4_EE"
+- "name": "_ZN9tesseract9Tesseract19classify_word_pass1ERKNS_8WordDataEPPNS_8WERD_RESEPNS_13PointerVectorIS4_EE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -27,8 +25,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void tesseract::Tesseract::classify_word_pass1(const struct WordData &, WERD_RES **, PointerVector<tesseract::WERD_RES> *)"
-- "exceptions": []
-  "name": "_ZN9tesseract15TessTsvRenderer15AddImageHandlerEPNS_11TessBaseAPIE"
+- "name": "_ZN9tesseract15TessTsvRenderer15AddImageHandlerEPNS_11TessBaseAPIE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool tesseract::TessTsvRenderer::AddImageHandler(TessBaseAPI *)"
-- "exceptions": []
-  "name": "_ZN9tesseract19TessBoxTextRenderer15AddImageHandlerEPNS_11TessBaseAPIE"
+- "name": "_ZN9tesseract19TessBoxTextRenderer15AddImageHandlerEPNS_11TessBaseAPIE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool tesseract::TessBoxTextRenderer::AddImageHandler(TessBaseAPI *)"
-- "exceptions": []
-  "name": "_ZN9tesseract11TessBaseAPI10GetTSVTextEi"
+- "name": "_ZN9tesseract11TessBaseAPI10GetTSVTextEi"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/tidy-html5.yaml
+++ b/benchmark-sets/all/tidy-html5.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "tidySaveStdout"
+- "name": "tidySaveStdout"
   "params":
   - "name": "tdoc"
     "type": "bool "
   "return_type": "int"
   "signature": "int tidySaveStdout(TidyDoc)"
-- "exceptions": []
-  "name": "tidySaveString"
+- "name": "tidySaveString"
   "params":
   - "name": "tdoc"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int tidySaveString(TidyDoc, tmbstr, uint *)"
-- "exceptions": []
-  "name": "tidyParseSource"
+- "name": "tidyParseSource"
   "params":
   - "name": "tdoc"
     "type": "bool "
@@ -26,15 +23,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int tidyParseSource(TidyDoc, TidyInputSource *)"
-- "exceptions": []
-  "name": "tidyParseStdin"
+- "name": "tidyParseStdin"
   "params":
   - "name": "tdoc"
     "type": "bool "
   "return_type": "int"
   "signature": "int tidyParseStdin(TidyDoc)"
-- "exceptions": []
-  "name": "tidySaveFile"
+- "name": "tidySaveFile"
   "params":
   - "name": "tdoc"
     "type": "bool "

--- a/benchmark-sets/all/tinygltf.yaml
+++ b/benchmark-sets/all/tinygltf.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8tinygltf8TinyGLTF18LoadBinaryFromFileEPNS_5ModelEPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESA_RKS9_j"
+- "name": "_ZN8tinygltf8TinyGLTF18LoadBinaryFromFileEPNS_5ModelEPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESA_RKS9_j"
   "params":
   - "name": "this"
     "type": "bool "
@@ -16,8 +15,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool tinygltf::TinyGLTF::LoadBinaryFromFile(Model *, string *, string *, const string &, unsigned int)"
-- "exceptions": []
-  "name": "_ZN8tinygltf8TinyGLTF20WriteGltfSceneToFileEPKNS_5ModelERKNSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEbbbb"
+- "name": "_ZN8tinygltf8TinyGLTF20WriteGltfSceneToFileEPKNS_5ModelERKNSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEbbbb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -35,8 +33,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool tinygltf::TinyGLTF::WriteGltfSceneToFile(const Model *, const string &, bool, bool, bool, bool)"
-- "exceptions": []
-  "name": "_ZN8tinygltf8TinyGLTF22WriteGltfSceneToStreamEPKNS_5ModelERNSt3__113basic_ostreamIcNS4_11char_traitsIcEEEEbb"
+- "name": "_ZN8tinygltf8TinyGLTF22WriteGltfSceneToStreamEPKNS_5ModelERNSt3__113basic_ostreamIcNS4_11char_traitsIcEEEEbb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -50,8 +47,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool tinygltf::TinyGLTF::WriteGltfSceneToStream(const Model *, ostream &, bool, bool)"
-- "exceptions": []
-  "name": "_ZN8tinygltf8TinyGLTF20LoadBinaryFromMemoryEPNS_5ModelEPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESA_PKhjRKS9_j"
+- "name": "_ZN8tinygltf8TinyGLTF20LoadBinaryFromMemoryEPNS_5ModelEPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESA_PKhjRKS9_j"
   "params":
   - "name": "this"
     "type": "bool "
@@ -71,8 +67,7 @@
     "type": "int"
   "return_type": "bool"
   "signature": "bool tinygltf::TinyGLTF::LoadBinaryFromMemory(Model *, string *, string *, const unsigned char *, unsigned int, const string &, unsigned int)"
-- "exceptions": []
-  "name": "_ZN8tinygltf8TinyGLTF17LoadASCIIFromFileEPNS_5ModelEPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESA_RKS9_j"
+- "name": "_ZN8tinygltf8TinyGLTF17LoadASCIIFromFileEPNS_5ModelEPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESA_RKS9_j"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/tinyobjloader.yaml
+++ b/benchmark-sets/all/tinyobjloader.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7tinyobj7LoadObjEPNS_8attrib_tEPNSt3__16vectorINS_7shape_tENS2_9allocatorIS4_EEEEPNS3_INS_10material_tENS5_IS9_EEEEPNS2_12basic_stringIcNS2_11char_traitsIcEENS5_IcEEEESI_PKcSK_bb"
+- "name": "_ZN7tinyobj7LoadObjEPNS_8attrib_tEPNSt3__16vectorINS_7shape_tENS2_9allocatorIS4_EEEEPNS3_INS_10material_tENS5_IS9_EEEEPNS2_12basic_stringIcNS2_11char_traitsIcEENS5_IcEEEESI_PKcSK_bb"
   "params":
   - "name": "attrib"
     "type": "bool "
@@ -22,8 +21,7 @@
     "type": "bool"
   "return_type": "bool"
   "signature": "bool tinyobj::LoadObj(struct attrib_t *, vector<tinyobj::shape_t, std::__1::allocator<tinyobj::shape_t> > *, vector<tinyobj::material_t, std::__1::allocator<tinyobj::material_t> > *, string *, string *, const char *, const char *, bool, bool)"
-- "exceptions": []
-  "name": "_ZN7tinyobj7shape_tC2ERKS0_"
+- "name": "_ZN7tinyobj7shape_tC2ERKS0_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct shape_t & tinyobj::shape_t::operator=(struct shape_t *, struct DW_TAG_rvalue_reference_typeshape_t)"
-- "exceptions": []
-  "name": "_ZN7tinyobj9ObjReader13ParseFromFileERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEERKNS_15ObjReaderConfigE"
+- "name": "_ZN7tinyobj9ObjReader13ParseFromFileERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEERKNS_15ObjReaderConfigE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -42,8 +39,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool tinyobj::ObjReader::ParseFromFile(const string &, const struct ObjReaderConfig &)"
-- "exceptions": []
-  "name": "_ZN7tinyobj19LoadObjWithCallbackERNSt3__113basic_istreamIcNS0_11char_traitsIcEEEERKNS_10callback_tEPvPNS_14MaterialReaderEPNS0_12basic_stringIcS3_NS0_9allocatorIcEEEESG_"
+- "name": "_ZN7tinyobj19LoadObjWithCallbackERNSt3__113basic_istreamIcNS0_11char_traitsIcEEEERKNS_10callback_tEPvPNS_14MaterialReaderEPNS0_12basic_stringIcS3_NS0_9allocatorIcEEEESG_"
   "params":
   - "name": "inStream"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool tinyobj::LoadObjWithCallback(istream &, const struct callback_t &, void *, MaterialReader *, string *, string *)"
-- "exceptions": []
-  "name": "_ZN7tinyobj18MaterialFileReaderclERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEPNS1_6vectorINS_10material_tENS5_ISB_EEEEPNS1_3mapIS7_iNS1_4lessIS7_EENS5_INS1_4pairIS8_iEEEEEEPS7_SN_"
+- "name": "_ZN7tinyobj18MaterialFileReaderclERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEPNS1_6vectorINS_10material_tENS5_ISB_EEEEPNS1_3mapIS7_iNS1_4lessIS7_EENS5_INS1_4pairIS8_iEEEEEEPS7_SN_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/tinyxml2.yaml
+++ b/benchmark-sets/all/tinyxml2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK8tinyxml210XMLElement12ShallowCloneEPNS_11XMLDocumentE"
+- "name": "_ZNK8tinyxml210XMLElement12ShallowCloneEPNS_11XMLDocumentE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "XMLNode * tinyxml2::XMLElement::ShallowClone(XMLDocument *)"
-- "exceptions": []
-  "name": "_ZN8tinyxml210XMLPrinter10VisitEnterERKNS_10XMLElementEPKNS_12XMLAttributeE"
+- "name": "_ZN8tinyxml210XMLPrinter10VisitEnterERKNS_10XMLElementEPKNS_12XMLAttributeE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool tinyxml2::XMLPrinter::VisitEnter(const XMLElement &, const XMLAttribute *)"
-- "exceptions": []
-  "name": "_ZN8tinyxml210XMLElement9ParseDeepEPcPNS_7StrPairEPi"
+- "name": "_ZN8tinyxml210XMLElement9ParseDeepEPcPNS_7StrPairEPi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "char * tinyxml2::XMLElement::ParseDeep(char *, StrPair *, int *)"
-- "exceptions": []
-  "name": "_ZN8tinyxml210XMLElement12SetAttributeEPKcS2_"
+- "name": "_ZN8tinyxml210XMLElement12SetAttributeEPKcS2_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void tinyxml2::XMLElement::SetAttribute(const char *, const char *)"
-- "exceptions": []
-  "name": "_ZN8tinyxml211XMLDocument8LoadFileEPKc"
+- "name": "_ZN8tinyxml211XMLDocument8LoadFileEPKc"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/tmux.yaml
+++ b/benchmark-sets/all/tmux.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "tty_open"
+- "name": "tty_open"
   "params":
   - "name": "tty"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int tty_open(struct tty *, char **)"
-- "exceptions": []
-  "name": "cmd_attach_session"
+- "name": "cmd_attach_session"
   "params":
   - "name": "item"
     "type": "bool "
@@ -29,8 +27,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typecmd_retval cmd_attach_session(struct cmdq_item *, const char *, int, int, int, const char *, int, const char *)"
-- "exceptions": []
-  "name": "client_main"
+- "name": "client_main"
   "params":
   - "name": "base"
     "type": "bool "
@@ -44,8 +41,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int client_main(struct event_base *, int, char **, uint64_t, int)"
-- "exceptions": []
-  "name": "server_start"
+- "name": "server_start"
   "params":
   - "name": "client"
     "type": "bool "
@@ -59,8 +55,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int server_start(struct tmuxproc *, int, struct event_base *, int, char *)"
-- "exceptions": []
-  "name": "server_client_open"
+- "name": "server_client_open"
   "params":
   - "name": "c"
     "type": "bool "

--- a/benchmark-sets/all/tomlplusplus.yaml
+++ b/benchmark-sets/all/tomlplusplus.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4toml2v313source_regionaSERKS1_"
+- "name": "_ZN4toml2v313source_regionaSERKS1_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/tpm2-tss.yaml
+++ b/benchmark-sets/all/tpm2-tss.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "iesys_gen_auths"
+- "name": "iesys_gen_auths"
   "params":
   - "name": "esys_context"
     "type": "bool "
@@ -14,22 +13,19 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TSS2_RC iesys_gen_auths(ESYS_CONTEXT *, RSRC_NODE_T *, RSRC_NODE_T *, RSRC_NODE_T *, TSS2L_SYS_AUTH_COMMAND *)"
-- "exceptions": []
-  "name": "test_esys_checks_pre"
+- "name": "test_esys_checks_pre"
   "params":
   - "name": "test_ctx"
     "type": "bool "
   "return_type": "int"
   "signature": "int test_esys_checks_pre(TSS2_TEST_ESYS_CONTEXT *)"
-- "exceptions": []
-  "name": "test_esys_checks_post"
+- "name": "test_esys_checks_post"
   "params":
   - "name": "test_ctx"
     "type": "bool "
   "return_type": "int"
   "signature": "int test_esys_checks_post(TSS2_TEST_ESYS_CONTEXT *)"
-- "exceptions": []
-  "name": "Tss2_Sys_CreatePrimary"
+- "name": "Tss2_Sys_CreatePrimary"
   "params":
   - "name": "sysContext"
     "type": "bool "
@@ -61,8 +57,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "TSS2_RC Tss2_Sys_CreatePrimary(TSS2_SYS_CONTEXT *, TPMI_RH_HIERARCHY, const TSS2L_SYS_AUTH_COMMAND *, const TPM2B_SENSITIVE_CREATE *, const TPM2B_PUBLIC *, const TPM2B_DATA *, const TPML_PCR_SELECTION *, TPM2_HANDLE *, TPM2B_PUBLIC *, TPM2B_CREATION_DATA *, TPM2B_DIGEST *, TPMT_TK_CREATION *, TPM2B_NAME *, TSS2L_SYS_AUTH_RESPONSE *)"
-- "exceptions": []
-  "name": "Tss2_Sys_Create"
+- "name": "Tss2_Sys_Create"
   "params":
   - "name": "sysContext"
     "type": "bool "

--- a/benchmark-sets/all/tremor.yaml
+++ b/benchmark-sets/all/tremor.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ov_test"
+- "name": "ov_test"
   "params":
   - "name": "f"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ov_test(FILE *, OggVorbis_File *, const char *, long)"
-- "exceptions": []
-  "name": "ov_open"
+- "name": "ov_open"
   "params":
   - "name": "f"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ov_open(FILE *, OggVorbis_File *, const char *, long)"
-- "exceptions": []
-  "name": "ov_time_seek"
+- "name": "ov_time_seek"
   "params":
   - "name": "vf"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ov_time_seek(OggVorbis_File *, ogg_int64_t)"
-- "exceptions": []
-  "name": "ov_pcm_seek"
+- "name": "ov_pcm_seek"
   "params":
   - "name": "vf"
     "type": "bool "
@@ -43,8 +39,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ov_pcm_seek(OggVorbis_File *, ogg_int64_t)"
-- "exceptions": []
-  "name": "ov_test_open"
+- "name": "ov_test_open"
   "params":
   - "name": "vf"
     "type": "bool "

--- a/benchmark-sets/all/unbound.yaml
+++ b/benchmark-sets/all/unbound.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ub_resolve_event"
+- "name": "ub_resolve_event"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -18,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ub_resolve_event(struct ub_ctx *, const char *, int, int, void *, ub_event_callback_type, int *)"
-- "exceptions": []
-  "name": "auth_zones_startprobesequence"
+- "name": "auth_zones_startprobesequence"
   "params":
   - "name": "az"
     "type": "bool "
@@ -33,8 +31,7 @@
     "type": "short"
   "return_type": "int"
   "signature": "int auth_zones_startprobesequence(struct auth_zones *, struct module_env *, uint8_t *, size_t, uint16_t)"
-- "exceptions": []
-  "name": "ub_resolve"
+- "name": "ub_resolve"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -48,8 +45,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ub_resolve(struct ub_ctx *, const char *, int, int, struct ub_result **)"
-- "exceptions": []
-  "name": "ub_resolve_async"
+- "name": "ub_resolve_async"
   "params":
   - "name": "ctx"
     "type": "bool "
@@ -67,8 +63,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ub_resolve_async(struct ub_ctx *, const char *, int, int, void *, ub_callback_type, int *)"
-- "exceptions": []
-  "name": "auth_zones_notify"
+- "name": "auth_zones_notify"
   "params":
   - "name": "az"
     "type": "bool "

--- a/benchmark-sets/all/unicorn.yaml
+++ b/benchmark-sets/all/unicorn.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "decNumberLn"
+- "name": "decNumberLn"
   "params":
   - "name": "res"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "decNumber * decNumberLn(decNumber *, const decNumber *, decContext *)"
-- "exceptions": []
-  "name": "decNumberSquareRoot"
+- "name": "decNumberSquareRoot"
   "params":
   - "name": "res"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "decNumber * decNumberSquareRoot(decNumber *, const decNumber *, decContext *)"
-- "exceptions": []
-  "name": "ppc64_v3_handle_mmu_fault"
+- "name": "ppc64_v3_handle_mmu_fault"
   "params":
   - "name": "cpu"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int ppc64_v3_handle_mmu_fault(PowerPCCPU *, vaddr, int, int)"
-- "exceptions": []
-  "name": "decNumberLog10"
+- "name": "decNumberLog10"
   "params":
   - "name": "res"
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "decNumber * decNumberLog10(decNumber *, const decNumber *, decContext *)"
-- "exceptions": []
-  "name": "decNumberPower"
+- "name": "decNumberPower"
   "params":
   - "name": "res"
     "type": "bool "

--- a/benchmark-sets/all/unit.yaml
+++ b/benchmark-sets/all/unit.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "nxt_runtime_create"
+- "name": "nxt_runtime_create"
   "params":
   - "name": "task"
     "type": "bool "
   "return_type": "int"
   "signature": "nxt_int_t nxt_runtime_create(nxt_task_t *)"
-- "exceptions": []
-  "name": "nxt_process_init_start"
+- "name": "nxt_process_init_start"
   "params":
   - "name": "task"
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "nxt_int_t nxt_process_init_start(nxt_task_t *, nxt_process_init_t)"
-- "exceptions": []
-  "name": "nxt_main_process_start"
+- "name": "nxt_main_process_start"
   "params":
   - "name": "thr"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "nxt_int_t nxt_main_process_start(nxt_thread_t *, nxt_task_t *, nxt_runtime_t *)"
-- "exceptions": []
-  "name": "nxt_process_start"
+- "name": "nxt_process_start"
   "params":
   - "name": "task"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "nxt_int_t nxt_process_start(nxt_task_t *, nxt_process_t *)"
-- "exceptions": []
-  "name": "nxt_http_application_handler"
+- "name": "nxt_http_application_handler"
   "params":
   - "name": "task"
     "type": "bool "

--- a/benchmark-sets/all/unrar.yaml
+++ b/benchmark-sets/all/unrar.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN10MainHeaderD2Ev"
+- "name": "_ZN10MainHeaderD2Ev"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "struct MainHeader & MainHeader::operator=(struct MainHeader *, struct DW_TAG_rvalue_reference_typeMainHeader)"
-- "exceptions": []
-  "name": "_ZN4FileaSERS_"
+- "name": "_ZN4FileaSERS_"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/uriparser.yaml
+++ b/benchmark-sets/all/uriparser.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "uriTestMemoryManager"
+- "name": "uriTestMemoryManager"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "int uriTestMemoryManager(UriMemoryManager *)"
-- "exceptions": []
-  "name": "uriCompleteMemoryManager"
+- "name": "uriCompleteMemoryManager"
   "params":
   - "name": ""
     "type": "bool "
@@ -15,8 +13,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int uriCompleteMemoryManager(UriMemoryManager *, UriMemoryManager *)"
-- "exceptions": []
-  "name": "uriEmulateReallocarray"
+- "name": "uriEmulateReallocarray"
   "params":
   - "name": ""
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void * uriEmulateReallocarray(UriMemoryManager *, void *, size_t, size_t)"
-- "exceptions": []
-  "name": "uriEmulateCalloc"
+- "name": "uriEmulateCalloc"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/usbguard.yaml
+++ b/benchmark-sets/all/usbguard.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8usbguard6Logger5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
+- "name": "_ZN8usbguard6Logger5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void usbguard::Logger::write(const struct Source &, const DW_TAG_enumeration_typeLevel, const string &)"
-- "exceptions": []
-  "name": "_ZN8usbguard11OStreamSink5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
+- "name": "_ZN8usbguard11OStreamSink5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void usbguard::OStreamSink::write(const struct Source &, DW_TAG_enumeration_typeLevel, const string &)"
-- "exceptions": []
-  "name": "_ZN8usbguard13AuditFileSink5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
+- "name": "_ZN8usbguard13AuditFileSink5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void usbguard::AuditFileSink::write(const struct Source &, DW_TAG_enumeration_typeLevel, const string &)"
-- "exceptions": []
-  "name": "_ZN8usbguard10SyslogSink5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
+- "name": "_ZN8usbguard10SyslogSink5writeERKNS_9LogStream6SourceENS1_5LevelERKNSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -51,8 +47,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void usbguard::SyslogSink::write(const struct Source &, DW_TAG_enumeration_typeLevel, const string &)"
-- "exceptions": []
-  "name": "_ZN8usbguard6LoggerclERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEiS9_NS_9LogStream5LevelE"
+- "name": "_ZN8usbguard6LoggerclERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEiS9_NS_9LogStream5LevelE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/usrsctp.yaml
+++ b/benchmark-sets/all/usrsctp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "usrsctp_bindx"
+- "name": "usrsctp_bindx"
   "params":
   - "name": ""
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int usrsctp_bindx(struct socket *, struct sockaddr *, int, int)"
-- "exceptions": []
-  "name": "usrsctp_connectx"
+- "name": "usrsctp_connectx"
   "params":
   - "name": ""
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int usrsctp_connectx(struct socket *, const struct sockaddr *, int, sctp_assoc_t *)"
-- "exceptions": []
-  "name": "usrsctp_init_nothreads"
+- "name": "usrsctp_init_nothreads"
   "params":
   - "name": ""
     "type": "short"
@@ -36,8 +33,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void usrsctp_init_nothreads(uint16_t, DW_TAG_subroutine_typeInfinite loop *, DW_TAG_subroutine_typeInfinite loop *)"
-- "exceptions": []
-  "name": "usrsctp_peeloff"
+- "name": "usrsctp_peeloff"
   "params":
   - "name": ""
     "type": "bool "
@@ -45,8 +41,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "struct socket * usrsctp_peeloff(struct socket *, sctp_assoc_t)"
-- "exceptions": []
-  "name": "usrsctp_shutdown"
+- "name": "usrsctp_shutdown"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/utf8proc.yaml
+++ b/benchmark-sets/all/utf8proc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "utf8proc_decompose"
+- "name": "utf8proc_decompose"
   "params":
   - "name": ""
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "utf8proc_ssize_t utf8proc_decompose(const utf8proc_uint8_t *, utf8proc_ssize_t, utf8proc_int32_t *, utf8proc_ssize_t, utf8proc_option_t)"
-- "exceptions": []
-  "name": "utf8proc_errmsg"
+- "name": "utf8proc_errmsg"
   "params":
   - "name": ""
     "type": "size_t"

--- a/benchmark-sets/all/util-linux.yaml
+++ b/benchmark-sets/all/util-linux.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "mnt_table_parse_fstab"
+- "name": "mnt_table_parse_fstab"
   "params":
   - "name": "tb"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mnt_table_parse_fstab(struct libmnt_table *, const char *)"
-- "exceptions": []
-  "name": "mnt_table_is_fs_mounted"
+- "name": "mnt_table_is_fs_mounted"
   "params":
   - "name": "tb"
     "type": "bool "
@@ -17,15 +15,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int mnt_table_is_fs_mounted(struct libmnt_table *, struct libmnt_fs *)"
-- "exceptions": []
-  "name": "mnt_new_table_from_dir"
+- "name": "mnt_new_table_from_dir"
   "params":
   - "name": "dirname"
     "type": "bool "
   "return_type": "void"
   "signature": "struct libmnt_table * mnt_new_table_from_dir(const char *)"
-- "exceptions": []
-  "name": "__mnt_table_parse_mountinfo"
+- "name": "__mnt_table_parse_mountinfo"
   "params":
   - "name": "tb"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int __mnt_table_parse_mountinfo(struct libmnt_table *, const char *, struct libmnt_table *)"
-- "exceptions": []
-  "name": "mnt_table_parse_mtab"
+- "name": "mnt_table_parse_mtab"
   "params":
   - "name": "tb"
     "type": "bool "

--- a/benchmark-sets/all/uwebsockets.yaml
+++ b/benchmark-sets/all/uwebsockets.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZN3uWS12TemplatedAppILb1EE7publishENSt3__117basic_string_viewIcNS2_11char_traitsIcEEEES6_NS_6OpCodeEbENKUlPNS_10SubscriberERNS_19TopicTreeBigMessageEE_clES9_SB_"
+- "name": "_ZZN3uWS12TemplatedAppILb1EE7publishENSt3__117basic_string_viewIcNS2_11char_traitsIcEEEES6_NS_6OpCodeEbENKUlPNS_10SubscriberERNS_19TopicTreeBigMessageEE_clES9_SB_"
   "params":
   - "name": ""
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void uWS::TemplatedApp<true>::operator()(const void *, struct Subscriber *, struct TopicTreeBigMessage &)"
-- "exceptions": []
-  "name": "_ZZN3uWS9WebSocketILb0ELb1EZ4testvE13PerSocketDataE7publishENSt3__117basic_string_viewIcNS3_11char_traitsIcEEEES7_NS_6OpCodeEbENKUlPNS_10SubscriberERNS_19TopicTreeBigMessageEE_clESA_SC_"
+- "name": "_ZZN3uWS9WebSocketILb0ELb1EZ4testvE13PerSocketDataE7publishENSt3__117basic_string_viewIcNS3_11char_traitsIcEEEES7_NS_6OpCodeEbENKUlPNS_10SubscriberERNS_19TopicTreeBigMessageEE_clESA_SC_"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void uWS::operator()(const void *, struct Subscriber *, struct TopicTreeBigMessage &)"
-- "exceptions": []
-  "name": "us_create_udp_socket"
+- "name": "us_create_udp_socket"
   "params":
   - "name": ""
     "type": "bool "
@@ -38,8 +35,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "struct us_udp_socket_t * us_create_udp_socket(struct us_loop_t *, struct us_udp_packet_buffer_t *, DW_TAG_subroutine_typeInfinite loop *, DW_TAG_subroutine_typeInfinite loop *, const char *, unsigned short, void *)"
-- "exceptions": []
-  "name": "_ZN3uWS12HttpResponseILb1EE16writeUnsignedHexEj"
+- "name": "_ZN3uWS12HttpResponseILb1EE16writeUnsignedHexEj"
   "params":
   - "name": ""
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void uWS::HttpResponse<true>::writeUnsignedHex(struct HttpResponse<false> *, unsigned int)"
-- "exceptions": []
-  "name": "_ZN3uWS4Loop3runEv"
+- "name": "_ZN3uWS4Loop3runEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/valijson.yaml
+++ b/benchmark-sets/all/valijson.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZNK8valijson11constraints15BasicConstraintINS0_14EnumConstraintEE5cloneEPFPvmEPFvS4_E"
+- "name": "_ZNK8valijson11constraints15BasicConstraintINS0_14EnumConstraintEE5cloneEPFPvmEPFvS4_E"
   "params":
   - "name": "this"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "OwningPointer valijson::constraints::BasicConstraint<valijson::constraints::EnumConstraint>::clone(const struct BasicConstraint<valijson::constraints::TypeConstraint> *, CustomAlloc, CustomFree)"
-- "exceptions": []
-  "name": "_ZN8valijson8adapters12BasicAdapterINS0_23GenericRapidJsonAdapterIN9rapidjson12GenericValueINS3_4UTF8IcEENS3_19MemoryPoolAllocatorINS3_12CrtAllocatorEEEEEEENS0_21GenericRapidJsonArrayISA_EENS0_28GenericRapidJsonObjectMemberISA_EENS0_22GenericRapidJsonObjectISA_EENS0_21GenericRapidJsonValueISA_EEE23ObjectComparisonFunctorclERKNSt3__112basic_stringIcNSM_11char_traitsIcEENSM_9allocatorIcEEEERKNS0_7AdapterE"
+- "name": "_ZN8valijson8adapters12BasicAdapterINS0_23GenericRapidJsonAdapterIN9rapidjson12GenericValueINS3_4UTF8IcEENS3_19MemoryPoolAllocatorINS3_12CrtAllocatorEEEEEEENS0_21GenericRapidJsonArrayISA_EENS0_28GenericRapidJsonObjectMemberISA_EENS0_22GenericRapidJsonObjectISA_EENS0_21GenericRapidJsonValueISA_EEE23ObjectComparisonFunctorclERKNSt3__112basic_stringIcNSM_11char_traitsIcEENSM_9allocatorIcEEEERKNS0_7AdapterE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,15 +21,13 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool valijson::adapters::BasicAdapter<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::adapters::GenericRapidJsonArray<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::adapters::GenericRapidJsonObjectMember<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::adapters::GenericRapidJsonObject<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::adapters::GenericRapidJsonValue<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > > >::ObjectComparisonFunctor::operator()(const string &, const Adapter &)"
-- "exceptions": []
-  "name": "_ZNK8valijson8adapters27GenericRapidJsonFrozenValueIN9rapidjson12GenericValueINS2_4UTF8IcEENS2_19MemoryPoolAllocatorINS2_12CrtAllocatorEEEEEE5cloneEv"
+- "name": "_ZNK8valijson8adapters27GenericRapidJsonFrozenValueIN9rapidjson12GenericValueINS2_4UTF8IcEENS2_19MemoryPoolAllocatorINS2_12CrtAllocatorEEEEEE5cloneEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "FrozenValue * valijson::adapters::GenericRapidJsonFrozenValue<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >::clone(const GenericRapidJsonFrozenValue<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > > *)"
-- "exceptions": []
-  "name": "_ZN8valijson8adapters12BasicAdapterINS0_23GenericRapidJsonAdapterIN9rapidjson12GenericValueINS3_4UTF8IcEENS3_19MemoryPoolAllocatorINS3_12CrtAllocatorEEEEEEENS0_21GenericRapidJsonArrayISA_EENS0_28GenericRapidJsonObjectMemberISA_EENS0_22GenericRapidJsonObjectISA_EENS0_21GenericRapidJsonValueISA_EEE22ArrayComparisonFunctorclERKNS0_7AdapterE"
+- "name": "_ZN8valijson8adapters12BasicAdapterINS0_23GenericRapidJsonAdapterIN9rapidjson12GenericValueINS3_4UTF8IcEENS3_19MemoryPoolAllocatorINS3_12CrtAllocatorEEEEEEENS0_21GenericRapidJsonArrayISA_EENS0_28GenericRapidJsonObjectMemberISA_EENS0_22GenericRapidJsonObjectISA_EENS0_21GenericRapidJsonValueISA_EEE22ArrayComparisonFunctorclERKNS0_7AdapterE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/varnish.yaml
+++ b/benchmark-sets/all/varnish.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "WS_VSB_new"
+- "name": "WS_VSB_new"
   "params":
   - "name": "vsb"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void WS_VSB_new(struct vsb *, struct ws *)"
-- "exceptions": []
-  "name": "VSB_quote_pfx"
+- "name": "VSB_quote_pfx"
   "params":
   - "name": "s"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void VSB_quote_pfx(struct vsb *, const char *, const void *, int, int)"
-- "exceptions": []
-  "name": "WS_ReqPipeline"
+- "name": "WS_ReqPipeline"
   "params":
   - "name": "ws"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "unsigned int WS_ReqPipeline(struct ws *, const void *, const void *)"
-- "exceptions": []
-  "name": "VSB_quote"
+- "name": "VSB_quote"
   "params":
   - "name": "s"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void VSB_quote(struct vsb *, const void *, int, int)"
-- "exceptions": []
-  "name": "WS_Panic"
+- "name": "WS_Panic"
   "params":
   - "name": "vsb"
     "type": "bool "

--- a/benchmark-sets/all/vlc.yaml
+++ b/benchmark-sets/all/vlc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ExecuteCommand"
+- "name": "ExecuteCommand"
   "params":
   - "name": "p_vlm"
     "type": "bool "
@@ -10,22 +9,19 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int ExecuteCommand(vlm_t *, const char *, vlm_message_t **)"
-- "exceptions": []
-  "name": "Preparse"
+- "name": "Preparse"
   "params":
   - "name": "data"
     "type": "bool "
   "return_type": "void"
   "signature": "void * Preparse(void *)"
-- "exceptions": []
-  "name": "libvlc_release"
+- "name": "libvlc_release"
   "params":
   - "name": "p_instance"
     "type": "bool "
   "return_type": "void"
   "signature": "void libvlc_release(libvlc_instance_t *)"
-- "exceptions": []
-  "name": "vlm_New"
+- "name": "vlm_New"
   "params":
   - "name": "libvlc"
     "type": "bool "
@@ -33,8 +29,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "vlm_t * vlm_New(libvlc_int_t *, const char *)"
-- "exceptions": []
-  "name": "libvlc_InternalCleanup"
+- "name": "libvlc_InternalCleanup"
   "params":
   - "name": "p_libvlc"
     "type": "bool "

--- a/benchmark-sets/all/vorbis.yaml
+++ b/benchmark-sets/all/vorbis.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ov_pcm_seek_page_lap"
+- "name": "ov_pcm_seek_page_lap"
   "params":
   - "name": "vf"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ov_pcm_seek_page_lap(OggVorbis_File *, ogg_int64_t)"
-- "exceptions": []
-  "name": "ov_pcm_seek_lap"
+- "name": "ov_pcm_seek_lap"
   "params":
   - "name": "vf"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "int ov_pcm_seek_lap(OggVorbis_File *, ogg_int64_t)"
-- "exceptions": []
-  "name": "ov_time_seek_page_lap"
+- "name": "ov_time_seek_page_lap"
   "params":
   - "name": "vf"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "double"
   "return_type": "int"
   "signature": "int ov_time_seek_page_lap(OggVorbis_File *, double)"
-- "exceptions": []
-  "name": "ov_time_seek_lap"
+- "name": "ov_time_seek_lap"
   "params":
   - "name": "vf"
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "double"
   "return_type": "int"
   "signature": "int ov_time_seek_lap(OggVorbis_File *, double)"
-- "exceptions": []
-  "name": "ov_halfrate"
+- "name": "ov_halfrate"
   "params":
   - "name": "vf"
     "type": "bool "

--- a/benchmark-sets/all/vulkan-loader.yaml
+++ b/benchmark-sets/all/vulkan-loader.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "terminator_EnumerateInstanceLayerProperties"
+- "name": "terminator_EnumerateInstanceLayerProperties"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "VkResult terminator_EnumerateInstanceLayerProperties(uint32_t *, VkLayerProperties *)"
-- "exceptions": []
-  "name": "vkEnumerateInstanceVersion"
+- "name": "vkEnumerateInstanceVersion"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "VkResult vkEnumerateInstanceVersion(uint32_t *)"
-- "exceptions": []
-  "name": "terminator_pre_instance_EnumerateInstanceLayerProperties"
+- "name": "terminator_pre_instance_EnumerateInstanceLayerProperties"
   "params":
   - "name": ""
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "VkResult terminator_pre_instance_EnumerateInstanceLayerProperties(const VkEnumerateInstanceLayerPropertiesChain *, uint32_t *, VkLayerProperties *)"
-- "exceptions": []
-  "name": "vkGetDeviceProcAddr"
+- "name": "vkGetDeviceProcAddr"
   "params":
   - "name": ""
     "type": "bool "
@@ -35,8 +31,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "PFN_vkVoidFunction vkGetDeviceProcAddr(VkDevice, const char *)"
-- "exceptions": []
-  "name": "vkEnumerateInstanceLayerProperties"
+- "name": "vkEnumerateInstanceLayerProperties"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/w3m.yaml
+++ b/benchmark-sets/all/w3m.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "Stralign_left"
+- "name": "Stralign_left"
   "params":
   - "name": "s"
     "type": "bool "
@@ -8,15 +7,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "Str Stralign_left(Str, int)"
-- "exceptions": []
-  "name": "Strnew_m_charp"
+- "name": "Strnew_m_charp"
   "params":
   - "name": "p"
     "type": "bool "
   "return_type": "void"
   "signature": "Str Strnew_m_charp(const char *, void)"
-- "exceptions": []
-  "name": "Stralign_center"
+- "name": "Stralign_center"
   "params":
   - "name": "s"
     "type": "bool "
@@ -24,15 +21,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "Str Stralign_center(Str, int)"
-- "exceptions": []
-  "name": "Sprintf"
+- "name": "Sprintf"
   "params":
   - "name": "fmt"
     "type": "bool "
   "return_type": "void"
   "signature": "Str Sprintf(char *, void)"
-- "exceptions": []
-  "name": "Stralign_right"
+- "name": "Stralign_right"
   "params":
   - "name": "s"
     "type": "bool "

--- a/benchmark-sets/all/wabt.yaml
+++ b/benchmark-sets/all/wabt.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4wabt15ParseWastScriptEPNS_9WastLexerEPNSt3__110unique_ptrINS_6ScriptENS2_14default_deleteIS4_EEEEPNS2_6vectorINS_5ErrorENS2_9allocatorISA_EEEEPNS_16WastParseOptionsE"
+- "name": "_ZN4wabt15ParseWastScriptEPNS_9WastLexerEPNSt3__110unique_ptrINS_6ScriptENS2_14default_deleteIS4_EEEEPNS2_6vectorINS_5ErrorENS2_9allocatorISA_EEEEPNS_16WastParseOptionsE"
   "params":
   - "name": "lexer"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "struct Result wabt::ParseWastScript(WastLexer *, unique_ptr<wabt::Script, std::__1::default_delete<wabt::Script> > *, Errors *, struct WastParseOptions *)"
-- "exceptions": []
-  "name": "_ZN4wabt10WastParser16ParseCommandListEPNS_6ScriptEPNSt3__16vectorINS3_10unique_ptrINS_7CommandENS3_14default_deleteIS6_EEEENS3_9allocatorIS9_EEEE"
+- "name": "_ZN4wabt10WastParser16ParseCommandListEPNS_6ScriptEPNSt3__16vectorINS3_10unique_ptrINS_7CommandENS3_14default_deleteIS6_EEEENS3_9allocatorIS9_EEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "struct Result wabt::WastParser::ParseCommandList(struct Script *, CommandPtrVector *)"
-- "exceptions": []
-  "name": "_ZN4wabt10WastParser11ParseScriptEPNSt3__110unique_ptrINS_6ScriptENS1_14default_deleteIS3_EEEE"
+- "name": "_ZN4wabt10WastParser11ParseScriptEPNSt3__110unique_ptrINS_6ScriptENS1_14default_deleteIS3_EEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "struct Result wabt::WastParser::ParseScript(unique_ptr<wabt::Script, std::__1::default_delete<wabt::Script> > *)"
-- "exceptions": []
-  "name": "_ZN4wabt10WastParser22ParseAssertTrapCommandEPNSt3__110unique_ptrINS_7CommandENS1_14default_deleteIS3_EEEE"
+- "name": "_ZN4wabt10WastParser22ParseAssertTrapCommandEPNSt3__110unique_ptrINS_7CommandENS1_14default_deleteIS3_EEEE"
   "params":
   - "name": "this"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "struct Result wabt::WastParser::ParseAssertTrapCommand(CommandPtr *)"
-- "exceptions": []
-  "name": "_ZN4wabt10WastParser12ParseCommandEPNS_6ScriptEPNSt3__110unique_ptrINS_7CommandENS3_14default_deleteIS5_EEEE"
+- "name": "_ZN4wabt10WastParser12ParseCommandEPNS_6ScriptEPNSt3__110unique_ptrINS_7CommandENS3_14default_deleteIS5_EEEE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/wasm3.yaml
+++ b/benchmark-sets/all/wasm3.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "m3_GetFunctionName"
+- "name": "m3_GetFunctionName"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "void"
   "signature": "const char * m3_GetFunctionName(IM3Function)"
-- "exceptions": []
-  "name": "m3_GetMemorySize"
+- "name": "m3_GetMemorySize"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/wget.yaml
+++ b/benchmark-sets/all/wget.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gnutls_record_recv_packet"
+- "name": "gnutls_record_recv_packet"
   "params":
   - "name": "session"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t gnutls_record_recv_packet(gnutls_session_t, gnutls_packet_t *)"
-- "exceptions": []
-  "name": "gnutls_bye"
+- "name": "gnutls_bye"
   "params":
   - "name": "session"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int gnutls_bye(gnutls_session_t, gnutls_close_request_t)"
-- "exceptions": []
-  "name": "gnutls_record_recv_seq"
+- "name": "gnutls_record_recv_seq"
   "params":
   - "name": "session"
     "type": "bool "
@@ -30,8 +27,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t gnutls_record_recv_seq(gnutls_session_t, void *, size_t, unsigned char *)"
-- "exceptions": []
-  "name": "gnutls_record_recv"
+- "name": "gnutls_record_recv"
   "params":
   - "name": "session"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "size_t"
   "return_type": "size_t"
   "signature": "ssize_t gnutls_record_recv(gnutls_session_t, void *, size_t)"
-- "exceptions": []
-  "name": "gnutls_session_get_data"
+- "name": "gnutls_session_get_data"
   "params":
   - "name": "session"
     "type": "bool "

--- a/benchmark-sets/all/wget2.yaml
+++ b/benchmark-sets/all/wget2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "wget_tcp_vprintf"
+- "name": "wget_tcp_vprintf"
   "params":
   - "name": "tcp"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t wget_tcp_vprintf(wget_tcp *, const char *, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "wget_tcp_printf"
+- "name": "wget_tcp_printf"
   "params":
   - "name": "tcp"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t wget_tcp_printf(wget_tcp *, const char *, void)"
-- "exceptions": []
-  "name": "gnutls_record_recv_packet"
+- "name": "gnutls_record_recv_packet"
   "params":
   - "name": "session"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "ssize_t gnutls_record_recv_packet(gnutls_session_t, gnutls_packet_t *)"
-- "exceptions": []
-  "name": "gnutls_session_get_data"
+- "name": "gnutls_session_get_data"
   "params":
   - "name": "session"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int gnutls_session_get_data(gnutls_session_t, void *, size_t *)"
-- "exceptions": []
-  "name": "gnutls_record_recv_seq"
+- "name": "gnutls_record_recv_seq"
   "params":
   - "name": "session"
     "type": "bool "

--- a/benchmark-sets/all/woff2.yaml
+++ b/benchmark-sets/all/woff2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "BrotliDecoderTakeOutput"
+- "name": "BrotliDecoderTakeOutput"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const uint8_t * BrotliDecoderTakeOutput(BrotliDecoderStateInternal *, size_t *)"
-- "exceptions": []
-  "name": "BrotliDecoderCreateInstance"
+- "name": "BrotliDecoderCreateInstance"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "BrotliDecoderState * BrotliDecoderCreateInstance(brotli_alloc_func, brotli_free_func, void *)"
-- "exceptions": []
-  "name": "BrotliDecoderSetParameter"
+- "name": "BrotliDecoderSetParameter"
   "params":
   - "name": ""
     "type": "bool "
@@ -30,15 +27,13 @@
     "type": "int"
   "return_type": "int"
   "signature": "int BrotliDecoderSetParameter(BrotliDecoderStateInternal *, BrotliDecoderParameter, uint32_t)"
-- "exceptions": []
-  "name": "BrotliDecoderIsFinished"
+- "name": "BrotliDecoderIsFinished"
   "params":
   - "name": ""
     "type": "bool "
   "return_type": "int"
   "signature": "int BrotliDecoderIsFinished(const BrotliDecoderStateInternal *)"
-- "exceptions": []
-  "name": "BrotliDecoderHasMoreOutput"
+- "name": "BrotliDecoderHasMoreOutput"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/all/wolfmqtt.yaml
+++ b/benchmark-sets/all/wolfmqtt.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "wolfSSL_CertManagerLoadCA"
+- "name": "wolfSSL_CertManagerLoadCA"
   "params":
   - "name": "cm"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER *, const char *, const char *)"
-- "exceptions": []
-  "name": "MqttClient_Publish_ex"
+- "name": "MqttClient_Publish_ex"
   "params":
   - "name": "client"
     "type": "bool "
@@ -21,22 +19,19 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int MqttClient_Publish_ex(MqttClient *, MqttPublish *, MqttPublishCb)"
-- "exceptions": []
-  "name": "MqttClient_Disconnect"
+- "name": "MqttClient_Disconnect"
   "params":
   - "name": "client"
     "type": "bool "
   "return_type": "int"
   "signature": "int MqttClient_Disconnect(MqttClient *)"
-- "exceptions": []
-  "name": "MqttClient_Ping"
+- "name": "MqttClient_Ping"
   "params":
   - "name": "client"
     "type": "bool "
   "return_type": "int"
   "signature": "int MqttClient_Ping(MqttClient *)"
-- "exceptions": []
-  "name": "MqttClient_Disconnect_ex"
+- "name": "MqttClient_Disconnect_ex"
   "params":
   - "name": "client"
     "type": "bool "

--- a/benchmark-sets/all/wpantund.yaml
+++ b/benchmark-sets/all/wpantund.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN19TunnelIPv6Interface16processNetlinkFDEv"
+- "name": "_ZN19TunnelIPv6Interface16processNetlinkFDEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void TunnelIPv6Interface::processNetlinkFD()"
-- "exceptions": []
-  "name": "_ZN2nl8wpantund17SpinelNCPTaskJoin14vprocess_eventEiP13__va_list_tag"
+- "name": "_ZN2nl8wpantund17SpinelNCPTaskJoin14vprocess_eventEiP13__va_list_tag"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "_ZN2nl8wpantund32SpinelNCPTaskJoinerCommissioning14vprocess_eventEiP13__va_list_tag"
+- "name": "_ZN2nl8wpantund32SpinelNCPTaskJoinerCommissioning14vprocess_eventEiP13__va_list_tag"
   "params":
   - "name": "this"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int nl::wpantund::SpinelNCPTaskJoinerCommissioning::vprocess_event(int, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "_ZN2nl8wpantund17SpinelNCPTaskForm14vprocess_eventEiP13__va_list_tag"
+- "name": "_ZN2nl8wpantund17SpinelNCPTaskForm14vprocess_eventEiP13__va_list_tag"
   "params":
   - "name": "this"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int nl::wpantund::SpinelNCPTaskForm::vprocess_event(int, struct __va_list_tag *)"
-- "exceptions": []
-  "name": "_ZN2nl8wpantund17SpinelNCPTaskScan14vprocess_eventEiP13__va_list_tag"
+- "name": "_ZN2nl8wpantund17SpinelNCPTaskScan14vprocess_eventEiP13__va_list_tag"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/wxwidgets.yaml
+++ b/benchmark-sets/all/wxwidgets.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN16wxFontMapperBase17CharsetToEncodingERK8wxStringb"
+- "name": "_ZN16wxFontMapperBase17CharsetToEncodingERK8wxStringb"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool"
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typewxFontEncoding wxFontMapperBase::CharsetToEncoding(const wxString &, bool)"
-- "exceptions": []
-  "name": "_ZN16wxFontMapperBase31NonInteractiveCharsetToEncodingERK8wxString"
+- "name": "_ZN16wxFontMapperBase31NonInteractiveCharsetToEncodingERK8wxString"
   "params":
   - "name": "this"
     "type": "bool "
@@ -19,15 +17,13 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int wxFontMapperBase::NonInteractiveCharsetToEncoding(const wxString &)"
-- "exceptions": []
-  "name": "_ZN14wxPlatformInfo22InitForCurrentPlatformEv"
+- "name": "_ZN14wxPlatformInfo22InitForCurrentPlatformEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void wxPlatformInfo::InitForCurrentPlatform()"
-- "exceptions": []
-  "name": "_ZN14wxPlatformInfoC2Ev"
+- "name": "_ZN14wxPlatformInfoC2Ev"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/xerces-c.yaml
+++ b/benchmark-sets/all/xerces-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN11xercesc_3_222UnionDatatypeValidator4initEPNS_17DatatypeValidatorEPNS_14RefHashTableOfINS_12KVStringPairENS_12StringHasherEEEPNS_16RefArrayVectorOfIDsEEPNS_13MemoryManagerE"
+- "name": "_ZN11xercesc_3_222UnionDatatypeValidator4initEPNS_17DatatypeValidatorEPNS_14RefHashTableOfINS_12KVStringPairENS_12StringHasherEEEPNS_16RefArrayVectorOfIDsEEPNS_13MemoryManagerE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/xnnpack.yaml
+++ b/benchmark-sets/all/xnnpack.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "xnn_create_convolution2d_nhwc_qd8_f16_qc8w"
+- "name": "xnn_create_convolution2d_nhwc_qd8_f16_qc8w"
   "params":
   - "name": ""
     "type": "int"
@@ -52,8 +51,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typexnn_status xnn_create_convolution2d_nhwc_qd8_f16_qc8w(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, size_t, size_t, size_t, size_t, const float *, const int8_t *, const float *, float, float, uint32_t, xnn_code_cache_t, xnn_weights_cache_t, xnn_operator_t *)"
-- "exceptions": []
-  "name": "xnn_create_fused_convolution2d_nhwc_f32"
+- "name": "xnn_create_fused_convolution2d_nhwc_f32"
   "params":
   - "name": ""
     "type": "int"
@@ -103,8 +101,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typexnn_status xnn_create_fused_convolution2d_nhwc_f32(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, size_t, size_t, size_t, size_t, const float *, const float *, size_t, struct xnn_post_operation *, uint32_t, xnn_code_cache_t, xnn_weights_cache_t, xnn_operator_t *)"
-- "exceptions": []
-  "name": "xnn_create_convolution2d_nhwc_qu8"
+- "name": "xnn_create_convolution2d_nhwc_qu8"
   "params":
   - "name": ""
     "type": "int"
@@ -166,8 +163,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typexnn_status xnn_create_convolution2d_nhwc_qu8(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, size_t, size_t, size_t, size_t, uint8_t, float, uint8_t, float, const uint8_t *, const int32_t *, uint8_t, float, uint8_t, uint8_t, uint32_t, xnn_code_cache_t, xnn_weights_cache_t, xnn_operator_t *)"
-- "exceptions": []
-  "name": "xnn_create_convolution2d_nhwc_qs8_qc8w"
+- "name": "xnn_create_convolution2d_nhwc_qs8_qc8w"
   "params":
   - "name": ""
     "type": "int"
@@ -227,8 +223,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "DW_TAG_enumeration_typexnn_status xnn_create_convolution2d_nhwc_qs8_qc8w(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, size_t, size_t, size_t, size_t, int8_t, float, const float *, const int8_t *, const int32_t *, int8_t, float, int8_t, int8_t, uint32_t, xnn_code_cache_t, xnn_weights_cache_t, xnn_operator_t *)"
-- "exceptions": []
-  "name": "xnn_create_convolution2d_nhwc_f32"
+- "name": "xnn_create_convolution2d_nhwc_f32"
   "params":
   - "name": ""
     "type": "int"

--- a/benchmark-sets/all/xpdf.yaml
+++ b/benchmark-sets/all/xpdf.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3Gfx14opSetExtGStateEP6Objecti"
+- "name": "_ZN3Gfx14opSetExtGStateEP6Objecti"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void Gfx::opSetExtGState(Object *, int)"
-- "exceptions": []
-  "name": "_ZN6PDFDoc12displayPagesEP9OutputDeviiddiiiiPFiPvES2_"
+- "name": "_ZN6PDFDoc12displayPagesEP9OutputDeviiddiiiiPFiPvES2_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -39,8 +37,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void PDFDoc::displayPages(OutputDev *, int, int, double, double, int, GBool, GBool, GBool, DW_TAG_subroutine_typeInfinite loop *, void *)"
-- "exceptions": []
-  "name": "_ZN6PDFDoc16displayPageSliceEP9OutputDeviddiiiiiiiiPFiPvES2_"
+- "name": "_ZN6PDFDoc16displayPageSliceEP9OutputDeviddiiiiiiiiPFiPvES2_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -74,8 +71,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void PDFDoc::displayPageSlice(OutputDev *, int, double, double, int, GBool, GBool, GBool, int, int, int, int, DW_TAG_subroutine_typeInfinite loop *, void *)"
-- "exceptions": []
-  "name": "_ZN15SplashOutputDev8drawCharEP8GfxStateddddddjiPjiiii"
+- "name": "_ZN15SplashOutputDev8drawCharEP8GfxStateddddddjiPjiiii"
   "params":
   - "name": "this"
     "type": "bool "
@@ -109,8 +105,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void SplashOutputDev::drawChar(GfxState *, double, double, double, double, double, double, CharCode, int, Unicode *, int, GBool, GBool, GBool)"
-- "exceptions": []
-  "name": "_ZN15SplashOutputDev12doUpdateFontEP8GfxState"
+- "name": "_ZN15SplashOutputDev12doUpdateFontEP8GfxState"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/xs.yaml
+++ b/benchmark-sets/all/xs.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "fxImportNow"
+- "name": "fxImportNow"
   "params":
   - "name": "the"
     "type": "bool "
   "return_type": "void"
   "signature": "void fxImportNow(txMachine *)"
-- "exceptions": []
-  "name": "fxLoadModulesRejected"
+- "name": "fxLoadModulesRejected"
   "params":
   - "name": "the"
     "type": "bool "
   "return_type": "void"
   "signature": "void fxLoadModulesRejected(txMachine *)"
-- "exceptions": []
-  "name": "fxAwaitImport"
+- "name": "fxAwaitImport"
   "params":
   - "name": "the"
     "type": "bool "
@@ -22,15 +19,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void fxAwaitImport(txMachine *, txBoolean)"
-- "exceptions": []
-  "name": "fxImport"
+- "name": "fxImport"
   "params":
   - "name": "the"
     "type": "bool "
   "return_type": "void"
   "signature": "void fxImport(txMachine *)"
-- "exceptions": []
-  "name": "yaml_emitter_dump"
+- "name": "yaml_emitter_dump"
   "params":
   - "name": "emitter"
     "type": "bool "

--- a/benchmark-sets/all/xvid.yaml
+++ b/benchmark-sets/all/xvid.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "enc_encode"
+- "name": "enc_encode"
   "params":
   - "name": "pEnc"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int enc_encode(Encoder *, xvid_enc_frame_t *, xvid_enc_stats_t *)"
-- "exceptions": []
-  "name": "xvid_encore"
+- "name": "xvid_encore"
   "params":
   - "name": "handle"
     "type": "bool "
@@ -23,8 +21,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int xvid_encore(void *, int, void *, void *)"
-- "exceptions": []
-  "name": "MotionEstimationBVOP"
+- "name": "MotionEstimationBVOP"
   "params":
   - "name": "pParam"
     "type": "bool "
@@ -58,15 +55,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "void MotionEstimationBVOP(const MBParam *, const FRAMEINFO *, const int32_t, const int32_t, const const MACROBLOCK *, const const IMAGE *, const const IMAGE *, const const IMAGE *, const const IMAGE *, const const FRAMEINFO *, const const IMAGE *, const const IMAGE *, const const IMAGE *, const const IMAGE *, const int)"
-- "exceptions": []
-  "name": "MotionEstimateSMP"
+- "name": "MotionEstimateSMP"
   "params":
   - "name": "h"
     "type": "bool "
   "return_type": "void"
   "signature": "void MotionEstimateSMP(SMPData *)"
-- "exceptions": []
-  "name": "SMPMotionEstimationBVOP"
+- "name": "SMPMotionEstimationBVOP"
   "params":
   - "name": "h"
     "type": "bool "

--- a/benchmark-sets/all/xz.yaml
+++ b/benchmark-sets/all/xz.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "lzma_index_buffer_encode"
+- "name": "lzma_index_buffer_encode"
   "params":
   - "name": "i"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "lzma_ret lzma_index_buffer_encode(const lzma_index *, uint8_t *, size_t *, size_t)"
-- "exceptions": []
-  "name": "lzma_block_decoder"
+- "name": "lzma_block_decoder"
   "params":
   - "name": "strm"
     "type": "bool "
@@ -21,8 +19,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "lzma_ret lzma_block_decoder(lzma_stream *, lzma_block *)"
-- "exceptions": []
-  "name": "lzma_lzma_encoder_init"
+- "name": "lzma_lzma_encoder_init"
   "params":
   - "name": "next"
     "type": "bool "
@@ -32,8 +29,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "lzma_ret lzma_lzma_encoder_init(lzma_next_coder *, const lzma_allocator *, const lzma_filter_info *)"
-- "exceptions": []
-  "name": "lzma_raw_decoder"
+- "name": "lzma_raw_decoder"
   "params":
   - "name": "strm"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "lzma_ret lzma_raw_decoder(lzma_stream *, const lzma_filter *)"
-- "exceptions": []
-  "name": "lzma_block_encoder"
+- "name": "lzma_block_encoder"
   "params":
   - "name": "strm"
     "type": "bool "

--- a/benchmark-sets/all/yajl-ruby.yaml
+++ b/benchmark-sets/all/yajl-ruby.yaml
@@ -1,20 +1,17 @@
 "functions":
-- "exceptions": []
-  "name": "yajl_tok_name"
+- "name": "yajl_tok_name"
   "params":
   - "name": "tok"
     "type": "int"
   "return_type": "void"
   "signature": "const char * yajl_tok_name(yajl_tok)"
-- "exceptions": []
-  "name": "yajl_parse_complete"
+- "name": "yajl_parse_complete"
   "params":
   - "name": "hand"
     "type": "bool "
   "return_type": "int"
   "signature": "yajl_status yajl_parse_complete(yajl_handle)"
-- "exceptions": []
-  "name": "yajl_get_error"
+- "name": "yajl_get_error"
   "params":
   - "name": "hand"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "unsigned char * yajl_get_error(yajl_handle, int, const unsigned char *, unsigned int)"
-- "exceptions": []
-  "name": "yajl_lex_peek"
+- "name": "yajl_lex_peek"
   "params":
   - "name": "lexer"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "yajl_tok yajl_lex_peek(yajl_lexer, const unsigned char *, unsigned int, unsigned int)"
-- "exceptions": []
-  "name": "yajl_render_error_string"
+- "name": "yajl_render_error_string"
   "params":
   - "name": "hand"
     "type": "bool "

--- a/benchmark-sets/all/yara.yaml
+++ b/benchmark-sets/all/yara.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "yr_compiler_add_fd"
+- "name": "yr_compiler_add_fd"
   "params":
   - "name": "compiler"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int yr_compiler_add_fd(YR_COMPILER *, int, const char *, const char *)"
-- "exceptions": []
-  "name": "yr_compiler_add_bytes"
+- "name": "yr_compiler_add_bytes"
   "params":
   - "name": "compiler"
     "type": "bool "
@@ -25,8 +23,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int yr_compiler_add_bytes(YR_COMPILER *, const void *, size_t, const char *)"
-- "exceptions": []
-  "name": "yr_lex_parse_rules_file"
+- "name": "yr_lex_parse_rules_file"
   "params":
   - "name": "rules_file"
     "type": "bool "
@@ -34,8 +31,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int yr_lex_parse_rules_file(FILE *, YR_COMPILER *)"
-- "exceptions": []
-  "name": "yr_compiler_add_file"
+- "name": "yr_compiler_add_file"
   "params":
   - "name": "compiler"
     "type": "bool "
@@ -47,8 +43,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int yr_compiler_add_file(YR_COMPILER *, FILE *, const char *, const char *)"
-- "exceptions": []
-  "name": "yr_lex_parse_rules_fd"
+- "name": "yr_lex_parse_rules_fd"
   "params":
   - "name": "rules_fd"
     "type": "int"

--- a/benchmark-sets/all/zlib.yaml
+++ b/benchmark-sets/all/zlib.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "gzputs"
+- "name": "gzputs"
   "params":
   - "name": "file"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int gzputs(gzFile, const char *)"
-- "exceptions": []
-  "name": "gzprintf"
+- "name": "gzprintf"
   "params":
   - "name": "file"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int gzprintf(gzFile, const char *, void)"
-- "exceptions": []
-  "name": "gzputc"
+- "name": "gzputc"
   "params":
   - "name": "file"
     "type": "bool "
@@ -26,8 +23,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int gzputc(gzFile, int)"
-- "exceptions": []
-  "name": "gzfwrite"
+- "name": "gzfwrite"
   "params":
   - "name": "buf"
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "z_size_t gzfwrite(voidpc, z_size_t, z_size_t, gzFile)"
-- "exceptions": []
-  "name": "gzsetparams"
+- "name": "gzsetparams"
   "params":
   - "name": "file"
     "type": "bool "

--- a/benchmark-sets/all/znc.yaml
+++ b/benchmark-sets/all/znc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN7CClient11UserCommandER7CString"
+- "name": "_ZN7CClient11UserCommandER7CString"
   "params":
   - "name": "this"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "void CClient::UserCommand(CString &)"
-- "exceptions": []
-  "name": "_ZN4CZNC11ParseConfigERK7CStringRS0_"
+- "name": "_ZN4CZNC11ParseConfigERK7CStringRS0_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool CZNC::ParseConfig(const CString &, CString &)"
-- "exceptions": []
-  "name": "_ZN7CClient13OnTextMessageER12CTextMessage"
+- "name": "_ZN7CClient13OnTextMessageER12CTextMessage"
   "params":
   - "name": "this"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool CClient::OnTextMessage(CTextMessage &)"
-- "exceptions": []
-  "name": "_ZN7CClient14OnOtherMessageER8CMessage"
+- "name": "_ZN7CClient14OnOtherMessageER8CMessage"
   "params":
   - "name": "this"
     "type": "bool "
@@ -37,8 +33,7 @@
     "type": "bool "
   "return_type": "bool"
   "signature": "bool CClient::OnOtherMessage(CMessage &)"
-- "exceptions": []
-  "name": "_ZN7CClient8ReadLineERK7CString"
+- "name": "_ZN7CClient8ReadLineERK7CString"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/all/zstd.yaml
+++ b/benchmark-sets/all/zstd.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ZDICT_trainFromBuffer"
+- "name": "ZDICT_trainFromBuffer"
   "params":
   - "name": "dictBuffer"
     "type": "bool "
@@ -14,8 +13,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "size_t ZDICT_trainFromBuffer(void *, size_t, const void *, const size_t *, unsigned int)"
-- "exceptions": []
-  "name": "ZDICT_optimizeTrainFromBuffer_cover"
+- "name": "ZDICT_optimizeTrainFromBuffer_cover"
   "params":
   - "name": "dictBuffer"
     "type": "bool "
@@ -31,8 +29,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t ZDICT_optimizeTrainFromBuffer_cover(void *, size_t, const void *, const size_t *, unsigned int, ZDICT_cover_params_t *)"
-- "exceptions": []
-  "name": "ZDICT_optimizeTrainFromBuffer_fastCover"
+- "name": "ZDICT_optimizeTrainFromBuffer_fastCover"
   "params":
   - "name": "dictBuffer"
     "type": "bool "
@@ -48,8 +45,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t ZDICT_optimizeTrainFromBuffer_fastCover(void *, size_t, const void *, const size_t *, unsigned int, ZDICT_fastCover_params_t *)"
-- "exceptions": []
-  "name": "ZSTD_flushStream"
+- "name": "ZSTD_flushStream"
   "params":
   - "name": "zcs"
     "type": "bool "
@@ -57,8 +53,7 @@
     "type": "bool "
   "return_type": "size_t"
   "signature": "size_t ZSTD_flushStream(ZSTD_CStream *, ZSTD_outBuffer *)"
-- "exceptions": []
-  "name": "ZDICT_trainFromBuffer_legacy"
+- "name": "ZDICT_trainFromBuffer_legacy"
   "params":
   - "name": "dictBuffer"
     "type": "bool "

--- a/benchmark-sets/all/zydis.yaml
+++ b/benchmark-sets/all/zydis.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ZydisFormatterBufferRestore"
+- "name": "ZydisFormatterBufferRestore"
   "params":
   - "name": ""
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "ZyanStatus ZydisFormatterBufferRestore(ZydisFormatterBuffer *, ZyanUPointer)"
-- "exceptions": []
-  "name": "ZydisFormatterBasePrintPrefixes"
+- "name": "ZydisFormatterBasePrintPrefixes"
   "params":
   - "name": ""
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "ZyanStatus ZydisFormatterBasePrintPrefixes(const ZydisFormatter *, ZydisFormatterBuffer *, ZydisFormatterContext *)"
-- "exceptions": []
-  "name": "ZydisEncoderNopFill"
+- "name": "ZydisEncoderNopFill"
   "params":
   - "name": ""
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "size_t"
   "return_type": "int"
   "signature": "ZyanStatus ZydisEncoderNopFill(void *, ZyanUSize)"
-- "exceptions": []
-  "name": "ZydisFormatterSetHook"
+- "name": "ZydisFormatterSetHook"
   "params":
   - "name": ""
     "type": "bool "
@@ -39,8 +35,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "ZyanStatus ZydisFormatterSetHook(ZydisFormatter *, ZydisFormatterFunction, const void **)"
-- "exceptions": []
-  "name": "ZydisFormatterBufferGetString"
+- "name": "ZydisFormatterBufferGetString"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/comparison/abseil-cpp.yaml
+++ b/benchmark-sets/comparison/abseil-cpp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_115BinaryToDecimal13RunConversionENS_7uint128EiNS_11FunctionRefIFvS2_EEEENKUlNS_4SpanIjEEE_clES8_"
+- "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_115BinaryToDecimal13RunConversionENS_7uint128EiNS_11FunctionRefIFvS2_EEEENKUlNS_4SpanIjEEE_clES8_"
   "params":
   - "name": "this"
     "type": "bool "
@@ -10,8 +9,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "void absl::str_format_internal::(anonymous namespace)::BinaryToDecimal::operator()(const void *, Span<unsigned int>)"
-- "exceptions": []
-  "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_122FormatFNegativeExpSlowENS_7uint128EiRKNS1_11FormatStateEENK3$_0clENS1_24FractionalDigitGeneratorE"
+- "name": "_ZZN4absl19str_format_internal12_GLOBAL__N_122FormatFNegativeExpSlowENS_7uint128EiRKNS1_11FormatStateEENK3$_0clENS1_24FractionalDigitGeneratorE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/comparison/ada-url.yaml
+++ b/benchmark-sets/comparison/ada-url.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "ada_can_parse_with_base"
+- "name": "ada_can_parse_with_base"
   "params":
   - "name": "input"
     "type": "bool "

--- a/benchmark-sets/comparison/bluez.yaml
+++ b/benchmark-sets/comparison/bluez.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "g_obex_new"
+- "name": "g_obex_new"
   "params":
   - "name": "io"
     "type": "bool "
@@ -12,8 +11,7 @@
     "type": "size_t"
   "return_type": "void"
   "signature": "GObex * g_obex_new(GIOChannel *, GObexTransportType, gssize, gssize)"
-- "exceptions": []
-  "name": "g_obex_get_req"
+- "name": "g_obex_get_req"
   "params":
   - "name": "obex"
     "type": "bool "

--- a/benchmark-sets/comparison/brpc.yaml
+++ b/benchmark-sets/comparison/brpc.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN4brpc6policy15DiscoveryClient10DoRegisterEv"
+- "name": "_ZN4brpc6policy15DiscoveryClient10DoRegisterEv"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/comparison/hoextdown.yaml
+++ b/benchmark-sets/comparison/hoextdown.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "hoedown_document_render_inline"
+- "name": "hoedown_document_render_inline"
   "params":
   - "name": "doc"
     "type": "bool "

--- a/benchmark-sets/comparison/hostap.yaml
+++ b/benchmark-sets/comparison/hostap.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "wpa_supplicant_add_iface"
+- "name": "wpa_supplicant_add_iface"
   "params":
   - "name": "global"
     "type": "bool "

--- a/benchmark-sets/comparison/ibmswtpm2.yaml
+++ b/benchmark-sets/comparison/ibmswtpm2.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "TPM2_Create"
+- "name": "TPM2_Create"
   "params":
   - "name": "in"
     "type": "bool "

--- a/benchmark-sets/comparison/igraph.yaml
+++ b/benchmark-sets/comparison/igraph.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "igraph_sparsemat_arpack_rssolve"
+- "name": "igraph_sparsemat_arpack_rssolve"
   "params":
   - "name": "A"
     "type": "bool "

--- a/benchmark-sets/comparison/krb5.yaml
+++ b/benchmark-sets/comparison/krb5.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "krb5_gss_store_cred"
+- "name": "krb5_gss_store_cred"
   "params":
   - "name": "minor_status"
     "type": "bool "

--- a/benchmark-sets/comparison/libfuse.yaml
+++ b/benchmark-sets/comparison/libfuse.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "af_gb_alloc_data"
+- "name": "af_gb_alloc_data"
   "params":
   - "name": "len"
     "type": "size_t"

--- a/benchmark-sets/comparison/liblouis.yaml
+++ b/benchmark-sets/comparison/liblouis.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "lou_getTypeformForEmphClass"
+- "name": "lou_getTypeformForEmphClass"
   "params":
   - "name": "tableList"
     "type": "bool "

--- a/benchmark-sets/comparison/libraw.yaml
+++ b/benchmark-sets/comparison/libraw.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN6LibRaw14selectCRXTrackEv"
+- "name": "_ZN6LibRaw14selectCRXTrackEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "void"
   "signature": "void LibRaw::selectCRXTrack()"
-- "exceptions": []
-  "name": "_ZN6LibRaw17crxLoadDecodeLoopEPvi"
+- "name": "_ZN6LibRaw17crxLoadDecodeLoopEPvi"
   "params":
   - "name": "this"
     "type": "bool "
@@ -17,8 +15,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "void LibRaw::crxLoadDecodeLoop(void *, int)"
-- "exceptions": []
-  "name": "_ZN6LibRaw13parseCR3_CTMDEs"
+- "name": "_ZN6LibRaw13parseCR3_CTMDEs"
   "params":
   - "name": "this"
     "type": "bool "
@@ -26,15 +23,13 @@
     "type": "short"
   "return_type": "int"
   "signature": "int LibRaw::parseCR3_CTMD(short)"
-- "exceptions": []
-  "name": "_ZN6LibRaw13sraw_midpointEv"
+- "name": "_ZN6LibRaw13sraw_midpointEv"
   "params":
   - "name": "this"
     "type": "bool "
   "return_type": "int"
   "signature": "int LibRaw::sraw_midpoint()"
-- "exceptions": []
-  "name": "_ZN6LibRaw14crxDecodePlaneEPvj"
+- "name": "_ZN6LibRaw14crxDecodePlaneEPvj"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/comparison/libsndfile.yaml
+++ b/benchmark-sets/comparison/libsndfile.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "sf_open"
+- "name": "sf_open"
   "params":
   - "name": "path"
     "type": "bool "

--- a/benchmark-sets/comparison/libsodium.yaml
+++ b/benchmark-sets/comparison/libsodium.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "argon2_finalize"
+- "name": "argon2_finalize"
   "params":
   - "name": "context"
     "type": "bool "

--- a/benchmark-sets/comparison/mosh.yaml
+++ b/benchmark-sets/comparison/mosh.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8Terminal11Framebuffer6resizeEii"
+- "name": "_ZN8Terminal11Framebuffer6resizeEii"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/comparison/opendnp3.yaml
+++ b/benchmark-sets/comparison/opendnp3.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN8opendnp320FreezeRequestHandler13ProcessHeaderERKNS_11RangeHeaderE"
+- "name": "_ZN8opendnp320FreezeRequestHandler13ProcessHeaderERKNS_11RangeHeaderE"
   "params":
   - "name": "this"
     "type": "bool "

--- a/benchmark-sets/comparison/protobuf-c.yaml
+++ b/benchmark-sets/comparison/protobuf-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "protobuf_c_buffer_simple_append"
+- "name": "protobuf_c_buffer_simple_append"
   "params":
   - "name": "buffer"
     "type": "bool "

--- a/benchmark-sets/comparison/quickjs.yaml
+++ b/benchmark-sets/comparison/quickjs.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "JS_ParseJSON2"
+- "name": "JS_ParseJSON2"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/comparison/rabbitmq-c.yaml
+++ b/benchmark-sets/comparison/rabbitmq-c.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "amqp_tx_rollback"
+- "name": "amqp_tx_rollback"
   "params":
   - "name": "state"
     "type": "bool "

--- a/benchmark-sets/comparison/resiprocate.yaml
+++ b/benchmark-sets/comparison/resiprocate.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN5resip11SdpContentsaSERKS0_"
+- "name": "_ZN5resip11SdpContentsaSERKS0_"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/comparison/rnp.yaml
+++ b/benchmark-sets/comparison/rnp.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "_ZN3rnp8KeyStore16import_signatureER9pgp_key_tRK15pgp_signature_t"
+- "name": "_ZN3rnp8KeyStore16import_signatureER9pgp_key_tRK15pgp_signature_t"
   "params":
   - "name": ""
     "type": "bool "

--- a/benchmark-sets/comparison/stb.yaml
+++ b/benchmark-sets/comparison/stb.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "stbi_is_16_bit_from_file"
+- "name": "stbi_is_16_bit_from_file"
   "params":
   - "name": "f"
     "type": "bool "

--- a/benchmark-sets/comparison/tmux.yaml
+++ b/benchmark-sets/comparison/tmux.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "cmd_attach_session"
+- "name": "cmd_attach_session"
   "params":
   - "name": "item"
     "type": "bool "

--- a/benchmark-sets/comparison/util-linux.yaml
+++ b/benchmark-sets/comparison/util-linux.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "mnt_new_table_from_dir"
+- "name": "mnt_new_table_from_dir"
   "params":
   - "name": "dirname"
     "type": "bool "
   "return_type": "void"
   "signature": "struct libmnt_table * mnt_new_table_from_dir(const char *)"
-- "exceptions": []
-  "name": "__mnt_table_parse_mountinfo"
+- "name": "__mnt_table_parse_mountinfo"
   "params":
   - "name": "tb"
     "type": "bool "

--- a/benchmark-sets/comparison/xs.yaml
+++ b/benchmark-sets/comparison/xs.yaml
@@ -1,13 +1,11 @@
 "functions":
-- "exceptions": []
-  "name": "fxLoadModulesRejected"
+- "name": "fxLoadModulesRejected"
   "params":
   - "name": "the"
     "type": "bool "
   "return_type": "void"
   "signature": "void fxLoadModulesRejected(txMachine *)"
-- "exceptions": []
-  "name": "fxAwaitImport"
+- "name": "fxAwaitImport"
   "params":
   - "name": "the"
     "type": "bool "

--- a/benchmark-sets/from-test-small/krb5.yaml
+++ b/benchmark-sets/from-test-small/krb5.yaml
@@ -1,4 +1,4 @@
-"is_test_benchmark": true
+"is_test_benchmark": !!bool "true"
 "language": "c"
 "project": "krb5"
 "target_name": "fuzz_gss"

--- a/benchmark-sets/from-test-small/liblouis.yaml
+++ b/benchmark-sets/from-test-small/liblouis.yaml
@@ -1,4 +1,4 @@
-"is_test_benchmark": true
+"is_test_benchmark": !!bool "true"
 "language": "c"
 "project": "liblouis"
 "target_name": "fuzz_translate_generic"

--- a/benchmark-sets/from-test-small/libraw.yaml
+++ b/benchmark-sets/from-test-small/libraw.yaml
@@ -1,4 +1,4 @@
-"is_test_benchmark": true
+"is_test_benchmark": !!bool "true"
 "language": "c++"
 "project": "libraw"
 "target_name": "libraw_fuzzer"

--- a/benchmark-sets/from-test-small/libsodium.yaml
+++ b/benchmark-sets/from-test-small/libsodium.yaml
@@ -1,4 +1,4 @@
-"is_test_benchmark": true
+"is_test_benchmark": !!bool "true"
 "language": "c++"
 "project": "libsodium"
 "target_name": "secretbox_easy_fuzzer"

--- a/benchmark-sets/jvm-all/antlr3-java.yaml
+++ b/benchmark-sets/jvm-all/antlr3-java.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.antlr.tool.Interpreter].scan(java.lang.String,org.antlr.runtime.debug.DebugEventListener,java.util.List<NFAState>)"
+- "name": "[org.antlr.tool.Interpreter].scan(java.lang.String,org.antlr.runtime.debug.DebugEventListener,java.util.List<NFAState>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -12,27 +9,19 @@
     "type": "java.util.List<NFAState>"
   "return_type": "void"
   "signature": "[org.antlr.tool.Interpreter].scan(java.lang.String,org.antlr.runtime.debug.DebugEventListener,java.util.List<NFAState>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.antlr.tool.Grammar].createLookaheadDFAs(boolean)"
+- "name": "[org.antlr.tool.Grammar].createLookaheadDFAs(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "void"
   "signature": "[org.antlr.tool.Grammar].createLookaheadDFAs(boolean)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.antlr.grammar.v3.TreeToNFAConverter].setElement(org.antlr.misc.IntSet)"
+- "name": "[org.antlr.grammar.v3.TreeToNFAConverter].setElement(org.antlr.misc.IntSet)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.misc.IntSet"
   "return_type": "void"
   "signature": "[org.antlr.grammar.v3.TreeToNFAConverter].setElement(org.antlr.misc.IntSet)"
-- "exceptions":
-  - "org.antlr.runtime.NoViableAltException"
-  "is_jvm_static": false
-  "name": "[org.antlr.grammar.v3.ANTLRv3Lexer$DFA2].specialStateTransition(int,org.antlr.runtime.IntStream)"
+- "name": "[org.antlr.grammar.v3.ANTLRv3Lexer$DFA2].specialStateTransition(int,org.antlr.runtime.IntStream)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -40,10 +29,7 @@
     "type": "org.antlr.runtime.IntStream"
   "return_type": "int"
   "signature": "[org.antlr.grammar.v3.ANTLRv3Lexer$DFA2].specialStateTransition(int,org.antlr.runtime.IntStream)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.antlr.tool.Grammar].getSetFromRule(org.antlr.grammar.v3.TreeToNFAConverter,java.lang.String)"
+- "name": "[org.antlr.tool.Grammar].getSetFromRule(org.antlr.grammar.v3.TreeToNFAConverter,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.grammar.v3.TreeToNFAConverter"
@@ -51,10 +37,7 @@
     "type": "java.lang.String"
   "return_type": "org.antlr.misc.IntSet"
   "signature": "[org.antlr.tool.Grammar].getSetFromRule(org.antlr.grammar.v3.TreeToNFAConverter,java.lang.String)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.antlr.grammar.v3.TreeToNFAConverter].setRule(org.antlr.tool.GrammarAST)"
+- "name": "[org.antlr.grammar.v3.TreeToNFAConverter].setRule(org.antlr.tool.GrammarAST)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.tool.GrammarAST"

--- a/benchmark-sets/jvm-all/antlr4-java.yaml
+++ b/benchmark-sets/jvm-all/antlr4-java.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.antlr.v4.analysis.LeftRecursiveRuleTransformer].translateLeftRecursiveRule(org.antlr.v4.tool.ast.GrammarRootAST,org.antlr.v4.tool.LeftRecursiveRule,java.lang.String)"
+- "name": "[org.antlr.v4.analysis.LeftRecursiveRuleTransformer].translateLeftRecursiveRule(org.antlr.v4.tool.ast.GrammarRootAST,org.antlr.v4.tool.LeftRecursiveRule,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.v4.tool.ast.GrammarRootAST"
@@ -11,27 +9,19 @@
     "type": "java.lang.String"
   "return_type": "boolean"
   "signature": "[org.antlr.v4.analysis.LeftRecursiveRuleTransformer].translateLeftRecursiveRule(org.antlr.v4.tool.ast.GrammarRootAST,org.antlr.v4.tool.LeftRecursiveRule,java.lang.String)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.antlr.v4.parse.ATNBuilder].ruleBlock(org.antlr.v4.tool.ast.GrammarAST)"
+- "name": "[org.antlr.v4.parse.ATNBuilder].ruleBlock(org.antlr.v4.tool.ast.GrammarAST)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.v4.tool.ast.GrammarAST"
   "return_type": "org.antlr.v4.automata.ATNFactory$Handle"
   "signature": "[org.antlr.v4.parse.ATNBuilder].ruleBlock(org.antlr.v4.tool.ast.GrammarAST)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.antlr.v4.parse.ATNBuilder].block(org.antlr.v4.tool.ast.GrammarAST)"
+- "name": "[org.antlr.v4.parse.ATNBuilder].block(org.antlr.v4.tool.ast.GrammarAST)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.v4.tool.ast.GrammarAST"
   "return_type": "org.antlr.v4.automata.ATNFactory$Handle"
   "signature": "[org.antlr.v4.parse.ATNBuilder].block(org.antlr.v4.tool.ast.GrammarAST)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.antlr.v4.analysis.LeftRecursiveRuleTransformer].parseArtificialRule(org.antlr.v4.tool.Grammar,java.lang.String)"
+- "name": "[org.antlr.v4.analysis.LeftRecursiveRuleTransformer].parseArtificialRule(org.antlr.v4.tool.Grammar,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.v4.tool.Grammar"
@@ -39,17 +29,13 @@
     "type": "java.lang.String"
   "return_type": "org.antlr.v4.tool.ast.RuleAST"
   "signature": "[org.antlr.v4.analysis.LeftRecursiveRuleTransformer].parseArtificialRule(org.antlr.v4.tool.Grammar,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.antlr.v4.codegen.model.RuleFunction].getDeclsForAllElements(java.util.List<AltAST>)"
+- "name": "[org.antlr.v4.codegen.model.RuleFunction].getDeclsForAllElements(java.util.List<AltAST>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<AltAST>"
   "return_type": "java.util.Set<Decl>"
   "signature": "[org.antlr.v4.codegen.model.RuleFunction].getDeclsForAllElements(java.util.List<AltAST>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.antlr.v4.codegen.CodeGenerator].generateParser(boolean)"
+- "name": "[org.antlr.v4.codegen.CodeGenerator].generateParser(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"

--- a/benchmark-sets/jvm-all/apache-commons-bcel.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-bcel.yaml
@@ -1,48 +1,35 @@
 "functions":
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.bcel.classfile.ConstantPool].constantToString(org.apache.bcel.classfile.Constant)"
+- "name": "[org.apache.bcel.classfile.ConstantPool].constantToString(org.apache.bcel.classfile.Constant)"
   "params":
   - "name": "arg0"
     "type": "org.apache.bcel.classfile.Constant"
   "return_type": "java.lang.String"
   "signature": "[org.apache.bcel.classfile.ConstantPool].constantToString(org.apache.bcel.classfile.Constant)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.bcel.classfile.JavaClass].equals(java.lang.Object)"
+- "name": "[org.apache.bcel.classfile.JavaClass].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[org.apache.bcel.classfile.JavaClass].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.bcel.classfile.Field].equals(java.lang.Object)"
+- "name": "[org.apache.bcel.classfile.Field].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[org.apache.bcel.classfile.Field].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.bcel.generic.FieldGen].equals(java.lang.Object)"
+- "name": "[org.apache.bcel.generic.FieldGen].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[org.apache.bcel.generic.FieldGen].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.bcel.generic.MethodGen].equals(java.lang.Object)"
+- "name": "[org.apache.bcel.generic.MethodGen].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[org.apache.bcel.generic.MethodGen].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.bcel.generic.ClassGen].equals(java.lang.Object)"
+- "name": "[org.apache.bcel.generic.ClassGen].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/apache-commons-cli.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-cli.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String,boolean,java.lang.String)"
+- "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String,boolean,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -14,10 +11,7 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.cli.Option"
   "signature": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String,boolean,java.lang.String)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,boolean,java.lang.String)"
+- "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,boolean,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -27,10 +21,7 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.cli.Option"
   "signature": "[org.apache.commons.cli.Option].<init>(java.lang.String,boolean,java.lang.String)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String)"
+- "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -38,33 +29,25 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.cli.Option"
   "signature": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.TypeHandler].<init>(java.util.Map)"
+- "name": "[org.apache.commons.cli.TypeHandler].<init>(java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "Map"
   "return_type": "org.apache.commons.cli.TypeHandler"
   "signature": "[org.apache.commons.cli.TypeHandler].<init>(java.util.Map)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.DefaultParser].<init>(boolean)"
+- "name": "[org.apache.commons.cli.DefaultParser].<init>(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "org.apache.commons.cli.DefaultParser"
   "signature": "[org.apache.commons.cli.DefaultParser].<init>(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.CommandLine].hasOption(java.lang.String)"
+- "name": "[org.apache.commons.cli.CommandLine].hasOption(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "boolean"
   "signature": "[org.apache.commons.cli.CommandLine].hasOption(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.DefaultParser].parse(org.apache.commons.cli.Options,java.lang.String[],java.util.Properties)"
+- "name": "[org.apache.commons.cli.DefaultParser].parse(org.apache.commons.cli.Options,java.lang.String[],java.util.Properties)"
   "params":
   - "name": "arg0"
     "type": "g.apache.commons.cli.Options"

--- a/benchmark-sets/jvm-all/apache-commons-codec.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-codec.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.language.bm.Rule].<init>(java.lang.String,java.lang.String,java.lang.String,org.apache.commons.codec.language.bm.Rule$PhonemeExpr)"
+- "name": "[org.apache.commons.codec.language.bm.Rule].<init>(java.lang.String,java.lang.String,java.lang.String,org.apache.commons.codec.language.bm.Rule$PhonemeExpr)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -13,9 +11,7 @@
     "type": "org.apache.commons.codec.language.bm.Rule$PhonemeExpr"
   "return_type": "org.apache.commons.codec.language.bm.Rule"
   "signature": "[org.apache.commons.codec.language.bm.Rule].<init>(java.lang.String,java.lang.String,java.lang.String,org.apache.commons.codec.language.bm.Rule$PhonemeExpr)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean,org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean,org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -27,9 +23,7 @@
     "type": "org.apache.commons.codec.CodecPolicy"
   "return_type": "org.apache.commons.codec.binary.Base64"
   "signature": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean,org.apache.commons.codec.CodecPolicy)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean)"
+- "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -39,9 +33,7 @@
     "type": "boolean"
   "return_type": "org.apache.commons.codec.binary.Base64"
   "signature": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base32].<init>(int,byte[],boolean,byte,org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base32].<init>(int,byte[],boolean,byte,org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -55,9 +47,7 @@
     "type": "org.apache.commons.codec.CodecPolicy"
   "return_type": "org.apache.commons.codec.binary.Base32"
   "signature": "[org.apache.commons.codec.binary.Base32].<init>(int,byte[],boolean,byte,org.apache.commons.codec.CodecPolicy)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base32InputStream].<init>(java.io.InputStream,boolean,int,byte[],org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base32InputStream].<init>(java.io.InputStream,boolean,int,byte[],org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -71,9 +61,7 @@
     "type": "org.apache.commons.codec.CodecPolicy"
   "return_type": "org.apache.commons.codec.binary.Base32InputStream"
   "signature": "[org.apache.commons.codec.binary.Base32InputStream].<init>(java.io.InputStream,boolean,int,byte[],org.apache.commons.codec.CodecPolicy)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base16InputStream].<init>(java.io.InputStream,boolean,boolean,org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base16InputStream].<init>(java.io.InputStream,boolean,boolean,org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"

--- a/benchmark-sets/jvm-all/apache-commons-collections.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-collections.yaml
@@ -1,39 +1,29 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BitMapExtractor)"
+- "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BitMapExtractor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections4.bloomfilter.BitMapExtractor"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BitMapExtractor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.collection.IndexedCollection].removeIf(java.util.function.Predicate<? super C>)"
+- "name": "[org.apache.commons.collections4.collection.IndexedCollection].removeIf(java.util.function.Predicate<? super C>)"
   "params":
   - "name": "arg0"
     "type": "java.util.function.Predicate<? super C>"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.collection.IndexedCollection].removeIf(java.util.function.Predicate<? super C>)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.collections4.CollectionUtils].getCardinalityMap(java.lang.Iterable<? extends O>)"
+- "name": "[org.apache.commons.collections4.CollectionUtils].getCardinalityMap(java.lang.Iterable<? extends O>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Iterable<? extends O>"
   "return_type": "java.util.Map<O,Integer>"
   "signature": "[org.apache.commons.collections4.CollectionUtils].getCardinalityMap(java.lang.Iterable<? extends O>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.IndexExtractor)"
+- "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.IndexExtractor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections4.bloomfilter.IndexExtractor"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.IndexExtractor)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.collections4.CollectionUtils].addAll(java.util.Collection<C>,java.lang.Iterable<? extends C>)"
+- "name": "[org.apache.commons.collections4.CollectionUtils].addAll(java.util.Collection<C>,java.lang.Iterable<? extends C>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Collection<C>"
@@ -41,9 +31,7 @@
     "type": "java.lang.Iterable<? extends C>"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.CollectionUtils].addAll(java.util.Collection<C>,java.lang.Iterable<? extends C>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BloomFilter)"
+- "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BloomFilter)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections4.bloomfilter.BloomFilter"

--- a/benchmark-sets/jvm-all/apache-commons-compress.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-compress.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.compress.harmony.pack200.AttributeDefinitionBands].<init>(org.apache.commons.compress.harmony.pack200.Segment,int,org.objectweb.asm.Attribute[])"
+- "name": "[org.apache.commons.compress.harmony.pack200.AttributeDefinitionBands].<init>(org.apache.commons.compress.harmony.pack200.Segment,int,org.objectweb.asm.Attribute[])"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.compress.harmony.pack200.Segment"
@@ -11,9 +9,7 @@
     "type": "org.objectweb.asm.Attribute[]"
   "return_type": "org.apache.commons.compress.harmony.pack200.AttributeDefinitionBands"
   "signature": "[org.apache.commons.compress.harmony.pack200.AttributeDefinitionBands].<init>(org.apache.commons.compress.harmony.pack200.Segment,int,org.objectweb.asm.Attribute[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.compress.harmony.pack200.FileBands].<init>(org.apache.commons.compress.harmony.pack200.CpBands,org.apache.commons.compress.harmony.pack200.SegmentHeader,org.apache.commons.compress.harmony.pack200.PackingOptions,org.apache.commons.compress.harmony.pack200.Archive$SegmentUnit,int)"
+- "name": "[org.apache.commons.compress.harmony.pack200.FileBands].<init>(org.apache.commons.compress.harmony.pack200.CpBands,org.apache.commons.compress.harmony.pack200.SegmentHeader,org.apache.commons.compress.harmony.pack200.PackingOptions,org.apache.commons.compress.harmony.pack200.Archive$SegmentUnit,int)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.compress.harmony.pack200.CpBands"
@@ -27,10 +23,7 @@
     "type": "int"
   "return_type": "org.apache.commons.compress.harmony.pack200.FileBands"
   "signature": "[org.apache.commons.compress.harmony.pack200.FileBands].<init>(org.apache.commons.compress.harmony.pack200.CpBands,org.apache.commons.compress.harmony.pack200.SegmentHeader,org.apache.commons.compress.harmony.pack200.PackingOptions,org.apache.commons.compress.harmony.pack200.Archive$SegmentUnit,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream].<init>(java.io.InputStream,boolean)"
+- "name": "[org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream].<init>(java.io.InputStream,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -38,10 +31,7 @@
     "type": "boolean"
   "return_type": "org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream"
   "signature": "[org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream].<init>(java.io.InputStream,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.compress.archivers.tar.TarArchiveEntry].<init>(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption[])"
+- "name": "[org.apache.commons.compress.archivers.tar.TarArchiveEntry].<init>(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption[])"
   "params":
   - "name": "arg0"
     "type": "java.nio.file.Path"
@@ -51,9 +41,7 @@
     "type": "java.nio.file.LinkOption[]"
   "return_type": "org.apache.commons.compress.archivers.tar.TarArchiveEntry"
   "signature": "[org.apache.commons.compress.archivers.tar.TarArchiveEntry].<init>(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.compress.archivers.tar.TarArchiveEntry].<init>(java.io.File,java.lang.String)"
+- "name": "[org.apache.commons.compress.archivers.tar.TarArchiveEntry].<init>(java.io.File,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.io.File"
@@ -61,10 +49,7 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.compress.archivers.tar.TarArchiveEntry"
   "signature": "[org.apache.commons.compress.archivers.tar.TarArchiveEntry].<init>(java.io.File,java.lang.String)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream].<init>(java.io.InputStream,boolean)"
+- "name": "[org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream].<init>(java.io.InputStream,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"

--- a/benchmark-sets/jvm-all/apache-commons-csv.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-csv.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVParser].<init>(java.io.Reader,org.apache.commons.csv.CSVFormat,long,long)"
+- "name": "[org.apache.commons.csv.CSVParser].<init>(java.io.Reader,org.apache.commons.csv.CSVFormat,long,long)"
   "params":
   - "name": "arg0"
     "type": "java.io.Reader"
@@ -14,10 +11,7 @@
     "type": "long"
   "return_type": "org.apache.commons.csv.CSVParser"
   "signature": "[org.apache.commons.csv.CSVParser].<init>(java.io.Reader,org.apache.commons.csv.CSVFormat,long,long)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVPrinter].<init>(java.lang.Appendable,org.apache.commons.csv.CSVFormat)"
+- "name": "[org.apache.commons.csv.CSVPrinter].<init>(java.lang.Appendable,org.apache.commons.csv.CSVFormat)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Appendable"
@@ -25,34 +19,25 @@
     "type": "org.apache.commons.csv.CSVFormat"
   "return_type": "org.apache.commons.csv.CSVPrinter"
   "signature": "[org.apache.commons.csv.CSVPrinter].<init>(java.lang.Appendable,org.apache.commons.csv.CSVFormat)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVPrinter].close(boolean)"
+- "name": "[org.apache.commons.csv.CSVPrinter].close(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "void"
   "signature": "[org.apache.commons.csv.CSVPrinter].close(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(char)"
+- "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(char)"
   "params":
   - "name": "arg0"
     "type": "char"
   "return_type": "org.apache.commons.csv.CSVFormat$Builder"
   "signature": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(char)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVFormat$Builder].setDelimiter(char)"
+- "name": "[org.apache.commons.csv.CSVFormat$Builder].setDelimiter(char)"
   "params":
   - "name": "arg0"
     "type": "char"
   "return_type": "org.apache.commons.csv.CSVFormat$Builder"
   "signature": "[org.apache.commons.csv.CSVFormat$Builder].setDelimiter(char)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(java.lang.Character)"
+- "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(java.lang.Character)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Character"

--- a/benchmark-sets/jvm-all/apache-commons-imaging.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-imaging.yaml
@@ -1,19 +1,11 @@
 "functions":
-- "exceptions":
-  - "org.apache.commons.imaging.ImagingException"
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.imaging.icc.IccProfileInfo].toString(java.lang.String)"
+- "name": "[org.apache.commons.imaging.icc.IccProfileInfo].toString(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.commons.imaging.icc.IccProfileInfo].toString(java.lang.String)"
-- "exceptions":
-  - "org.apache.commons.imaging.ImagingException"
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.imaging.icc.IccTag].dump(java.io.PrintWriter,java.lang.String)"
+- "name": "[org.apache.commons.imaging.icc.IccTag].dump(java.io.PrintWriter,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.io.PrintWriter"
@@ -21,34 +13,25 @@
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.apache.commons.imaging.icc.IccTag].dump(java.io.PrintWriter,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.imaging.common.GenericImageMetadata].toString(java.lang.String)"
+- "name": "[org.apache.commons.imaging.common.GenericImageMetadata].toString(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.commons.imaging.common.GenericImageMetadata].toString(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.imaging.formats.jpeg.JpegImageMetadata].toString(java.lang.String)"
+- "name": "[org.apache.commons.imaging.formats.jpeg.JpegImageMetadata].toString(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.commons.imaging.formats.jpeg.JpegImageMetadata].toString(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.imaging.formats.tiff.TiffImageMetadata$Directory].toString(java.lang.String)"
+- "name": "[org.apache.commons.imaging.formats.tiff.TiffImageMetadata$Directory].toString(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.commons.imaging.formats.tiff.TiffImageMetadata$Directory].toString(java.lang.String)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.imaging.formats.jpeg.segments.DhtSegment].<init>(int,int,java.io.InputStream)"
+- "name": "[org.apache.commons.imaging.formats.jpeg.segments.DhtSegment].<init>(int,int,java.io.InputStream)"
   "params":
   - "name": "arg0"
     "type": "int"

--- a/benchmark-sets/jvm-all/apache-commons-jxpath.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-jxpath.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.functions.ConstructorFunction].invoke(org.apache.commons.jxpath.ExpressionContext,java.lang.Object[])"
+- "name": "[org.apache.commons.jxpath.functions.ConstructorFunction].invoke(org.apache.commons.jxpath.ExpressionContext,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.jxpath.ExpressionContext"
@@ -9,9 +7,7 @@
     "type": "java.lang.Object[]"
   "return_type": "java.lang.Object"
   "signature": "[org.apache.commons.jxpath.functions.ConstructorFunction].invoke(org.apache.commons.jxpath.ExpressionContext,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.ClassFunctions].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
+- "name": "[org.apache.commons.jxpath.ClassFunctions].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -21,9 +17,7 @@
     "type": "java.lang.Object[]"
   "return_type": "org.apache.commons.jxpath.Function"
   "signature": "[org.apache.commons.jxpath.ClassFunctions].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.FunctionLibrary].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
+- "name": "[org.apache.commons.jxpath.FunctionLibrary].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -33,9 +27,7 @@
     "type": "java.lang.Object[]"
   "return_type": "org.apache.commons.jxpath.Function"
   "signature": "[org.apache.commons.jxpath.FunctionLibrary].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.util.JXPath11CompatibleTypeConverter].convert(java.lang.Object,java.lang.Class)"
+- "name": "[org.apache.commons.jxpath.util.JXPath11CompatibleTypeConverter].convert(java.lang.Object,java.lang.Class)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -43,17 +35,13 @@
     "type": "java.lang.Class"
   "return_type": "java.lang.Object"
   "signature": "[org.apache.commons.jxpath.util.JXPath11CompatibleTypeConverter].convert(java.lang.Object,java.lang.Class)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.ri.NamespaceResolver].getPrefix(java.lang.String)"
+- "name": "[org.apache.commons.jxpath.ri.NamespaceResolver].getPrefix(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.commons.jxpath.ri.NamespaceResolver].getPrefix(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.ri.model.container.ContainerPointer].attributeIterator(org.apache.commons.jxpath.ri.QName)"
+- "name": "[org.apache.commons.jxpath.ri.model.container.ContainerPointer].attributeIterator(org.apache.commons.jxpath.ri.QName)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.jxpath.ri.QName"

--- a/benchmark-sets/jvm-all/apache-commons-lang.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-lang.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.lang3.text.ExtendedMessageFormat].<init>(java.lang.String,java.util.Locale,java.util.Map)"
+- "name": "[org.apache.commons.lang3.text.ExtendedMessageFormat].<init>(java.lang.String,java.util.Locale,java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -11,9 +9,7 @@
     "type": "java.util.Map"
   "return_type": "org.apache.commons.lang3.text.ExtendedMessageFormat"
   "signature": "[org.apache.commons.lang3.text.ExtendedMessageFormat].<init>(java.lang.String,java.util.Locale,java.util.Map)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.lang3.builder.ReflectionDiffBuilder].<init>(java.lang.Object,java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle)"
+- "name": "[org.apache.commons.lang3.builder.ReflectionDiffBuilder].<init>(java.lang.Object,java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -23,9 +19,7 @@
     "type": "org.apache.commons.lang3.builder.ToStringStyle"
   "return_type": "org.apache.commons.lang3.builder.ReflectionDiffBuilder"
   "signature": "[org.apache.commons.lang3.builder.ReflectionDiffBuilder].<init>(java.lang.Object,java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.lang3.builder.ReflectionToStringBuilder].<init>(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle,java.lang.StringBuffer,java.lang.Class,boolean,boolean,boolean)"
+- "name": "[org.apache.commons.lang3.builder.ReflectionToStringBuilder].<init>(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle,java.lang.StringBuffer,java.lang.Class,boolean,boolean,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -43,9 +37,7 @@
     "type": "boolean"
   "return_type": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
   "signature": "[org.apache.commons.lang3.builder.ReflectionToStringBuilder].<init>(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle,java.lang.StringBuffer,java.lang.Class,boolean,boolean,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.lang3.builder.ReflectionToStringBuilder].<init>(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle,java.lang.StringBuffer,java.lang.Class,boolean,boolean)"
+- "name": "[org.apache.commons.lang3.builder.ReflectionToStringBuilder].<init>(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle,java.lang.StringBuffer,java.lang.Class,boolean,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -61,9 +53,7 @@
     "type": "boolean"
   "return_type": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
   "signature": "[org.apache.commons.lang3.builder.ReflectionToStringBuilder].<init>(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle,java.lang.StringBuffer,java.lang.Class,boolean,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.lang3.text.StrSubstitutor].<init>(org.apache.commons.lang3.text.StrLookup,org.apache.commons.lang3.text.StrMatcher,org.apache.commons.lang3.text.StrMatcher,char,org.apache.commons.lang3.text.StrMatcher)"
+- "name": "[org.apache.commons.lang3.text.StrSubstitutor].<init>(org.apache.commons.lang3.text.StrLookup,org.apache.commons.lang3.text.StrMatcher,org.apache.commons.lang3.text.StrMatcher,char,org.apache.commons.lang3.text.StrMatcher)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.lang3.text.StrLookup"
@@ -77,9 +67,7 @@
     "type": "org.apache.commons.lang3.text.StrMatcher"
   "return_type": "org.apache.commons.lang3.text.StrSubstitutor"
   "signature": "[org.apache.commons.lang3.text.StrSubstitutor].<init>(org.apache.commons.lang3.text.StrLookup,org.apache.commons.lang3.text.StrMatcher,org.apache.commons.lang3.text.StrMatcher,char,org.apache.commons.lang3.text.StrMatcher)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.lang3.text.StrSubstitutor].<init>(org.apache.commons.lang3.text.StrLookup,java.lang.String,java.lang.String,char,java.lang.String)"
+- "name": "[org.apache.commons.lang3.text.StrSubstitutor].<init>(org.apache.commons.lang3.text.StrLookup,java.lang.String,java.lang.String,char,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.lang3.text.StrLookup"

--- a/benchmark-sets/jvm-all/apache-commons-net.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-net.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.net.ntp.TimeInfo].<init>(org.apache.commons.net.ntp.NtpV3Packet,long,java.util.List,boolean)"
+- "name": "[org.apache.commons.net.ntp.TimeInfo].<init>(org.apache.commons.net.ntp.NtpV3Packet,long,java.util.List,boolean)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.net.ntp.NtpV3Packet"
@@ -13,9 +11,7 @@
     "type": "boolean"
   "return_type": "org.apache.commons.net.ntp.TimeInfo"
   "signature": "[org.apache.commons.net.ntp.TimeInfo].<init>(org.apache.commons.net.ntp.NtpV3Packet,long,java.util.List,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.net.nntp.NewGroupsOrNewsQuery].<init>(java.util.Calendar,boolean)"
+- "name": "[org.apache.commons.net.nntp.NewGroupsOrNewsQuery].<init>(java.util.Calendar,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.util.Calendar"
@@ -23,17 +19,13 @@
     "type": "boolean"
   "return_type": "org.apache.commons.net.nntp.NewGroupsOrNewsQuery"
   "signature": "[org.apache.commons.net.nntp.NewGroupsOrNewsQuery].<init>(java.util.Calendar,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.net.ftp.parser.NTFTPEntryParser].<init>(org.apache.commons.net.ftp.FTPClientConfig)"
+- "name": "[org.apache.commons.net.ftp.parser.NTFTPEntryParser].<init>(org.apache.commons.net.ftp.FTPClientConfig)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.net.ftp.FTPClientConfig"
   "return_type": "org.apache.commons.net.ftp.parser.NTFTPEntryParser"
   "signature": "[org.apache.commons.net.ftp.parser.NTFTPEntryParser].<init>(org.apache.commons.net.ftp.FTPClientConfig)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.net.util.Base64].<init>(int,byte[],boolean)"
+- "name": "[org.apache.commons.net.util.Base64].<init>(int,byte[],boolean)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -43,17 +35,13 @@
     "type": "boolean"
   "return_type": "org.apache.commons.net.util.Base64"
   "signature": "[org.apache.commons.net.util.Base64].<init>(int,byte[],boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.net.ntp.TimeStamp].<init>(java.util.Date)"
+- "name": "[org.apache.commons.net.ntp.TimeStamp].<init>(java.util.Date)"
   "params":
   - "name": "arg0"
     "type": "java.util.Date"
   "return_type": "org.apache.commons.net.ntp.TimeStamp"
   "signature": "[org.apache.commons.net.ntp.TimeStamp].<init>(java.util.Date)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.net.util.Base64].<init>(int,byte[])"
+- "name": "[org.apache.commons.net.util.Base64].<init>(int,byte[])"
   "params":
   - "name": "arg0"
     "type": "int"

--- a/benchmark-sets/jvm-all/apache-commons-validator.yaml
+++ b/benchmark-sets/jvm-all/apache-commons-validator.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.routines.CreditCardValidator].<init>(long)"
+- "name": "[org.apache.commons.validator.routines.CreditCardValidator].<init>(long)"
   "params":
   - "name": "arg0"
     "type": "long"
   "return_type": "org.apache.commons.validator.routines.CreditCardValidator"
   "signature": "[org.apache.commons.validator.routines.CreditCardValidator].<init>(long)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long)"
+- "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"
@@ -19,9 +15,7 @@
     "type": "long"
   "return_type": "org.apache.commons.validator.routines.UrlValidator"
   "signature": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long,org.apache.commons.validator.routines.DomainValidator)"
+- "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long,org.apache.commons.validator.routines.DomainValidator)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"
@@ -33,29 +27,19 @@
     "type": "org.apache.commons.validator.routines.DomainValidator"
   "return_type": "org.apache.commons.validator.routines.UrlValidator"
   "signature": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long,org.apache.commons.validator.routines.DomainValidator)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.validator.util.ValidatorUtils].copyFastHashMap(org.apache.commons.collections.FastHashMap)"
+- "name": "[org.apache.commons.validator.util.ValidatorUtils].copyFastHashMap(org.apache.commons.collections.FastHashMap)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections.FastHashMap"
   "return_type": "org.apache.commons.collections.FastHashMap"
   "signature": "[org.apache.commons.validator.util.ValidatorUtils].copyFastHashMap(org.apache.commons.collections.FastHashMap)"
-- "exceptions":
-  - "java.io.IOException"
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.io.InputStream[])"
+- "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.io.InputStream[])"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream[]"
   "return_type": "org.apache.commons.validator.ValidatorResources"
   "signature": "[org.apache.commons.validator.ValidatorResources].<init>(java.io.InputStream[])"
-- "exceptions":
-  - "java.io.IOException"
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.lang.String[])"
+- "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"

--- a/benchmark-sets/jvm-all/apache-felix-dev.yaml
+++ b/benchmark-sets/jvm-all/apache-felix-dev.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": true
-  "name": "[org.apache.felix.utils.properties.InterpolationHelper].substVars(java.lang.String,java.lang.String,java.util.Map,java.util.Map,org.apache.felix.utils.properties.InterpolationHelper$SubstitutionCallback,boolean,boolean,boolean)"
+- "name": "[org.apache.felix.utils.properties.InterpolationHelper].substVars(java.lang.String,java.lang.String,java.util.Map,java.util.Map,org.apache.felix.utils.properties.InterpolationHelper$SubstitutionCallback,boolean,boolean,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -22,9 +19,7 @@
     "type": "boolean"
   "return_type": "java.lang.String"
   "signature": "[org.apache.felix.utils.properties.InterpolationHelper].substVars(java.lang.String,java.lang.String,java.util.Map,java.util.Map,org.apache.felix.utils.properties.InterpolationHelper$SubstitutionCallback,boolean,boolean,boolean)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.felix.utils.resource.ResourceUtils].toString(org.osgi.resource.Resource,java.lang.String,java.util.Map<String,Object>,java.util.Map<String,String>)"
+- "name": "[org.apache.felix.utils.resource.ResourceUtils].toString(org.osgi.resource.Resource,java.lang.String,java.util.Map<String,Object>,java.util.Map<String,String>)"
   "params":
   - "name": "arg0"
     "type": "org.osgi.resource.Resource"
@@ -36,9 +31,7 @@
     "type": "java.util.Map<String,String>"
   "return_type": "java.lang.String"
   "signature": "[org.apache.felix.utils.resource.ResourceUtils].toString(org.osgi.resource.Resource,java.lang.String,java.util.Map<String,Object>,java.util.Map<String,String>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.felix.utils.properties.Properties].put(java.lang.String,java.util.List<String>,java.util.List<String>)"
+- "name": "[org.apache.felix.utils.properties.Properties].put(java.lang.String,java.util.List<String>,java.util.List<String>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -48,9 +41,7 @@
     "type": "java.util.List<String>"
   "return_type": "java.lang.String"
   "signature": "[org.apache.felix.utils.properties.Properties].put(java.lang.String,java.util.List<String>,java.util.List<String>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.felix.utils.properties.Properties].put(java.lang.String,java.lang.String)"
+- "name": "[org.apache.felix.utils.properties.Properties].put(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -58,9 +49,7 @@
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.felix.utils.properties.Properties].put(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.felix.utils.properties.TypedProperties].put(java.lang.String,java.lang.Object)"
+- "name": "[org.apache.felix.utils.properties.TypedProperties].put(java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -68,9 +57,7 @@
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[org.apache.felix.utils.properties.TypedProperties].put(java.lang.String,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.felix.utils.properties.Properties].put(java.lang.Object,java.lang.Object)"
+- "name": "[org.apache.felix.utils.properties.Properties].put(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/apache-poi.yaml
+++ b/benchmark-sets/jvm-all/apache-poi.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.poi.sl.draw.DrawTextParagraph].draw(java.awt.Graphics2D)"
+- "name": "[org.apache.poi.sl.draw.DrawTextParagraph].draw(java.awt.Graphics2D)"
   "params":
   - "name": "arg0"
     "type": "java.awt.Graphics2D"
   "return_type": "void"
   "signature": "[org.apache.poi.sl.draw.DrawTextParagraph].draw(java.awt.Graphics2D)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.poi.sl.draw.DrawTextShape].drawParagraphs(java.awt.Graphics2D,double,double)"
+- "name": "[org.apache.poi.sl.draw.DrawTextShape].drawParagraphs(java.awt.Graphics2D,double,double)"
   "params":
   - "name": "arg0"
     "type": "java.awt.Graphics2D"
@@ -19,9 +15,7 @@
     "type": "double"
   "return_type": "double"
   "signature": "[org.apache.poi.sl.draw.DrawTextShape].drawParagraphs(java.awt.Graphics2D,double,double)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.poi.sl.draw.DrawShape].getAnchor(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PlaceableShape<?,?>)"
+- "name": "[org.apache.poi.sl.draw.DrawShape].getAnchor(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PlaceableShape<?,?>)"
   "params":
   - "name": "arg0"
     "type": "java.awt.Graphics2D"
@@ -29,17 +23,13 @@
     "type": "org.apache.poi.sl.usermodel.PlaceableShape<?,?>"
   "return_type": "java.awt.geom.Rectangle2D"
   "signature": "[org.apache.poi.sl.draw.DrawShape].getAnchor(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PlaceableShape<?,?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.poi.sl.draw.DrawTextShape].getTextHeight(java.awt.Graphics2D)"
+- "name": "[org.apache.poi.sl.draw.DrawTextShape].getTextHeight(java.awt.Graphics2D)"
   "params":
   - "name": "arg0"
     "type": "java.awt.Graphics2D"
   "return_type": "double"
   "signature": "[org.apache.poi.sl.draw.DrawTextShape].getTextHeight(java.awt.Graphics2D)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.poi.sl.draw.DrawPaint].getPaint(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PaintStyle,org.apache.poi.sl.usermodel.PaintStyle$PaintModifier)"
+- "name": "[org.apache.poi.sl.draw.DrawPaint].getPaint(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PaintStyle,org.apache.poi.sl.usermodel.PaintStyle$PaintModifier)"
   "params":
   - "name": "arg0"
     "type": "java.awt.Graphics2D"
@@ -49,9 +39,7 @@
     "type": "org.apache.poi.sl.usermodel.PaintStyle$PaintModifier"
   "return_type": "java.awt.Paint"
   "signature": "[org.apache.poi.sl.draw.DrawPaint].getPaint(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PaintStyle,org.apache.poi.sl.usermodel.PaintStyle$PaintModifier)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.poi.sl.draw.DrawPaint].getPaint(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PaintStyle)"
+- "name": "[org.apache.poi.sl.draw.DrawPaint].getPaint(java.awt.Graphics2D,org.apache.poi.sl.usermodel.PaintStyle)"
   "params":
   - "name": "arg0"
     "type": "java.awt.Graphics2D"

--- a/benchmark-sets/jvm-all/args4j.yaml
+++ b/benchmark-sets/jvm-all/args4j.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.kohsuke.args4j.CmdLineParser].addArgument(org.kohsuke.args4j.spi.Setter,org.kohsuke.args4j.Argument)"
+- "name": "[org.kohsuke.args4j.CmdLineParser].addArgument(org.kohsuke.args4j.spi.Setter,org.kohsuke.args4j.Argument)"
   "params":
   - "name": "arg0"
     "type": "org.kohsuke.args4j.spi.Setter"
@@ -9,36 +7,25 @@
     "type": "org.kohsuke.args4j.Argument"
   "return_type": "void"
   "signature": "[org.kohsuke.args4j.CmdLineParser].addArgument(org.kohsuke.args4j.spi.Setter,org.kohsuke.args4j.Argument)"
-- "exceptions":
-  - "org.kohsuke.args4j.CmdLineException"
-  "is_jvm_static": false
-  "name": "[org.kohsuke.args4j.spi.SubCommandHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
+- "name": "[org.kohsuke.args4j.spi.SubCommandHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
   "params":
   - "name": "arg0"
     "type": "org.kohsuke.args4j.spi.Parameters"
   "return_type": "int"
   "signature": "[org.kohsuke.args4j.spi.SubCommandHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
-- "exceptions":
-  - "org.kohsuke.args4j.CmdLineException"
-  "is_jvm_static": false
-  "name": "[org.kohsuke.args4j.spi.BooleanOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
+- "name": "[org.kohsuke.args4j.spi.BooleanOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
   "params":
   - "name": "arg0"
     "type": "org.kohsuke.args4j.spi.Parameters"
   "return_type": "int"
   "signature": "[org.kohsuke.args4j.spi.BooleanOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
-- "exceptions":
-  - "org.kohsuke.args4j.CmdLineException"
-  "is_jvm_static": false
-  "name": "[org.kohsuke.args4j.spi.StringArrayOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
+- "name": "[org.kohsuke.args4j.spi.StringArrayOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
   "params":
   - "name": "arg0"
     "type": "org.kohsuke.args4j.spi.Parameters"
   "return_type": "int"
   "signature": "[org.kohsuke.args4j.spi.StringArrayOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.kohsuke.args4j.CmdLineParser].addOption(org.kohsuke.args4j.spi.Setter,org.kohsuke.args4j.Option)"
+- "name": "[org.kohsuke.args4j.CmdLineParser].addOption(org.kohsuke.args4j.spi.Setter,org.kohsuke.args4j.Option)"
   "params":
   - "name": "arg0"
     "type": "org.kohsuke.args4j.spi.Setter"
@@ -46,10 +33,7 @@
     "type": "org.kohsuke.args4j.Option"
   "return_type": "void"
   "signature": "[org.kohsuke.args4j.CmdLineParser].addOption(org.kohsuke.args4j.spi.Setter,org.kohsuke.args4j.Option)"
-- "exceptions":
-  - "org.kohsuke.args4j.CmdLineException"
-  "is_jvm_static": false
-  "name": "[org.kohsuke.args4j.spi.ExplicitBooleanOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
+- "name": "[org.kohsuke.args4j.spi.ExplicitBooleanOptionHandler].parseArguments(org.kohsuke.args4j.spi.Parameters)"
   "params":
   - "name": "arg0"
     "type": "org.kohsuke.args4j.spi.Parameters"

--- a/benchmark-sets/jvm-all/brotli-java.yaml
+++ b/benchmark-sets/jvm-all/brotli-java.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.brotli.dec.BrotliInputStream].<init>(java.io.InputStream,int)"
+- "name": "[org.brotli.dec.BrotliInputStream].<init>(java.io.InputStream,int)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -10,19 +7,13 @@
     "type": "int"
   "return_type": "org.brotli.dec.BrotliInputStream"
   "signature": "[org.brotli.dec.BrotliInputStream].<init>(java.io.InputStream,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.brotli.dec.BrotliInputStream].<init>(java.io.InputStream)"
+- "name": "[org.brotli.dec.BrotliInputStream].<init>(java.io.InputStream)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
   "return_type": "org.brotli.dec.BrotliInputStream"
   "signature": "[org.brotli.dec.BrotliInputStream].<init>(java.io.InputStream)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.brotli.dec.BrotliInputStream].read(byte[],int,int)"
+- "name": "[org.brotli.dec.BrotliInputStream].read(byte[],int,int)"
   "params":
   - "name": "arg0"
     "type": "byte[]"

--- a/benchmark-sets/jvm-all/calcite-avatica.yaml
+++ b/benchmark-sets/jvm-all/calcite-avatica.yaml
@@ -1,50 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.LocalProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
+- "name": "[org.apache.calcite.avatica.remote.LocalProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Request"
   "return_type": "org.apache.calcite.avatica.remote.Service$Response"
   "signature": "[org.apache.calcite.avatica.remote.LocalProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.RemoteProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
+- "name": "[org.apache.calcite.avatica.remote.RemoteProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Request"
   "return_type": "org.apache.calcite.avatica.remote.Service$Response"
   "signature": "[org.apache.calcite.avatica.remote.RemoteProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeResponse(org.apache.calcite.avatica.remote.Service$Response)"
+- "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeResponse(org.apache.calcite.avatica.remote.Service$Response)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Response"
   "return_type": "byte[]"
   "signature": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeResponse(org.apache.calcite.avatica.remote.Service$Response)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeRequest(org.apache.calcite.avatica.remote.Service$Request)"
+- "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeRequest(org.apache.calcite.avatica.remote.Service$Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Request"
   "return_type": "byte[]"
   "signature": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeRequest(org.apache.calcite.avatica.remote.Service$Request)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].parseRequest(byte[])"
+- "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].parseRequest(byte[])"
   "params":
   - "name": "arg0"
     "type": "byte[]"
   "return_type": "org.apache.calcite.avatica.remote.Service$Request"
   "signature": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].parseRequest(byte[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.Meta$Frame].equals(java.lang.Object)"
+- "name": "[org.apache.calcite.avatica.Meta$Frame].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/cbor-java.yaml
+++ b/benchmark-sets/jvm-all/cbor-java.yaml
@@ -1,24 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[co.nstant.in.cbor.CborEncoder].<init>(java.io.OutputStream)"
+- "name": "[co.nstant.in.cbor.CborEncoder].<init>(java.io.OutputStream)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
   "return_type": "co.nstant.in.cbor.CborEncoder"
   "signature": "[co.nstant.in.cbor.CborEncoder].<init>(java.io.OutputStream)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[co.nstant.in.cbor.CborDecoder].<init>(java.io.InputStream)"
+- "name": "[co.nstant.in.cbor.CborDecoder].<init>(java.io.InputStream)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
   "return_type": "co.nstant.in.cbor.CborDecoder"
   "signature": "[co.nstant.in.cbor.CborDecoder].<init>(java.io.InputStream)"
-- "exceptions":
-  - "co.nstant.in.cbor.CborException"
-  "is_jvm_static": false
-  "name": "[co.nstant.in.cbor.model.RationalNumber].<init>(co.nstant.in.cbor.model.Number,co.nstant.in.cbor.model.Number)"
+- "name": "[co.nstant.in.cbor.model.RationalNumber].<init>(co.nstant.in.cbor.model.Number,co.nstant.in.cbor.model.Number)"
   "params":
   - "name": "arg0"
     "type": "co.nstant.in.cbor.model.Number"
@@ -26,9 +19,7 @@
     "type": "co.nstant.in.cbor.model.Number"
   "return_type": "co.nstant.in.cbor.model.RationalNumber"
   "signature": "[co.nstant.in.cbor.model.RationalNumber].<init>(co.nstant.in.cbor.model.Number,co.nstant.in.cbor.model.Number)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[co.nstant.in.cbor.encoder.SpecialEncoder].<init>(co.nstant.in.cbor.CborEncoder,java.io.OutputStream)"
+- "name": "[co.nstant.in.cbor.encoder.SpecialEncoder].<init>(co.nstant.in.cbor.CborEncoder,java.io.OutputStream)"
   "params":
   - "name": "arg0"
     "type": "co.nstant.in.cbor.CborEncoder"
@@ -36,9 +27,7 @@
     "type": "java.io.OutputStream"
   "return_type": "co.nstant.in.cbor.encoder.SpecialEncoder"
   "signature": "[co.nstant.in.cbor.encoder.SpecialEncoder].<init>(co.nstant.in.cbor.CborEncoder,java.io.OutputStream)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[co.nstant.in.cbor.model.LanguageTaggedString].<init>(co.nstant.in.cbor.model.UnicodeString,co.nstant.in.cbor.model.UnicodeString)"
+- "name": "[co.nstant.in.cbor.model.LanguageTaggedString].<init>(co.nstant.in.cbor.model.UnicodeString,co.nstant.in.cbor.model.UnicodeString)"
   "params":
   - "name": "arg0"
     "type": "co.nstant.in.cbor.model.UnicodeString"
@@ -46,9 +35,7 @@
     "type": "co.nstant.in.cbor.model.UnicodeString"
   "return_type": "co.nstant.in.cbor.model.LanguageTaggedString"
   "signature": "[co.nstant.in.cbor.model.LanguageTaggedString].<init>(co.nstant.in.cbor.model.UnicodeString,co.nstant.in.cbor.model.UnicodeString)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[co.nstant.in.cbor.decoder.SpecialDecoder].<init>(co.nstant.in.cbor.CborDecoder,java.io.InputStream)"
+- "name": "[co.nstant.in.cbor.decoder.SpecialDecoder].<init>(co.nstant.in.cbor.CborDecoder,java.io.InputStream)"
   "params":
   - "name": "arg0"
     "type": "co.nstant.in.cbor.CborDecoder"

--- a/benchmark-sets/jvm-all/cglib.yaml
+++ b/benchmark-sets/jvm-all/cglib.yaml
@@ -1,49 +1,35 @@
 "functions":
-- "exceptions":
-  - "java.lang.Exception"
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.transform.TransformingClassGenerator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.transform.TransformingClassGenerator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.transform.TransformingClassGenerator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.reflect.MulticastDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.reflect.MulticastDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.reflect.MulticastDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.core.KeyFactory$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.core.KeyFactory$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.core.KeyFactory$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.beans.BeanCopier$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.beans.BeanCopier$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.beans.BeanCopier$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.beans.ImmutableBean$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.beans.ImmutableBean$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.beans.ImmutableBean$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions":
-  - "java.lang.NoSuchMethodException"
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.reflect.MethodDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.reflect.MethodDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"

--- a/benchmark-sets/jvm-all/checkstyle.yaml
+++ b/benchmark-sets/jvm-all/checkstyle.yaml
@@ -1,53 +1,35 @@
 "functions":
-- "exceptions":
-  - "org.antlr.v4.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].recordDeclaration(java.util.List<ModifierContext>)"
+- "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].recordDeclaration(java.util.List<ModifierContext>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<ModifierContext>"
   "return_type": "com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$RecordDeclarationContext"
   "signature": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].recordDeclaration(java.util.List<ModifierContext>)"
-- "exceptions":
-  - "org.antlr.v4.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].constructorDeclaration(java.util.List<ModifierContext>)"
+- "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].constructorDeclaration(java.util.List<ModifierContext>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<ModifierContext>"
   "return_type": "com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$ConstructorDeclarationContext"
   "signature": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].constructorDeclaration(java.util.List<ModifierContext>)"
-- "exceptions":
-  - "org.antlr.v4.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].interfaceDeclaration(java.util.List<ModifierContext>)"
+- "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].interfaceDeclaration(java.util.List<ModifierContext>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<ModifierContext>"
   "return_type": "com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$InterfaceDeclarationContext"
   "signature": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].interfaceDeclaration(java.util.List<ModifierContext>)"
-- "exceptions":
-  - "org.antlr.v4.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].methodDeclaration(java.util.List<ModifierContext>)"
+- "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].methodDeclaration(java.util.List<ModifierContext>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<ModifierContext>"
   "return_type": "com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$MethodDeclarationContext"
   "signature": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].methodDeclaration(java.util.List<ModifierContext>)"
-- "exceptions":
-  - "org.antlr.v4.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].interfaceMethodDeclaration(java.util.List<ModifierContext>)"
+- "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].interfaceMethodDeclaration(java.util.List<ModifierContext>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<ModifierContext>"
   "return_type": "com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser$InterfaceMethodDeclarationContext"
   "signature": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].interfaceMethodDeclaration(java.util.List<ModifierContext>)"
-- "exceptions":
-  - "org.antlr.v4.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].enumDeclaration(java.util.List<ModifierContext>)"
+- "name": "[com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser].enumDeclaration(java.util.List<ModifierContext>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<ModifierContext>"

--- a/benchmark-sets/jvm-all/cron-utils.yaml
+++ b/benchmark-sets/jvm-all/cron-utils.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.cronutils.mapper.CronMapper].<init>(com.cronutils.model.definition.CronDefinition,com.cronutils.model.definition.CronDefinition,com.cronutils.Function)"
+- "name": "[com.cronutils.mapper.CronMapper].<init>(com.cronutils.model.definition.CronDefinition,com.cronutils.model.definition.CronDefinition,com.cronutils.Function)"
   "params":
   - "name": "arg0"
     "type": "com.cronutils.model.definition.CronDefinition"
@@ -11,9 +9,7 @@
     "type": "com.cronutils.Function"
   "return_type": "com.cronutils.mapper.CronMapper"
   "signature": "[com.cronutils.mapper.CronMapper].<init>(com.cronutils.model.definition.CronDefinition,com.cronutils.model.definition.CronDefinition,com.cronutils.Function)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.cronutils.model.definition.CronDefinition].<init>(java.util.List,java.util.Set,java.util.Set,boolean)"
+- "name": "[com.cronutils.model.definition.CronDefinition].<init>(java.util.List,java.util.Set,java.util.Set,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.util.List"
@@ -25,9 +21,7 @@
     "type": "boolean"
   "return_type": "com.cronutils.model.definition.CronDefinition"
   "signature": "[com.cronutils.model.definition.CronDefinition].<init>(java.util.List,java.util.Set,java.util.Set,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.cronutils.model.field.expression.On].<init>(com.cronutils.model.field.value.IntegerFieldValue,com.cronutils.model.field.value.SpecialCharFieldValue)"
+- "name": "[com.cronutils.model.field.expression.On].<init>(com.cronutils.model.field.value.IntegerFieldValue,com.cronutils.model.field.value.SpecialCharFieldValue)"
   "params":
   - "name": "arg0"
     "type": "com.cronutils.model.field.value.IntegerFieldValue"
@@ -35,17 +29,13 @@
     "type": "com.cronutils.model.field.value.SpecialCharFieldValue"
   "return_type": "com.cronutils.model.field.expression.On"
   "signature": "[com.cronutils.model.field.expression.On].<init>(com.cronutils.model.field.value.IntegerFieldValue,com.cronutils.model.field.value.SpecialCharFieldValue)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.cronutils.model.CompositeCron].<init>(java.util.List)"
+- "name": "[com.cronutils.model.CompositeCron].<init>(java.util.List)"
   "params":
   - "name": "arg0"
     "type": "java.util.List"
   "return_type": "com.cronutils.model.CompositeCron"
   "signature": "[com.cronutils.model.CompositeCron].<init>(java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.cronutils.model.SingleCron].<init>(com.cronutils.model.definition.CronDefinition,java.util.List)"
+- "name": "[com.cronutils.model.SingleCron].<init>(com.cronutils.model.definition.CronDefinition,java.util.List)"
   "params":
   - "name": "arg0"
     "type": "com.cronutils.model.definition.CronDefinition"
@@ -53,9 +43,7 @@
     "type": "java.util.List"
   "return_type": "com.cronutils.model.SingleCron"
   "signature": "[com.cronutils.model.SingleCron].<init>(com.cronutils.model.definition.CronDefinition,java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.cronutils.model.field.expression.Every].<init>(com.cronutils.model.field.expression.FieldExpression,com.cronutils.model.field.value.IntegerFieldValue)"
+- "name": "[com.cronutils.model.field.expression.Every].<init>(com.cronutils.model.field.expression.FieldExpression,com.cronutils.model.field.value.IntegerFieldValue)"
   "params":
   - "name": "arg0"
     "type": "(com.cronutils.model.field.expression.FieldExpression"

--- a/benchmark-sets/jvm-all/curvesapi.yaml
+++ b/benchmark-sets/jvm-all/curvesapi.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.graphbuilder.curve.GroupIterator].<init>(java.lang.String,int)"
+- "name": "[com.graphbuilder.curve.GroupIterator].<init>(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "int"
   "return_type": "com.graphbuilder.curve.GroupIterator"
   "signature": "[com.graphbuilder.curve.GroupIterator].<init>(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.graphbuilder.curve.NURBSpline].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
+- "name": "[com.graphbuilder.curve.NURBSpline].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
   "params":
   - "name": "arg0"
     "type": "com.graphbuilder.curve.ControlPath"
@@ -19,17 +15,13 @@
     "type": "com.graphbuilder.curve.GroupIterator"
   "return_type": "com.graphbuilder.curve.NURBSpline"
   "signature": "[com.graphbuilder.curve.NURBSpline].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.graphbuilder.curve.GroupIterator].<init>(int[])"
+- "name": "[com.graphbuilder.curve.GroupIterator].<init>(int[])"
   "params":
   - "name": "arg0"
     "type": "int[]"
   "return_type": "com.graphbuilder.curve.GroupIterator"
   "signature": "[com.graphbuilder.curve.GroupIterator].<init>(int[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.graphbuilder.curve.BSpline].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
+- "name": "[com.graphbuilder.curve.BSpline].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
   "params":
   - "name": "arg0"
     "type": "com.graphbuilder.curve.ControlPath"
@@ -37,9 +29,7 @@
     "type": "com.graphbuilder.curve.GroupIterator"
   "return_type": "com.graphbuilder.curve.BSpline"
   "signature": "[com.graphbuilder.curve.BSpline].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.graphbuilder.curve.LagrangeCurve].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
+- "name": "[com.graphbuilder.curve.LagrangeCurve].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
   "params":
   - "name": "arg0"
     "type": "com.graphbuilder.curve.ControlPath"
@@ -47,9 +37,7 @@
     "type": "com.graphbuilder.curve.GroupIterator"
   "return_type": "com.graphbuilder.curve.LagrangeCurve"
   "signature": "[com.graphbuilder.curve.LagrangeCurve].<init>(com.graphbuilder.curve.ControlPath,com.graphbuilder.curve.GroupIterator)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.graphbuilder.math.FuncNode].child(int)"
+- "name": "[com.graphbuilder.math.FuncNode].child(int)"
   "params":
   - "name": "arg0"
     "type": "int"

--- a/benchmark-sets/jvm-all/dom4j.yaml
+++ b/benchmark-sets/jvm-all/dom4j.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.dom4j.DocumentFactory].createAttribute(org.dom4j.Element,java.lang.String,java.lang.String)"
+- "name": "[org.dom4j.DocumentFactory].createAttribute(org.dom4j.Element,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.dom4j.Element"
@@ -11,9 +9,7 @@
     "type": "java.lang.String"
   "return_type": "org.dom4j.Attribute"
   "signature": "[org.dom4j.DocumentFactory].createAttribute(org.dom4j.Element,java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.dom4j.datatype.DatatypeDocumentFactory].createAttribute(org.dom4j.Element,org.dom4j.QName,java.lang.String)"
+- "name": "[org.dom4j.datatype.DatatypeDocumentFactory].createAttribute(org.dom4j.Element,org.dom4j.QName,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.dom4j.Element"
@@ -23,9 +19,7 @@
     "type": "java.lang.String"
   "return_type": "org.dom4j.Attribute"
   "signature": "[org.dom4j.datatype.DatatypeDocumentFactory].createAttribute(org.dom4j.Element,org.dom4j.QName,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.dom4j.datatype.DatatypeDocumentFactory].loadSchema(org.dom4j.Document,org.dom4j.Namespace)"
+- "name": "[org.dom4j.datatype.DatatypeDocumentFactory].loadSchema(org.dom4j.Document,org.dom4j.Namespace)"
   "params":
   - "name": "arg0"
     "type": "org.dom4j.Document"
@@ -33,9 +27,7 @@
     "type": "org.dom4j.Namespace"
   "return_type": "void"
   "signature": "[org.dom4j.datatype.DatatypeDocumentFactory].loadSchema(org.dom4j.Document,org.dom4j.Namespace)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.dom4j.datatype.SchemaParser].build(org.dom4j.Document,org.dom4j.Namespace)"
+- "name": "[org.dom4j.datatype.SchemaParser].build(org.dom4j.Document,org.dom4j.Namespace)"
   "params":
   - "name": "arg0"
     "type": "org.dom4j.Document"
@@ -43,26 +35,19 @@
     "type": "org.dom4j.Namespace"
   "return_type": "void"
   "signature": "[org.dom4j.datatype.SchemaParser].build(org.dom4j.Document,org.dom4j.Namespace)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.dom4j.datatype.DatatypeDocumentFactory].loadSchema(org.dom4j.Document)"
+- "name": "[org.dom4j.datatype.DatatypeDocumentFactory].loadSchema(org.dom4j.Document)"
   "params":
   - "name": "arg0"
     "type": "org.dom4j.Document"
   "return_type": "void"
   "signature": "[org.dom4j.datatype.DatatypeDocumentFactory].loadSchema(org.dom4j.Document)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.dom4j.datatype.SchemaParser].build(org.dom4j.Document)"
+- "name": "[org.dom4j.datatype.SchemaParser].build(org.dom4j.Document)"
   "params":
   - "name": "arg0"
     "type": "org.dom4j.Document"
   "return_type": "void"
   "signature": "[org.dom4j.datatype.SchemaParser].build(org.dom4j.Document)"
-- "exceptions":
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[org.dom4j.io.DOMSAXContentHandler].endElement(java.lang.String,java.lang.String,java.lang.String)"
+- "name": "[org.dom4j.io.DOMSAXContentHandler].endElement(java.lang.String,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/evo-inflector.yaml
+++ b/benchmark-sets/jvm-all/evo-inflector.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.atteo.evo.inflector.English].<init>(org.atteo.evo.inflector.English$MODE)"
+- "name": "[org.atteo.evo.inflector.English].<init>(org.atteo.evo.inflector.English$MODE)"
   "params":
   - "name": "arg0"
     "type": "org.atteo.evo.inflector.English$MODE"
   "return_type": "org.atteo.evo.inflector.English"
   "signature": "[org.atteo.evo.inflector.English].<init>(org.atteo.evo.inflector.English$MODE)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.atteo.evo.inflector.English].setMode(org.atteo.evo.inflector.English$MODE)"
+- "name": "[org.atteo.evo.inflector.English].setMode(org.atteo.evo.inflector.English$MODE)"
   "params":
   - "name": "arg0"
     "type": "org.atteo.evo.inflector.English$MODE"
   "return_type": "void"
   "signature": "[org.atteo.evo.inflector.English].setMode(org.atteo.evo.inflector.English$MODE)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.atteo.evo.inflector.English].plural(java.lang.String,int)"
+- "name": "[org.atteo.evo.inflector.English].plural(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -25,9 +19,7 @@
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.atteo.evo.inflector.English].plural(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.atteo.evo.inflector.English].getPlural(java.lang.String,int)"
+- "name": "[org.atteo.evo.inflector.English].getPlural(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -35,17 +27,13 @@
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.atteo.evo.inflector.English].getPlural(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.atteo.evo.inflector.English].plural(java.lang.String)"
+- "name": "[org.atteo.evo.inflector.English].plural(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.atteo.evo.inflector.English].plural(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.atteo.evo.inflector.English].getPlural(java.lang.String)"
+- "name": "[org.atteo.evo.inflector.English].getPlural(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/exp4j.yaml
+++ b/benchmark-sets/jvm-all/exp4j.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.ExpressionBuilder].<init>(java.lang.String)"
+- "name": "[net.objecthunter.exp4j.ExpressionBuilder].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "net.objecthunter.exp4j.ExpressionBuilder"
   "signature": "[net.objecthunter.exp4j.ExpressionBuilder].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set,boolean)"
+- "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -23,9 +19,7 @@
     "type": "boolean"
   "return_type": "net.objecthunter.exp4j.tokenizer.Tokenizer"
   "signature": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set)"
+- "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -37,9 +31,7 @@
     "type": "java.util.Set"
   "return_type": "net.objecthunter.exp4j.tokenizer.Tokenizer"
   "signature": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.ValidationResult].<init>(boolean,java.util.List)"
+- "name": "[net.objecthunter.exp4j.ValidationResult].<init>(boolean,java.util.List)"
   "params":
   - "name": "arg0"
     "type": "boolean"
@@ -47,17 +39,13 @@
     "type": "java.util.List"
   "return_type": "net.objecthunter.exp4j.ValidationResult"
   "signature": "[net.objecthunter.exp4j.ValidationResult].<init>(boolean,java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.FunctionToken].<init>(net.objecthunter.exp4j.function.Function)"
+- "name": "[net.objecthunter.exp4j.tokenizer.FunctionToken].<init>(net.objecthunter.exp4j.function.Function)"
   "params":
   - "name": "arg0"
     "type": "net.objecthunter.exp4j.function.Function"
   "return_type": "net.objecthunter.exp4j.tokenizer.FunctionToken"
   "signature": "[net.objecthunter.exp4j.tokenizer.FunctionToken].<init>(net.objecthunter.exp4j.function.Function)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.OperatorToken].<init>(net.objecthunter.exp4j.operator.Operator)"
+- "name": "[net.objecthunter.exp4j.tokenizer.OperatorToken].<init>(net.objecthunter.exp4j.operator.Operator)"
   "params":
   - "name": "arg0"
     "type": "net.objecthunter.exp4j.operator.Operator"

--- a/benchmark-sets/jvm-all/fastcsv.yaml
+++ b/benchmark-sets/jvm-all/fastcsv.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier,java.util.List)"
+- "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier,java.util.List)"
   "params":
   - "name": "arg0"
     "type": "de.siegmar.fastcsv.reader.FieldModifier"
@@ -9,9 +7,7 @@
     "type": "java.util.List"
   "return_type": "de.siegmar.fastcsv.reader.NamedCsvRecordHandler"
   "signature": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier,java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier,java.lang.String[])"
+- "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier,java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "de.siegmar.fastcsv.reader.FieldModifier"
@@ -19,33 +15,25 @@
     "type": "java.lang.String[]"
   "return_type": "de.siegmar.fastcsv.reader.NamedCsvRecordHandler"
   "signature": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier,java.lang.String[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(java.util.List)"
+- "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(java.util.List)"
   "params":
   - "name": "arg0"
     "type": "java.util.List"
   "return_type": "de.siegmar.fastcsv.reader.NamedCsvRecordHandler"
   "signature": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(java.lang.String[])"
+- "name": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.util.String[]"
   "return_type": "de.siegmar.fastcsv.reader.NamedCsvRecordHandler"
   "signature": "[de.siegmar.fastcsv.reader.NamedCsvRecordHandler].<init>(java.lang.String[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[de.siegmar.fastcsv.reader.CsvReader$lambda_stream_0__1].<init>(de.siegmar.fastcsv.reader.CsvReader)"
+- "name": "[de.siegmar.fastcsv.reader.CsvReader$lambda_stream_0__1].<init>(de.siegmar.fastcsv.reader.CsvReader)"
   "params":
   - "name": "arg0"
     "type": "de.siegmar.fastcsv.reader.CsvReader"
   "return_type": "de.siegmar.fastcsv.reader.CsvReader$lambda_stream_0__1"
   "signature": "[de.siegmar.fastcsv.reader.CsvReader$lambda_stream_0__1].<init>(de.siegmar.fastcsv.reader.CsvReader)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[de.siegmar.fastcsv.reader.CsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier)"
+- "name": "[de.siegmar.fastcsv.reader.CsvRecordHandler].<init>(de.siegmar.fastcsv.reader.FieldModifier)"
   "params":
   - "name": "arg0"
     "type": "de.siegmar.fastcsv.reader.FieldModifier"

--- a/benchmark-sets/jvm-all/fuzzywuzzy.yaml
+++ b/benchmark-sets/jvm-all/fuzzywuzzy.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
+- "name": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -13,9 +11,7 @@
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.model.BoundExtractedResult"
   "signature": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
+- "name": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -25,17 +21,13 @@
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.model.ExtractedResult"
   "signature": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
+- "name": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.Extractor"
   "signature": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
+- "name": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -43,9 +35,7 @@
     "type": "java.lang.String"
   "return_type": "me.xdrop.diffutils.structs.MatchingBlock[]"
   "signature": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
+- "name": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/g-oauth-java-client.yaml
+++ b/benchmark-sets/jvm-all/g-oauth-java-client.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.api.client.auth.oauth2.Credential].handleResponse(com.google.api.client.http.HttpRequest,com.google.api.client.http.HttpResponse,boolean)"
+- "name": "[com.google.api.client.auth.oauth2.Credential].handleResponse(com.google.api.client.http.HttpRequest,com.google.api.client.http.HttpResponse,boolean)"
   "params":
   - "name": "arg0"
     "type": "com.google.api.client.http.HttpRequest"
@@ -11,28 +9,19 @@
     "type": "boolean"
   "return_type": "boolean"
   "signature": "[com.google.api.client.auth.oauth2.Credential].handleResponse(com.google.api.client.http.HttpRequest,com.google.api.client.http.HttpResponse,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.api.client.auth.oauth2.Credential].intercept(com.google.api.client.http.HttpRequest)"
+- "name": "[com.google.api.client.auth.oauth2.Credential].intercept(com.google.api.client.http.HttpRequest)"
   "params":
   - "name": "arg0"
     "type": "com.google.api.client.http.HttpRequest"
   "return_type": "void"
   "signature": "[com.google.api.client.auth.oauth2.Credential].intercept(com.google.api.client.http.HttpRequest)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.api.client.auth.oauth.OAuthParameters].intercept(com.google.api.client.http.HttpRequest)"
+- "name": "[com.google.api.client.auth.oauth.OAuthParameters].intercept(com.google.api.client.http.HttpRequest)"
   "params":
   - "name": "arg0"
     "type": "com.google.api.client.http.HttpRequest"
   "return_type": "void"
   "signature": "[com.google.api.client.auth.oauth.OAuthParameters].intercept(com.google.api.client.http.HttpRequest)"
-- "exceptions":
-  - "java.security.GeneralSecurityException"
-  "is_jvm_static": false
-  "name": "[com.google.api.client.auth.oauth.OAuthParameters].computeSignature(java.lang.String,com.google.api.client.http.GenericUrl)"
+- "name": "[com.google.api.client.auth.oauth.OAuthParameters].computeSignature(java.lang.String,com.google.api.client.http.GenericUrl)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -40,17 +29,13 @@
     "type": "com.google.api.client.http.GenericUrl"
   "return_type": "void"
   "signature": "[com.google.api.client.auth.oauth.OAuthParameters].computeSignature(java.lang.String,com.google.api.client.http.GenericUrl)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.api.client.auth.oauth2.Credential].setFromTokenResponse(com.google.api.client.auth.oauth2.TokenResponse)"
+- "name": "[com.google.api.client.auth.oauth2.Credential].setFromTokenResponse(com.google.api.client.auth.oauth2.TokenResponse)"
   "params":
   - "name": "arg0"
     "type": "com.google.api.client.auth.oauth2.TokenResponse"
   "return_type": "com.google.api.client.auth.oauth2.Credential"
   "signature": "[com.google.api.client.auth.oauth2.Credential].setFromTokenResponse(com.google.api.client.auth.oauth2.TokenResponse)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.api.client.auth.oauth2.TokenRequest].<init>(com.google.api.client.http.HttpTransport,com.google.api.client.json.JsonFactory,com.google.api.client.http.GenericUrl,java.lang.String,java.lang.Class)"
+- "name": "[com.google.api.client.auth.oauth2.TokenRequest].<init>(com.google.api.client.http.HttpTransport,com.google.api.client.json.JsonFactory,com.google.api.client.http.GenericUrl,java.lang.String,java.lang.Class)"
   "params":
   - "name": "arg0"
     "type": "com.google.api.client.http.HttpTransport"

--- a/benchmark-sets/jvm-all/gson.yaml
+++ b/benchmark-sets/jvm-all/gson.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.gson.internal.bind.TreeTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
+- "name": "[com.google.gson.internal.bind.TreeTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "com.google.gson.stream.JsonWriter"
@@ -10,10 +7,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[com.google.gson.internal.bind.TreeTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.gson.internal.bind.ArrayTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
+- "name": "[com.google.gson.internal.bind.ArrayTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "com.google.gson.stream.JsonWriter"
@@ -21,10 +15,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[com.google.gson.internal.bind.ArrayTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": true
-  "name": "[com.google.gson.internal.Streams].write(com.google.gson.JsonElement,com.google.gson.stream.JsonWriter)"
+- "name": "[com.google.gson.internal.Streams].write(com.google.gson.JsonElement,com.google.gson.stream.JsonWriter)"
   "params":
   - "name": "arg0"
     "type": "com.google.gson.JsonElement"
@@ -32,10 +23,7 @@
     "type": "com.google.gson.stream.JsonWriter"
   "return_type": "void"
   "signature": "[com.google.gson.internal.Streams].write(com.google.gson.JsonElement,com.google.gson.stream.JsonWriter)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.gson.internal.bind.ObjectTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
+- "name": "[com.google.gson.internal.bind.ObjectTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "com.google.gson.stream.JsonWriter"
@@ -43,9 +31,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[com.google.gson.internal.bind.ObjectTypeAdapter].write(com.google.gson.stream.JsonWriter,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.gson.internal.Excluder].excludeField(java.lang.reflect.Field,boolean)"
+- "name": "[com.google.gson.internal.Excluder].excludeField(java.lang.reflect.Field,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.reflect.Field"
@@ -53,9 +39,7 @@
     "type": "boolean"
   "return_type": "boolean"
   "signature": "[com.google.gson.internal.Excluder].excludeField(java.lang.reflect.Field,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.gson.internal.Excluder].excludeClass(java.lang.Class<?>,boolean)"
+- "name": "[com.google.gson.internal.Excluder].excludeClass(java.lang.Class<?>,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"
@@ -63,10 +47,7 @@
     "type": "boolean"
   "return_type": "boolean"
   "signature": "[com.google.gson.internal.Excluder].excludeClass(java.lang.Class<?>,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.gson.stream.JsonWriter].value(java.lang.String)"
+- "name": "[com.google.gson.stream.JsonWriter].value(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/guava.yaml
+++ b/benchmark-sets/jvm-all/guava.yaml
@@ -1,47 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.collect.HashBiMap].forEach(java.util.function.BiConsumer<? super K,? super V>)"
+- "name": "[com.google.common.collect.HashBiMap].forEach(java.util.function.BiConsumer<? super K,? super V>)"
   "params":
   - "name": "arg0"
     "type": "java.util.function.BiConsumer<? super K,? super V>"
   "return_type": "void"
   "signature": "[com.google.common.collect.HashBiMap].forEach(java.util.function.BiConsumer<? super K,? super V>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.collect.ImmutableSortedMap].forEach(java.util.function.BiConsumer<? super K,? super V>)"
+- "name": "[com.google.common.collect.ImmutableSortedMap].forEach(java.util.function.BiConsumer<? super K,? super V>)"
   "params":
   - "name": "arg0"
     "type": "java.util.function.BiConsumer<? super K,? super V>"
   "return_type": "void"
   "signature": "[com.google.common.collect.ImmutableSortedMap].forEach(java.util.function.BiConsumer<? super K,? super V>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.collect.TreeRangeMap].remove(com.google.common.collect.Range<K>)"
+- "name": "[com.google.common.collect.TreeRangeMap].remove(com.google.common.collect.Range<K>)"
   "params":
   - "name": "arg0"
     "type": "com.google.common.collect.Range<K>"
   "return_type": "void"
   "signature": "[com.google.common.collect.TreeRangeMap].remove(com.google.common.collect.Range<K>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.collect.ConcurrentHashMultiset].toArray(java.lang.Object[])"
+- "name": "[com.google.common.collect.ConcurrentHashMultiset].toArray(java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
   "return_type": "java.lang.Object[]"
   "signature": "[com.google.common.collect.ConcurrentHashMultiset].toArray(java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.collect.TreeMultiset].forEachEntry(java.util.function.ObjIntConsumer<? super E>)"
+- "name": "[com.google.common.collect.TreeMultiset].forEachEntry(java.util.function.ObjIntConsumer<? super E>)"
   "params":
   - "name": "arg0"
     "type": "java.util.functionObjIntConsumer<? super E>"
   "return_type": "void"
   "signature": "[com.google.common.collect.TreeMultiset].forEachEntry(java.util.function.ObjIntConsumer<? super E>)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.google.common.collect.Iterables].removeIf(java.lang.Iterable<T>,com.google.common.base.Predicate<? super T>)"
+- "name": "[com.google.common.collect.Iterables].removeIf(java.lang.Iterable<T>,com.google.common.base.Predicate<? super T>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Iterable<T>"

--- a/benchmark-sets/jvm-all/hamcrest.yaml
+++ b/benchmark-sets/jvm-all/hamcrest.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hamcrest.beans.HasPropertyWithValue].matchesSafely(java.lang.Object,org.hamcrest.Description)"
+- "name": "[org.hamcrest.beans.HasPropertyWithValue].matchesSafely(java.lang.Object,org.hamcrest.Description)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -9,9 +7,7 @@
     "type": "org.hamcrest.Description"
   "return_type": "boolean"
   "signature": "[org.hamcrest.beans.HasPropertyWithValue].matchesSafely(java.lang.Object,org.hamcrest.Description)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hamcrest.core.Every].matchesSafely(java.lang.Iterable<? extends T>,org.hamcrest.Description)"
+- "name": "[org.hamcrest.core.Every].matchesSafely(java.lang.Iterable<? extends T>,org.hamcrest.Description)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Iterable<? extends T>"
@@ -19,9 +15,7 @@
     "type": "org.hamcrest.Description"
   "return_type": "boolean"
   "signature": "[org.hamcrest.core.Every].matchesSafely(java.lang.Iterable<? extends T>,org.hamcrest.Description)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hamcrest.collection.IsArray].describeMismatchSafely(java.lang.Object,org.hamcrest.Description)"
+- "name": "[org.hamcrest.collection.IsArray].describeMismatchSafely(java.lang.Object,org.hamcrest.Description)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -29,9 +23,7 @@
     "type": "org.hamcrest.Description"
   "return_type": "void"
   "signature": "[org.hamcrest.collection.IsArray].describeMismatchSafely(java.lang.Object,org.hamcrest.Description)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hamcrest.collection.IsArray].describeMismatchSafely(java.lang.Object[],org.hamcrest.Description)"
+- "name": "[org.hamcrest.collection.IsArray].describeMismatchSafely(java.lang.Object[],org.hamcrest.Description)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
@@ -39,17 +31,13 @@
     "type": "org.hamcrest.Description"
   "return_type": "void"
   "signature": "[org.hamcrest.collection.IsArray].describeMismatchSafely(java.lang.Object[],org.hamcrest.Description)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hamcrest.collection.IsArray].matchesSafely(java.lang.Object)"
+- "name": "[org.hamcrest.collection.IsArray].matchesSafely(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[org.hamcrest.collection.IsArray].matchesSafely(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hamcrest.collection.IsArray].matchesSafely(java.lang.Object[])"
+- "name": "[org.hamcrest.collection.IsArray].matchesSafely(java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"

--- a/benchmark-sets/jvm-all/hikaricp.yaml
+++ b/benchmark-sets/jvm-all/hikaricp.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.zaxxer.hikari.pool.HikariPool].<init>(com.zaxxer.hikari.HikariConfig)"
+- "name": "[com.zaxxer.hikari.pool.HikariPool].<init>(com.zaxxer.hikari.HikariConfig)"
   "params":
   - "name": "arg0"
     "type": "com.zaxxer.hikari.HikariConfig"
   "return_type": "com.zaxxer.hikari.pool.HikariPool"
   "signature": "[com.zaxxer.hikari.pool.HikariPool].<init>(com.zaxxer.hikari.HikariConfig)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.zaxxer.hikari.HikariDataSource].<init>(com.zaxxer.hikari.HikariConfig)"
+- "name": "[com.zaxxer.hikari.HikariDataSource].<init>(com.zaxxer.hikari.HikariConfig)"
   "params":
   - "name": "arg0"
     "type": "com.zaxxer.hikari.HikariConfig"
   "return_type": "com.zaxxer.hikari.HikariDataSource"
   "signature": "[com.zaxxer.hikari.HikariDataSource].<init>(com.zaxxer.hikari.HikariConfig)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.zaxxer.hikari.util.DriverDataSource].<init>(java.lang.String,java.lang.String,java.util.Properties,java.lang.String,java.lang.String)"
+- "name": "[com.zaxxer.hikari.util.DriverDataSource].<init>(java.lang.String,java.lang.String,java.util.Properties,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -31,25 +25,19 @@
     "type": "java.lang.String"
   "return_type": "com.zaxxer.hikari.util.DriverDataSource"
   "signature": "[com.zaxxer.hikari.util.DriverDataSource].<init>(java.lang.String,java.lang.String,java.util.Properties,java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.zaxxer.hikari.HikariConfig].<init>(java.util.Properties)"
+- "name": "[com.zaxxer.hikari.HikariConfig].<init>(java.util.Properties)"
   "params":
   - "name": "arg0"
     "type": "java.util.Properties"
   "return_type": "com.zaxxer.hikari.HikariConfig"
   "signature": "[com.zaxxer.hikari.HikariConfig].<init>(java.util.Properties)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.zaxxer.hikari.HikariConfig].<init>(java.lang.String)"
+- "name": "[com.zaxxer.hikari.HikariConfig].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.zaxxer.hikari.HikariConfig"
   "signature": "[com.zaxxer.hikari.HikariConfig].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.zaxxer.hikari.util.ConcurrentBag].<init>(com.zaxxer.hikari.util.ConcurrentBag$IBagStateListener)"
+- "name": "[com.zaxxer.hikari.util.ConcurrentBag].<init>(com.zaxxer.hikari.util.ConcurrentBag$IBagStateListener)"
   "params":
   - "name": "arg0"
     "type": "com.zaxxer.hikari.util.ConcurrentBag$IBagStateListener"

--- a/benchmark-sets/jvm-all/hsqldb.yaml
+++ b/benchmark-sets/jvm-all/hsqldb.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hsqldb.persist.DataSpaceManagerBlocks].<init>(org.hsqldb.persist.DataFileCache)"
+- "name": "[org.hsqldb.persist.DataSpaceManagerBlocks].<init>(org.hsqldb.persist.DataFileCache)"
   "params":
   - "name": "arg0"
     "type": "org.hsqldb.persist.DataFileCache"
   "return_type": "org.hsqldb.persist.DataSpaceManagerBlocks"
   "signature": "[org.hsqldb.persist.DataSpaceManagerBlocks].<init>(org.hsqldb.persist.DataFileCache)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hsqldb.TableDerived].<init>(org.hsqldb.Database,org.hsqldb.HsqlNameManager$HsqlName,int,org.hsqldb.QueryExpression,org.hsqldb.Expression,int,int)"
+- "name": "[org.hsqldb.TableDerived].<init>(org.hsqldb.Database,org.hsqldb.HsqlNameManager$HsqlName,int,org.hsqldb.QueryExpression,org.hsqldb.Expression,int,int)"
   "params":
   - "name": "arg0"
     "type": "org.hsqldb.Database"
@@ -27,9 +23,7 @@
     "type": "int"
   "return_type": "org.hsqldb.TableDerived"
   "signature": "[org.hsqldb.TableDerived].<init>(org.hsqldb.Database,org.hsqldb.HsqlNameManager$HsqlName,int,org.hsqldb.QueryExpression,org.hsqldb.Expression,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hsqldb.Table].<init>(org.hsqldb.Database,org.hsqldb.HsqlNameManager$HsqlName,int)"
+- "name": "[org.hsqldb.Table].<init>(org.hsqldb.Database,org.hsqldb.HsqlNameManager$HsqlName,int)"
   "params":
   - "name": "arg0"
     "type": "org.hsqldb.Database"
@@ -39,18 +33,13 @@
     "type": "int"
   "return_type": "org.hsqldb.Table"
   "signature": "[org.hsqldb.Table].<init>(org.hsqldb.Database,org.hsqldb.HsqlNameManager$HsqlName,int)"
-- "exceptions":
-  - "java.sql.SQLException"
-  "is_jvm_static": false
-  "name": "[org.hsqldb.jdbc.JDBCConnection].<init>(org.hsqldb.persist.HsqlProperties)"
+- "name": "[org.hsqldb.jdbc.JDBCConnection].<init>(org.hsqldb.persist.HsqlProperties)"
   "params":
   - "name": "arg0"
     "type": "org.hsqldb.persist.HsqlProperties"
   "return_type": "org.hsqldb.jdbc.JDBCConnection"
   "signature": "[org.hsqldb.jdbc.JDBCConnection].<init>(org.hsqldb.persist.HsqlProperties)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hsqldb.persist.DataFileCache].<init>(org.hsqldb.Database,java.lang.String,boolean)"
+- "name": "[org.hsqldb.persist.DataFileCache].<init>(org.hsqldb.Database,java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "org.hsqldb.Database"
@@ -60,9 +49,7 @@
     "type": "boolean"
   "return_type": "org.hsqldb.persist.DataFileCache"
   "signature": "[org.hsqldb.persist.DataFileCache].<init>(org.hsqldb.Database,java.lang.String,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.hsqldb.types.IntervalSecondData].<init>(long,long,org.hsqldb.types.IntervalType,boolean)"
+- "name": "[org.hsqldb.types.IntervalSecondData].<init>(long,long,org.hsqldb.types.IntervalType,boolean)"
   "params":
   - "name": "arg0"
     "type": "long"

--- a/benchmark-sets/jvm-all/httpcomponents-client.yaml
+++ b/benchmark-sets/jvm-all/httpcomponents-client.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseHeaderElement(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
+- "name": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseHeaderElement(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
   "params":
   - "name": "arg0"
     "type": "java.lang.CharSequence"
@@ -9,9 +7,7 @@
     "type": "org.apache.hc.core5.http.message.ParserCursor"
   "return_type": "org.apache.hc.core5.http.HeaderElement"
   "signature": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseHeaderElement(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseParameters(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
+- "name": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseParameters(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
   "params":
   - "name": "arg0"
     "type": "java.lang.CharSequence"
@@ -19,9 +15,7 @@
     "type": "org.apache.hc.core5.http.message.ParserCursor"
   "return_type": "org.apache.hc.core5.http.NameValuePair[]"
   "signature": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseParameters(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseNameValuePair(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
+- "name": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseNameValuePair(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
   "params":
   - "name": "arg0"
     "type": "java.lang.CharSequence"
@@ -29,9 +23,7 @@
     "type": "org.apache.hc.core5.http.message.ParserCursor"
   "return_type": "org.apache.hc.core5.http.NameValuePair"
   "signature": "[org.apache.hc.core5.http.message.BasicHeaderValueParser].parseNameValuePair(java.lang.CharSequence,org.apache.hc.core5.http.message.ParserCursor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.core5.util.Tokenizer].parseValue(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter)"
+- "name": "[org.apache.hc.core5.util.Tokenizer].parseValue(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter)"
   "params":
   - "name": "arg0"
     "type": "java.lang.CharSequence"
@@ -41,9 +33,7 @@
     "type": "org.apache.hc.core5.util.Tokenizer$Delimiter"
   "return_type": "java.lang.String"
   "signature": "[org.apache.hc.core5.util.Tokenizer].parseValue(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.core5.util.Tokenizer].parseToken(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter)"
+- "name": "[org.apache.hc.core5.util.Tokenizer].parseToken(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter)"
   "params":
   - "name": "arg0"
     "type": "java.lang.CharSequence"
@@ -53,9 +43,7 @@
     "type": "org.apache.hc.core5.util.Tokenizer$Delimiter"
   "return_type": "java.lang.String"
   "signature": "[org.apache.hc.core5.util.Tokenizer].parseToken(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.core5.util.Tokenizer].copyUnquotedContent(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter,java.lang.StringBuilder)"
+- "name": "[org.apache.hc.core5.util.Tokenizer].copyUnquotedContent(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter,java.lang.StringBuilder)"
   "params":
   - "name": "arg0"
     "type": "java.lang.CharSequence"
@@ -67,17 +55,13 @@
     "type": "java.lang.StringBuilder"
   "return_type": "void"
   "signature": "[org.apache.hc.core5.util.Tokenizer].copyUnquotedContent(java.lang.CharSequence,org.apache.hc.core5.util.Tokenizer$Cursor,org.apache.hc.core5.util.Tokenizer$Delimiter,java.lang.StringBuilder)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.client5.http.classic.methods.HttpPost].<init>(java.net.URI)"
+- "name": "[org.apache.hc.client5.http.classic.methods.HttpPost].<init>(java.net.URI)"
   "params":
   - "name": "arg0"
     "type": "java.net.URI"
   "return_type": "org.apache.hc.client5.http.classic.methods.HttpPost"
   "signature": "[org.apache.hc.client5.http.classic.methods.HttpPost].<init>(java.net.URI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.hc.client5.http.classic.methods.HttpUriRequestBase].<init>(java.lang.String,java.net.URI)"
+- "name": "[org.apache.hc.client5.http.classic.methods.HttpUriRequestBase].<init>(java.lang.String,java.net.URI)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/jackson-dataformat-xml.yaml
+++ b/benchmark-sets/jvm-all/jackson-dataformat-xml.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,javax.xml.stream.XMLStreamReader,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
+- "name": "[com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,javax.xml.stream.XMLStreamReader,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"
@@ -18,9 +15,7 @@
     "type": "com.fasterxml.jackson.dataformat.xml.XmlNameProcessor"
   "return_type": "com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser"
   "signature": "[com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,javax.xml.stream.XMLStreamReader,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.xml.XmlFactory].<init>(com.fasterxml.jackson.core.ObjectCodec,int,int,javax.xml.stream.XMLInputFactory,javax.xml.stream.XMLOutputFactory,java.lang.String)"
+- "name": "[com.fasterxml.jackson.dataformat.xml.XmlFactory].<init>(com.fasterxml.jackson.core.ObjectCodec,int,int,javax.xml.stream.XMLInputFactory,javax.xml.stream.XMLOutputFactory,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.ObjectCodec"
@@ -36,9 +31,7 @@
     "type": "java.lang.String"
   "return_type": "com.fasterxml.jackson.dataformat.xml.XmlFactory"
   "signature": "[com.fasterxml.jackson.dataformat.xml.XmlFactory].<init>(com.fasterxml.jackson.core.ObjectCodec,int,int,javax.xml.stream.XMLInputFactory,javax.xml.stream.XMLOutputFactory,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream].<init>(javax.xml.stream.XMLStreamReader,com.fasterxml.jackson.core.io.ContentReference,int,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
+- "name": "[com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream].<init>(javax.xml.stream.XMLStreamReader,com.fasterxml.jackson.core.io.ContentReference,int,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
   "params":
   - "name": "arg0"
     "type": "javax.xml.stream.XMLStreamReader"
@@ -50,9 +43,7 @@
     "type": "com.fasterxml.jackson.dataformat.xml.XmlNameProcessor"
   "return_type": "com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream"
   "signature": "[com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream].<init>(javax.xml.stream.XMLStreamReader,com.fasterxml.jackson.core.io.ContentReference,int,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.xml.util.XmlInfo].<init>(java.lang.Boolean,java.lang.String,java.lang.Boolean,java.lang.Boolean)"
+- "name": "[com.fasterxml.jackson.dataformat.xml.util.XmlInfo].<init>(java.lang.Boolean,java.lang.String,java.lang.Boolean,java.lang.Boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Boolean"
@@ -64,9 +55,7 @@
     "type": "java.lang.Boolean"
   "return_type": "com.fasterxml.jackson.dataformat.xml.util.XmlInfo"
   "signature": "[com.fasterxml.jackson.dataformat.xml.util.XmlInfo].<init>(java.lang.Boolean,java.lang.String,java.lang.Boolean,java.lang.Boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.xml.XmlMapper].<init>(com.fasterxml.jackson.dataformat.xml.XmlFactory,com.fasterxml.jackson.dataformat.xml.JacksonXmlModule)"
+- "name": "[com.fasterxml.jackson.dataformat.xml.XmlMapper].<init>(com.fasterxml.jackson.dataformat.xml.XmlFactory,com.fasterxml.jackson.dataformat.xml.JacksonXmlModule)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.xml.XmlFactory"
@@ -74,9 +63,7 @@
     "type": "com.fasterxml.jackson.dataformat.xml.JacksonXmlModule"
   "return_type": "com.fasterxml.jackson.dataformat.xml.XmlMapper"
   "signature": "[com.fasterxml.jackson.dataformat.xml.XmlMapper].<init>(com.fasterxml.jackson.dataformat.xml.XmlFactory,com.fasterxml.jackson.dataformat.xml.JacksonXmlModule)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,javax.xml.stream.XMLStreamWriter,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
+- "name": "[com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,javax.xml.stream.XMLStreamWriter,com.fasterxml.jackson.dataformat.xml.XmlNameProcessor)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"

--- a/benchmark-sets/jvm-all/jackson-dataformats-binary.yaml
+++ b/benchmark-sets/jvm-all/jackson-dataformats-binary.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.avro.schema.RecordVisitor].<init>(com.fasterxml.jackson.databind.SerializerProvider,com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.dataformat.avro.schema.VisitorFormatWrapperImpl)"
+- "name": "[com.fasterxml.jackson.dataformat.avro.schema.RecordVisitor].<init>(com.fasterxml.jackson.databind.SerializerProvider,com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.dataformat.avro.schema.VisitorFormatWrapperImpl)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.databind.SerializerProvider"
@@ -11,9 +9,7 @@
     "type": "com.fasterxml.jackson.dataformat.avro.schema.VisitorFormatWrapperImpl"
   "return_type": "com.fasterxml.jackson.dataformat.avro.schema.RecordVisitor"
   "signature": "[com.fasterxml.jackson.dataformat.avro.schema.RecordVisitor].<init>(com.fasterxml.jackson.databind.SerializerProvider,com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.dataformat.avro.schema.VisitorFormatWrapperImpl)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.FieldType)"
+- "name": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.FieldType)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement"
@@ -21,9 +17,7 @@
     "type": "com.fasterxml.jackson.dataformat.protobuf.schema.FieldType"
   "return_type": "com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField"
   "signature": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.FieldType)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufMessage)"
+- "name": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufMessage)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement"
@@ -31,9 +25,7 @@
     "type": "com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufMessage"
   "return_type": "com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField"
   "signature": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufMessage)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufEnum)"
+- "name": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufEnum)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement"
@@ -41,9 +33,7 @@
     "type": "com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufEnum"
   "return_type": "com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField"
   "signature": "[com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufField].<init>(com.fasterxml.jackson.dataformat.protobuf.protoparser.protoparser.FieldElement,com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufEnum)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.smile.SmileGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.OutputStream,byte[],int,boolean)"
+- "name": "[com.fasterxml.jackson.dataformat.smile.SmileGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.OutputStream,byte[],int,boolean)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"
@@ -63,9 +53,7 @@
     "type": "boolean"
   "return_type": "com.fasterxml.jackson.dataformat.smile.SmileGenerator"
   "signature": "[com.fasterxml.jackson.dataformat.smile.SmileGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.OutputStream,byte[],int,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.smile.SmileGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.OutputStream)"
+- "name": "[com.fasterxml.jackson.dataformat.smile.SmileGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.OutputStream)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"

--- a/benchmark-sets/jvm-all/jackson-dataformats-text.yaml
+++ b/benchmark-sets/jvm-all/jackson-dataformats-text.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder].<init>(com.fasterxml.jackson.core.io.IOContext,int,java.io.Writer,com.fasterxml.jackson.dataformat.csv.CsvSchema,boolean)"
+- "name": "[com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder].<init>(com.fasterxml.jackson.core.io.IOContext,int,java.io.Writer,com.fasterxml.jackson.dataformat.csv.CsvSchema,boolean)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"
@@ -15,9 +13,7 @@
     "type": "boolean"
   "return_type": "com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder"
   "signature": "[com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder].<init>(com.fasterxml.jackson.core.io.IOContext,int,java.io.Writer,com.fasterxml.jackson.dataformat.csv.CsvSchema,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder].<init>(com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder,com.fasterxml.jackson.dataformat.csv.CsvSchema)"
+- "name": "[com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder].<init>(com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder,com.fasterxml.jackson.dataformat.csv.CsvSchema)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder"
@@ -25,9 +21,7 @@
     "type": "com.fasterxml.jackson.dataformat.csv.CsvSchema"
   "return_type": "com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder"
   "signature": "[com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder].<init>(com.fasterxml.jackson.dataformat.csv.impl.CsvEncoder,com.fasterxml.jackson.dataformat.csv.CsvSchema)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.csv.CsvGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.Writer,com.fasterxml.jackson.dataformat.csv.CsvSchema)"
+- "name": "[com.fasterxml.jackson.dataformat.csv.CsvGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.Writer,com.fasterxml.jackson.dataformat.csv.CsvSchema)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"
@@ -43,10 +37,7 @@
     "type": "com.fasterxml.jackson.dataformat.csv.CsvSchema"
   "return_type": "com.fasterxml.jackson.dataformat.csv.CsvGenerator"
   "signature": "[com.fasterxml.jackson.dataformat.csv.CsvGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.core.ObjectCodec,java.io.Writer,com.fasterxml.jackson.dataformat.csv.CsvSchema)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.yaml.YAMLGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker,com.fasterxml.jackson.core.ObjectCodec,java.io.Writer,org.yaml.snakeyaml.DumperOptions$Version)"
+- "name": "[com.fasterxml.jackson.dataformat.yaml.YAMLGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker,com.fasterxml.jackson.core.ObjectCodec,java.io.Writer,org.yaml.snakeyaml.DumperOptions$Version)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.io.IOContext"
@@ -64,9 +55,7 @@
     "type": "org.yaml.snakeyamlDumperOptions$Version"
   "return_type": "com.fasterxml.jackson.dataformat.yaml.YAMLGenerator"
   "signature": "[com.fasterxml.jackson.dataformat.yaml.YAMLGenerator].<init>(com.fasterxml.jackson.core.io.IOContext,int,int,com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker,com.fasterxml.jackson.core.ObjectCodec,java.io.Writer,org.yaml.snakeyaml.DumperOptions$Version)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.csv.CsvSchema].<init>(com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[],int,char,int,int,char[],java.lang.String,char[],java.lang.String)"
+- "name": "[com.fasterxml.jackson.dataformat.csv.CsvSchema].<init>(com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[],int,char,int,int,char[],java.lang.String,char[],java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[]"
@@ -88,9 +77,7 @@
     "type": "java.lang.String"
   "return_type": "com.fasterxml.jackson.dataformat.csv.CsvSchema"
   "signature": "[com.fasterxml.jackson.dataformat.csv.CsvSchema].<init>(com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[],int,char,int,int,char[],java.lang.String,char[],java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.dataformat.csv.CsvSchema].<init>(com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[],int,char,int,int,char[],int,char[])"
+- "name": "[com.fasterxml.jackson.dataformat.csv.CsvSchema].<init>(com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[],int,char,int,int,char[],int,char[])"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.dataformat.csv.CsvSchema$Column[]"

--- a/benchmark-sets/jvm-all/jackson-datatype-joda.yaml
+++ b/benchmark-sets/jvm-all/jackson-datatype-joda.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat,java.util.Locale)"
+- "name": "[com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat,java.util.Locale)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat"
@@ -9,41 +7,31 @@
     "type": "java.util.Locale"
   "return_type": "com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat"
   "signature": "[com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaPeriodFormat,java.util.Locale)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.joda.ser.LocalDateSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
+- "name": "[com.fasterxml.jackson.datatype.joda.ser.LocalDateSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat"
   "return_type": "com.fasterxml.jackson.datatype.joda.ser.LocalDateSerializer"
   "signature": "[com.fasterxml.jackson.datatype.joda.ser.LocalDateSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat].<init>(org.joda.time.format.DateTimeFormatter)"
+- "name": "[com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat].<init>(org.joda.time.format.DateTimeFormatter)"
   "params":
   - "name": "arg0"
     "type": "org.joda.time.format.DateTimeFormatter"
   "return_type": "com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat"
   "signature": "[com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat].<init>(org.joda.time.format.DateTimeFormatter)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
+- "name": "[com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat"
   "return_type": "com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer"
   "signature": "[com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.joda.deser.PeriodDeserializer].<init>(boolean)"
+- "name": "[com.fasterxml.jackson.datatype.joda.deser.PeriodDeserializer].<init>(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "com.fasterxml.jackson.datatype.joda.deser.PeriodDeserializer"
   "signature": "[com.fasterxml.jackson.datatype.joda.deser.PeriodDeserializer].<init>(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.joda.ser.LocalTimeSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
+- "name": "[com.fasterxml.jackson.datatype.joda.ser.LocalTimeSerializer].<init>(com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat"

--- a/benchmark-sets/jvm-all/jackson-datatypes-collections.yaml
+++ b/benchmark-sets/jvm-all/jackson-datatypes-collections.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonDeserializer,com.google.common.collect.BoundType)"
+- "name": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonDeserializer,com.google.common.collect.BoundType)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.databind.JavaType"
@@ -11,9 +9,7 @@
     "type": "com.google.common.collect.BoundType"
   "return_type": "com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer"
   "signature": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonDeserializer,com.google.common.collect.BoundType)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.google.common.collect.BoundType,com.fasterxml.jackson.databind.JavaType)"
+- "name": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.google.common.collect.BoundType,com.fasterxml.jackson.databind.JavaType)"
   "params":
   - "name": "arg0"
     "type": "com.google.common.collect.BoundType"
@@ -21,9 +17,7 @@
     "type": "com.fasterxml.jackson.databind.JavaType"
   "return_type": "com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer"
   "signature": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.google.common.collect.BoundType,com.fasterxml.jackson.databind.JavaType)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonSerializer)"
+- "name": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonSerializer)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.databind.JavaType"
@@ -31,9 +25,7 @@
     "type": "com.fasterxml.jackson.databind.JsonSerializer"
   "return_type": "com.fasterxml.jackson.datatype.guava.ser.RangeSerializer"
   "signature": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonSerializer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonSerializer,com.fasterxml.jackson.datatype.guava.deser.util.RangeHelper$RangeProperties)"
+- "name": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonSerializer,com.fasterxml.jackson.datatype.guava.deser.util.RangeHelper$RangeProperties)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.databind.JavaType"
@@ -43,9 +35,7 @@
     "type": "com.fasterxml.jackson.datatype.guava.deser.util.RangeHelper$RangeProperties"
   "return_type": "com.fasterxml.jackson.datatype.guava.ser.RangeSerializer"
   "signature": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonSerializer,com.fasterxml.jackson.datatype.guava.deser.util.RangeHelper$RangeProperties)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonDeserializer)"
+- "name": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonDeserializer)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.databind.JavaType"
@@ -53,9 +43,7 @@
     "type": "com.fasterxml.jackson.databind.JsonDeserializer"
   "return_type": "com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer"
   "signature": "[com.fasterxml.jackson.datatype.guava.deser.RangeDeserializer].<init>(com.fasterxml.jackson.databind.JavaType,com.fasterxml.jackson.databind.JsonDeserializer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType)"
+- "name": "[com.fasterxml.jackson.datatype.guava.ser.RangeSerializer].<init>(com.fasterxml.jackson.databind.JavaType)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.databind.JavaType"

--- a/benchmark-sets/jvm-all/jakarta-mail-api.yaml
+++ b/benchmark-sets/jvm-all/jakarta-mail-api.yaml
@@ -1,17 +1,11 @@
 "functions":
-- "exceptions":
-  - "jakarta.mail.internet.ParseException"
-  "is_jvm_static": false
-  "name": "[jakarta.mail.internet.ParameterList].<init>(java.lang.String)"
+- "name": "[jakarta.mail.internet.ParameterList].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "jakarta.mail.internet.ParameterList"
   "signature": "[jakarta.mail.internet.ParameterList].<init>(java.lang.String)"
-- "exceptions":
-  - "jakarta.mail.internet.AddressException"
-  "is_jvm_static": false
-  "name": "[jakarta.mail.internet.InternetAddress].<init>(java.lang.String,boolean)"
+- "name": "[jakarta.mail.internet.InternetAddress].<init>(java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -19,45 +13,31 @@
     "type": "boolean"
   "return_type": "jakarta.mail.internet.InternetAddress"
   "signature": "[jakarta.mail.internet.InternetAddress].<init>(java.lang.String,boolean)"
-- "exceptions":
-  - "jakarta.mail.internet.AddressException"
-  "is_jvm_static": false
-  "name": "[jakarta.mail.internet.InternetAddress].<init>(java.lang.String)"
+- "name": "[jakarta.mail.internet.InternetAddress].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "jakarta.mail.internet.InternetAddress"
   "signature": "[jakarta.mail.internet.InternetAddress].<init>(java.lang.String)"
-- "exceptions":
-  - "jakarta.mail.internet.ParseException"
-  "is_jvm_static": false
-  "name": "[jakarta.mail.internet.ContentDisposition].<init>(java.lang.String)"
+- "name": "[jakarta.mail.internet.ContentDisposition].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "jakarta.mail.internet.ContentDisposition"
   "signature": "[jakarta.mail.internet.ContentDisposition].<init>(java.lang.String)"
-- "exceptions":
-  - "jakarta.mail.internet.ParseException"
-  "is_jvm_static": false
-  "name": "[jakarta.mail.internet.ContentType].<init>(java.lang.String)"
+- "name": "[jakarta.mail.internet.ContentType].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "jakarta.mail.internet.ContentType"
   "signature": "[jakarta.mail.internet.ContentType].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[jakarta.mail.URLName].<init>(java.lang.String)"
+- "name": "[jakarta.mail.URLName].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "jakarta.mail.URLName"
   "signature": "[jakarta.mail.URLName].<init>(java.lang.String)"
-- "exceptions":
-  - "jakarta.mail.MessagingException"
-  "is_jvm_static": false
-  "name": "[jakarta.mail.internet.MimeMessage].<init>(jakarta.mail.internet.MimeMessage)"
+- "name": "[jakarta.mail.internet.MimeMessage].<init>(jakarta.mail.internet.MimeMessage)"
   "params":
   - "name": "arg0"
     "type": "jakarta.mail.internet.MimeMessage"

--- a/benchmark-sets/jvm-all/janino.yaml
+++ b/benchmark-sets/jvm-all/janino.yaml
@@ -1,52 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.codehaus.janino.Unparser].unparseStatements(java.util.List<? extends BlockStatement>)"
+- "name": "[org.codehaus.janino.Unparser].unparseStatements(java.util.List<? extends BlockStatement>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<? extends BlockStatement>"
   "return_type": "void"
   "signature": "[org.codehaus.janino.Unparser].unparseStatements(java.util.List<? extends BlockStatement>)"
-- "exceptions":
-  - "org.codehaus.commons.compiler.CompileException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.janino.util.DeepCopier].copyCatchClauses(java.util.Collection<? extends CatchClause>)"
+- "name": "[org.codehaus.janino.util.DeepCopier].copyCatchClauses(java.util.Collection<? extends CatchClause>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Collection<? extends CatchClause>"
   "return_type": "java.util.List<CatchClause>"
   "signature": "[org.codehaus.janino.util.DeepCopier].copyCatchClauses(java.util.Collection<? extends CatchClause>)"
-- "exceptions":
-  - "org.codehaus.commons.compiler.CompileException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.janino.util.DeepCopier].copyResources(java.util.Collection<? extends Resource>)"
+- "name": "[org.codehaus.janino.util.DeepCopier].copyResources(java.util.Collection<? extends Resource>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Collection<? extends Resource>"
   "return_type": "java.util.List<Resource>"
   "signature": "[org.codehaus.janino.util.DeepCopier].copyResources(java.util.Collection<? extends Resource>)"
-- "exceptions":
-  - "org.codehaus.commons.compiler.CompileException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.janino.util.DeepCopier].copyBlockStatements(java.util.Collection<? extends BlockStatement>)"
+- "name": "[org.codehaus.janino.util.DeepCopier].copyBlockStatements(java.util.Collection<? extends BlockStatement>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Collection<? extends BlockStatement>"
   "return_type": "java.util.List<BlockStatement>"
   "signature": "[org.codehaus.janino.util.DeepCopier].copyBlockStatements(java.util.Collection<? extends BlockStatement>)"
-- "exceptions":
-  - "org.codehaus.commons.compiler.CompileException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.janino.util.DeepCopier].copyCatchClause(org.codehaus.janino.Java$CatchClause)"
+- "name": "[org.codehaus.janino.util.DeepCopier].copyCatchClause(org.codehaus.janino.Java$CatchClause)"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.janino.Java$CatchClause"
   "return_type": "org.codehaus.janino.Java$CatchClause"
   "signature": "[org.codehaus.janino.util.DeepCopier].copyCatchClause(org.codehaus.janino.Java$CatchClause)"
-- "exceptions":
-  - "org.codehaus.commons.compiler.CompileException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.janino.util.DeepCopier].copyStatements(java.util.Collection<? extends BlockStatement>)"
+- "name": "[org.codehaus.janino.util.DeepCopier].copyStatements(java.util.Collection<? extends BlockStatement>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Collection<? extends BlockStatement>"

--- a/benchmark-sets/jvm-all/jansi.yaml
+++ b/benchmark-sets/jvm-all/jansi.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.fusesource.jansi.io.AnsiOutputStream].<init>(java.io.OutputStream,org.fusesource.jansi.io.AnsiOutputStream$WidthSupplier,org.fusesource.jansi.AnsiMode,org.fusesource.jansi.io.AnsiProcessor,org.fusesource.jansi.AnsiType,org.fusesource.jansi.AnsiColors,java.nio.charset.Charset,org.fusesource.jansi.io.AnsiOutputStream$IoRunnable,org.fusesource.jansi.io.AnsiOutputStream$IoRunnable,boolean)"
+- "name": "[org.fusesource.jansi.io.AnsiOutputStream].<init>(java.io.OutputStream,org.fusesource.jansi.io.AnsiOutputStream$WidthSupplier,org.fusesource.jansi.AnsiMode,org.fusesource.jansi.io.AnsiProcessor,org.fusesource.jansi.AnsiType,org.fusesource.jansi.AnsiColors,java.nio.charset.Charset,org.fusesource.jansi.io.AnsiOutputStream$IoRunnable,org.fusesource.jansi.io.AnsiOutputStream$IoRunnable,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
@@ -25,10 +23,7 @@
     "type": "boolean"
   "return_type": "org.fusesource.jansi.io.AnsiOutputStream"
   "signature": "[org.fusesource.jansi.io.AnsiOutputStream].<init>(java.io.OutputStream,org.fusesource.jansi.io.AnsiOutputStream$WidthSupplier,org.fusesource.jansi.AnsiMode,org.fusesource.jansi.io.AnsiProcessor,org.fusesource.jansi.AnsiType,org.fusesource.jansi.AnsiColors,java.nio.charset.Charset,org.fusesource.jansi.io.AnsiOutputStream$IoRunnable,org.fusesource.jansi.io.AnsiOutputStream$IoRunnable,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream,long)"
+- "name": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream,long)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
@@ -36,10 +31,7 @@
     "type": "long"
   "return_type": "org.fusesource.jansi.io.WindowsAnsiProcessor"
   "signature": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream,long)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream,boolean)"
+- "name": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
@@ -47,18 +39,13 @@
     "type": "boolean"
   "return_type": "org.fusesource.jansi.io.WindowsAnsiProcessor"
   "signature": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream)"
+- "name": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
   "return_type": "org.fusesource.jansi.io.WindowsAnsiProcessor"
   "signature": "[org.fusesource.jansi.io.WindowsAnsiProcessor].<init>(java.io.OutputStream)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.fusesource.jansi.io.ColorsAnsiProcessor].<init>(java.io.OutputStream,org.fusesource.jansi.AnsiColors)"
+- "name": "[org.fusesource.jansi.io.ColorsAnsiProcessor].<init>(java.io.OutputStream,org.fusesource.jansi.AnsiColors)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
@@ -66,9 +53,7 @@
     "type": "org.fusesource.jansi.AnsiColors"
   "return_type": "org.fusesource.jansi.io.ColorsAnsiProcessor"
   "signature": "[org.fusesource.jansi.io.ColorsAnsiProcessor].<init>(java.io.OutputStream,org.fusesource.jansi.AnsiColors)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.fusesource.jansi.Ansi].<init>(int)"
+- "name": "[org.fusesource.jansi.Ansi].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"

--- a/benchmark-sets/jvm-all/java-diff-utils.yaml
+++ b/benchmark-sets/jvm-all/java-diff-utils.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.algorithm.myers.MyersDiffWithLinearSpace].computeDiff(java.util.List<T>,java.util.List<T>,com.github.difflib.algorithm.DiffAlgorithmListener)"
+- "name": "[com.github.difflib.algorithm.myers.MyersDiffWithLinearSpace].computeDiff(java.util.List<T>,java.util.List<T>,com.github.difflib.algorithm.DiffAlgorithmListener)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<T>"
@@ -11,9 +9,7 @@
     "type": "com.github.difflib.algorithm.DiffAlgorithmListener"
   "return_type": "java.util.List<Change>"
   "signature": "[com.github.difflib.algorithm.myers.MyersDiffWithLinearSpace].computeDiff(java.util.List<T>,java.util.List<T>,com.github.difflib.algorithm.DiffAlgorithmListener)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.algorithm.myers.PathNode].<init>(int,int,boolean,boolean,com.github.difflib.algorithm.myers.PathNode)"
+- "name": "[com.github.difflib.algorithm.myers.PathNode].<init>(int,int,boolean,boolean,com.github.difflib.algorithm.myers.PathNode)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -27,17 +23,13 @@
     "type": "com.github.difflib.algorithm.myers.PathNode"
   "return_type": "com.github.difflib.algorithm.myers.PathNode"
   "signature": "[com.github.difflib.algorithm.myers.PathNode].<init>(int,int,boolean,boolean,com.github.difflib.algorithm.myers.PathNode)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.text.DiffRow].equals(java.lang.Object)"
+- "name": "[com.github.difflib.text.DiffRow].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[com.github.difflib.text.DiffRow].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.patch.Chunk].<init>(int,java.util.List)"
+- "name": "[com.github.difflib.patch.Chunk].<init>(int,java.util.List)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -45,9 +37,7 @@
     "type": "java.util.List"
   "return_type": "com.github.difflib.patch.Chunk"
   "signature": "[com.github.difflib.patch.Chunk].<init>(int,java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.patch.Chunk].<init>(int,java.lang.Object[])"
+- "name": "[com.github.difflib.patch.Chunk].<init>(int,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -55,9 +45,7 @@
     "type": "java.lang.Object[]"
   "return_type": "com.github.difflib.patch.Chunk"
   "signature": "[com.github.difflib.patch.Chunk].<init>(int,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.patch.Chunk].equals(java.lang.Object)"
+- "name": "[com.github.difflib.patch.Chunk].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/java-uuid-generator.yaml
+++ b/benchmark-sets/jvm-all/java-uuid-generator.yaml
@@ -1,17 +1,11 @@
 "functions":
-- "exceptions":
-  - "java.lang.NumberFormatException"
-  "is_jvm_static": false
-  "name": "[com.fasterxml.uuid.EthernetAddress].<init>(java.lang.String)"
+- "name": "[com.fasterxml.uuid.EthernetAddress].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.fasterxml.uuid.EthernetAddress"
   "signature": "[com.fasterxml.uuid.EthernetAddress].<init>(java.lang.String)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.fasterxml.uuid.UUIDTimer].<init>(java.util.Random,com.fasterxml.uuid.TimestampSynchronizer,com.fasterxml.uuid.UUIDClock)"
+- "name": "[com.fasterxml.uuid.UUIDTimer].<init>(java.util.Random,com.fasterxml.uuid.TimestampSynchronizer,com.fasterxml.uuid.UUIDClock)"
   "params":
   - "name": "arg0"
     "type": "java.util.Random"
@@ -21,9 +15,7 @@
     "type": "com.fasterxml.uuid.UUIDClock"
   "return_type": "com.fasterxml.uuid.UUIDTimer"
   "signature": "[com.fasterxml.uuid.UUIDTimer].<init>(java.util.Random,com.fasterxml.uuid.TimestampSynchronizer,com.fasterxml.uuid.UUIDClock)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.uuid.impl.TimeBasedGenerator].<init>(com.fasterxml.uuid.EthernetAddress,com.fasterxml.uuid.UUIDTimer)"
+- "name": "[com.fasterxml.uuid.impl.TimeBasedGenerator].<init>(com.fasterxml.uuid.EthernetAddress,com.fasterxml.uuid.UUIDTimer)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.uuid.EthernetAddress"
@@ -31,9 +23,7 @@
     "type": "com.fasterxml.uuid.UUIDTimer"
   "return_type": "com.fasterxml.uuid.impl.TimeBasedGenerator"
   "signature": "[com.fasterxml.uuid.impl.TimeBasedGenerator].<init>(com.fasterxml.uuid.EthernetAddress,com.fasterxml.uuid.UUIDTimer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.uuid.impl.TimeBasedReorderedGenerator].<init>(com.fasterxml.uuid.EthernetAddress,com.fasterxml.uuid.UUIDTimer)"
+- "name": "[com.fasterxml.uuid.impl.TimeBasedReorderedGenerator].<init>(com.fasterxml.uuid.EthernetAddress,com.fasterxml.uuid.UUIDTimer)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.uuid.EthernetAddress"
@@ -41,9 +31,7 @@
     "type": "com.fasterxml.uuid.UUIDTimer"
   "return_type": "com.fasterxml.uuid.impl.TimeBasedReorderedGenerator"
   "signature": "[com.fasterxml.uuid.impl.TimeBasedReorderedGenerator].<init>(com.fasterxml.uuid.EthernetAddress,com.fasterxml.uuid.UUIDTimer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.fasterxml.uuid.impl.NameBasedGenerator].<init>(java.util.UUID,java.security.MessageDigest,com.fasterxml.uuid.UUIDType)"
+- "name": "[com.fasterxml.uuid.impl.NameBasedGenerator].<init>(java.util.UUID,java.security.MessageDigest,com.fasterxml.uuid.UUIDType)"
   "params":
   - "name": "arg0"
     "type": "java.util.UUID"
@@ -53,10 +41,7 @@
     "type": "com.fasterxml.uuid.UUIDType"
   "return_type": "com.fasterxml.uuid.impl.NameBasedGenerator"
   "signature": "[com.fasterxml.uuid.impl.NameBasedGenerator].<init>(java.util.UUID,java.security.MessageDigest,com.fasterxml.uuid.UUIDType)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.fasterxml.uuid.ext.FileBasedTimestampSynchronizer].<init>(java.io.File,java.io.File,long)"
+- "name": "[com.fasterxml.uuid.ext.FileBasedTimestampSynchronizer].<init>(java.io.File,java.io.File,long)"
   "params":
   - "name": "arg0"
     "type": "java.io.File"

--- a/benchmark-sets/jvm-all/javacpp.yaml
+++ b/benchmark-sets/jvm-all/javacpp.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.tools.InfoMap].put(org.bytedeco.javacpp.tools.Info)"
+- "name": "[org.bytedeco.javacpp.tools.InfoMap].put(org.bytedeco.javacpp.tools.Info)"
   "params":
   - "name": "arg0"
     "type": "org.bytedeco.javacpp.tools.Info"
   "return_type": "org.bytedeco.javacpp.tools.InfoMap"
   "signature": "[org.bytedeco.javacpp.tools.InfoMap].put(org.bytedeco.javacpp.tools.Info)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.tools.InfoMap].put(int,org.bytedeco.javacpp.tools.Info)"
+- "name": "[org.bytedeco.javacpp.tools.InfoMap].put(int,org.bytedeco.javacpp.tools.Info)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -17,33 +13,25 @@
     "type": "org.bytedeco.javacpp.tools.Info"
   "return_type": "org.bytedeco.javacpp.tools.InfoMap"
   "signature": "[org.bytedeco.javacpp.tools.InfoMap].put(int,org.bytedeco.javacpp.tools.Info)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.ClassProperties].<init>(java.util.Properties)"
+- "name": "[org.bytedeco.javacpp.ClassProperties].<init>(java.util.Properties)"
   "params":
   - "name": "arg0"
     "type": "java.util.Properties"
   "return_type": "org.bytedeco.javacpp.ClassProperties"
   "signature": "[org.bytedeco.javacpp.ClassProperties].<init>(java.util.Properties)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.BooleanPointer].<init>(java.nio.ByteBuffer)"
+- "name": "[org.bytedeco.javacpp.BooleanPointer].<init>(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"
   "return_type": "org.bytedeco.javacpp.BooleanPointer"
   "signature": "[org.bytedeco.javacpp.BooleanPointer].<init>(java.nio.ByteBuffer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.BytePointer].<init>(java.nio.ByteBuffer)"
+- "name": "[org.bytedeco.javacpp.BytePointer].<init>(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"
   "return_type": "org.bytedeco.javacpp.BytePointer"
   "signature": "[org.bytedeco.javacpp.BytePointer].<init>(java.nio.ByteBuffer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.DoublePointer].<init>(java.nio.DoubleBuffer)"
+- "name": "[org.bytedeco.javacpp.DoublePointer].<init>(java.nio.DoubleBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.DoubleBuffer"

--- a/benchmark-sets/jvm-all/javaparser.yaml
+++ b/benchmark-sets/jvm-all/javaparser.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.javaparser.JavaParser].parse(com.github.javaparser.ParseStart<N>,com.github.javaparser.Provider)"
+- "name": "[com.github.javaparser.JavaParser].parse(com.github.javaparser.ParseStart<N>,com.github.javaparser.Provider)"
   "params":
   - "name": "arg0"
     "type": "com.github.javaparser.ParseStart<N>"
@@ -9,9 +7,7 @@
     "type": "com.github.javaparser.Provider"
   "return_type": "com.github.javaparser.ParseResult<N>"
   "signature": "[com.github.javaparser.JavaParser].parse(com.github.javaparser.ParseStart<N>,com.github.javaparser.Provider)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt,java.lang.Void)"
+- "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt,java.lang.Void)"
   "params":
   - "name": "arg0"
     "type": "com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt"
@@ -19,9 +15,7 @@
     "type": "java.lang.Void"
   "return_type": "java.lang.Integer"
   "signature": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt,java.lang.Void)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.expr.ObjectCreationExpr,java.lang.Void)"
+- "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.expr.ObjectCreationExpr,java.lang.Void)"
   "params":
   - "name": "arg0"
     "type": "com.github.javaparser.ast.expr.ObjectCreationExpr"
@@ -29,9 +23,7 @@
     "type": "java.lang.Void"
   "return_type": "java.lang.Integer"
   "signature": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.expr.ObjectCreationExpr,java.lang.Void)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.type.ClassOrInterfaceType,java.lang.Void)"
+- "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.type.ClassOrInterfaceType,java.lang.Void)"
   "params":
   - "name": "arg0"
     "type": "com.github.javaparser.ast.type.ClassOrInterfaceType"
@@ -39,9 +31,7 @@
     "type": "java.lang.Void"
   "return_type": "java.lang.Integer"
   "signature": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.type.ClassOrInterfaceType,java.lang.Void)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.CompilationUnit,java.lang.Void)"
+- "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.CompilationUnit,java.lang.Void)"
   "params":
   - "name": "arg0"
     "type": "com.github.javaparser.ast.CompilationUnit"
@@ -49,9 +39,7 @@
     "type": "java.lang.Void"
   "return_type": "java.lang.Integer"
   "signature": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.CompilationUnit,java.lang.Void)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.ImportDeclaration,java.lang.Void)"
+- "name": "[com.github.javaparser.ast.visitor.HashCodeVisitor].visit(com.github.javaparser.ast.ImportDeclaration,java.lang.Void)"
   "params":
   - "name": "arg0"
     "type": "com.github.javaparser.ast.ImportDeclaration"

--- a/benchmark-sets/jvm-all/jaxb.yaml
+++ b/benchmark-sets/jvm-all/jaxb.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.glassfish.jaxb.core.api.impl.NameConverter$Standard].toVariableName(java.lang.String)"
+- "name": "[org.glassfish.jaxb.core.api.impl.NameConverter$Standard].toVariableName(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.glassfish.jaxb.core.api.impl.NameConverter$Standard].toVariableName(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.glassfish.jaxb.runtime.v2.model.impl.RuntimeModelBuilder].createTransducer(org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeNonElementRef)"
+- "name": "[org.glassfish.jaxb.runtime.v2.model.impl.RuntimeModelBuilder].createTransducer(org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeNonElementRef)"
   "params":
   - "name": "arg0"
     "type": "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeNonElementRef"
   "return_type": "org.glassfish.jaxb.runtime.v2.runtime.Transducer<V>"
   "signature": "[org.glassfish.jaxb.runtime.v2.model.impl.RuntimeModelBuilder].createTransducer(org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeNonElementRef)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.glassfish.jaxb.runtime.v2.model.impl.ModelBuilder].getClassInfo(java.lang.Object,boolean,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
+- "name": "[org.glassfish.jaxb.runtime.v2.model.impl.ModelBuilder].getClassInfo(java.lang.Object,boolean,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -27,9 +21,7 @@
     "type": "org.glassfish.jaxb.core.v2.model.'annotation'.Locatable"
   "return_type": "org.glassfish.jaxb.core.v2.model.core.NonElement"
   "signature": "[org.glassfish.jaxb.runtime.v2.model.impl.ModelBuilder].getClassInfo(java.lang.Object,boolean,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.glassfish.jaxb.runtime.v2.model.impl.ModelBuilder].getTypeInfo(java.lang.Object,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
+- "name": "[org.glassfish.jaxb.runtime.v2.model.impl.ModelBuilder].getTypeInfo(java.lang.Object,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -37,17 +29,13 @@
     "type": "org.glassfish.jaxb.core.v2.model.'annotation'.Locatable"
   "return_type": "org.glassfish.jaxb.core.v2.model.core.NonElement"
   "signature": "[org.glassfish.jaxb.runtime.v2.model.impl.ModelBuilder].getTypeInfo(java.lang.Object,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.glassfish.jaxb.runtime.v2.model.impl.ClassInfoImpl].getProperty(java.lang.String)"
+- "name": "[org.glassfish.jaxb.runtime.v2.model.impl.ClassInfoImpl].getProperty(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.glassfish.jaxb.core.v2.model.core.PropertyInfo<T,C>"
   "signature": "[org.glassfish.jaxb.runtime.v2.model.impl.ClassInfoImpl].getProperty(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.glassfish.jaxb.runtime.v2.model.impl.RuntimeModelBuilder].getClassInfo(java.lang.Class,boolean,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
+- "name": "[org.glassfish.jaxb.runtime.v2.model.impl.RuntimeModelBuilder].getClassInfo(java.lang.Class,boolean,org.glassfish.jaxb.core.v2.model.'annotation'.Locatable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class"

--- a/benchmark-sets/jvm-all/jdom.yaml
+++ b/benchmark-sets/jvm-all/jdom.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "org.jdom2.JDOMException"
-  "is_jvm_static": false
-  "name": "[org.jdom2.output.support.AbstractSAXOutputProcessor].processAsDocument(org.jdom2.output.support.SAXTarget,org.jdom2.output.Format,java.util.List<? extends Content>)"
+- "name": "[org.jdom2.output.support.AbstractSAXOutputProcessor].processAsDocument(org.jdom2.output.support.SAXTarget,org.jdom2.output.Format,java.util.List<? extends Content>)"
   "params":
   - "name": "arg0"
     "type": "org.jdom2.output.support.SAXTarget"
@@ -12,9 +9,7 @@
     "type": "java.util.List<? extends Content>"
   "return_type": "void"
   "signature": "[org.jdom2.output.support.AbstractSAXOutputProcessor].processAsDocument(org.jdom2.output.support.SAXTarget,org.jdom2.output.Format,java.util.List<? extends Content>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jdom2.output.support.AbstractFormattedWalker$MultiText].appendText(org.jdom2.output.support.AbstractFormattedWalker$Trim,java.lang.String)"
+- "name": "[org.jdom2.output.support.AbstractFormattedWalker$MultiText].appendText(org.jdom2.output.support.AbstractFormattedWalker$Trim,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.jdom2.output.support.AbstractFormattedWalker$Trim"
@@ -22,17 +17,13 @@
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.jdom2.output.support.AbstractFormattedWalker$MultiText].appendText(org.jdom2.output.support.AbstractFormattedWalker$Trim,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jdom2.Document].setDocType(org.jdom2.DocType)"
+- "name": "[org.jdom2.Document].setDocType(org.jdom2.DocType)"
   "params":
   - "name": "arg0"
     "type": "org.jdom2.DocType"
   "return_type": "org.jdom2.Document"
   "signature": "[org.jdom2.Document].setDocType(org.jdom2.DocType)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jdom2.output.support.AbstractFormattedWalker$MultiText].appendCDATA(org.jdom2.output.support.AbstractFormattedWalker$Trim,java.lang.String)"
+- "name": "[org.jdom2.output.support.AbstractFormattedWalker$MultiText].appendCDATA(org.jdom2.output.support.AbstractFormattedWalker$Trim,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.jdom2.output.support.AbstractFormattedWalker$Trim"
@@ -40,9 +31,7 @@
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.jdom2.output.support.AbstractFormattedWalker$MultiText].appendCDATA(org.jdom2.output.support.AbstractFormattedWalker$Trim,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.jdom2.output.Format].escapeText(org.jdom2.output.EscapeStrategy,java.lang.String,java.lang.String)"
+- "name": "[org.jdom2.output.Format].escapeText(org.jdom2.output.EscapeStrategy,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.jdom2.output.EscapeStrategy"
@@ -52,9 +41,7 @@
     "type": "String"
   "return_type": "java.lang.String"
   "signature": "[org.jdom2.output.Format].escapeText(org.jdom2.output.EscapeStrategy,java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jdom2.EntityRef].setSystemID(java.lang.String)"
+- "name": "[org.jdom2.EntityRef].setSystemID(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/jettison.yaml
+++ b/benchmark-sets/jvm-all/jettison.yaml
@@ -1,18 +1,11 @@
 "functions":
-- "exceptions":
-  - "org.codehaus.jettison.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.jettison.json.JSONObject].<init>(org.codehaus.jettison.json.JSONTokener)"
+- "name": "[org.codehaus.jettison.json.JSONObject].<init>(org.codehaus.jettison.json.JSONTokener)"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.jettison.json.JSONTokener"
   "return_type": "org.codehaus.jettison.json.JSONObject"
   "signature": "[org.codehaus.jettison.json.JSONObject].<init>(org.codehaus.jettison.json.JSONTokener)"
-- "exceptions":
-  - "org.codehaus.jettison.json.JSONException"
-  - "javax.xml.stream.XMLStreamException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.jettison.mapped.MappedXMLStreamReader].<init>(org.codehaus.jettison.json.JSONObject,org.codehaus.jettison.mapped.MappedNamespaceConvention)"
+- "name": "[org.codehaus.jettison.mapped.MappedXMLStreamReader].<init>(org.codehaus.jettison.json.JSONObject,org.codehaus.jettison.mapped.MappedNamespaceConvention)"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.jettison.json.JSONObject"
@@ -20,37 +13,25 @@
     "type": "org.codehaus.jettison.mapped.MappedNamespaceConvention"
   "return_type": "org.codehaus.jettison.mapped.MappedXMLStreamReader"
   "signature": "[org.codehaus.jettison.mapped.MappedXMLStreamReader].<init>(org.codehaus.jettison.json.JSONObject,org.codehaus.jettison.mapped.MappedNamespaceConvention)"
-- "exceptions":
-  - "org.codehaus.jettison.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.jettison.json.JSONArray].<init>(org.codehaus.jettison.json.JSONTokener)"
+- "name": "[org.codehaus.jettison.json.JSONArray].<init>(org.codehaus.jettison.json.JSONTokener)"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.jettison.json.JSONTokener"
   "return_type": "org.codehaus.jettison.json.JSONArray"
   "signature": "[org.codehaus.jettison.json.JSONArray].<init>(org.codehaus.jettison.json.JSONTokener)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.codehaus.jettison.mapped.MappedNamespaceConvention].<init>(org.codehaus.jettison.mapped.Configuration)"
+- "name": "[org.codehaus.jettison.mapped.MappedNamespaceConvention].<init>(org.codehaus.jettison.mapped.Configuration)"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.jettison.mapped.Configuration"
   "return_type": "org.codehaus.jettison.mapped.MappedNamespaceConvention"
   "signature": "[org.codehaus.jettison.mapped.MappedNamespaceConvention].<init>(org.codehaus.jettison.mapped.Configuration)"
-- "exceptions":
-  - "org.codehaus.jettison.json.JSONException"
-  - "javax.xml.stream.XMLStreamException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.jettison.mapped.MappedXMLStreamReader].<init>(org.codehaus.jettison.json.JSONObject)"
+- "name": "[org.codehaus.jettison.mapped.MappedXMLStreamReader].<init>(org.codehaus.jettison.json.JSONObject)"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.jettison.json.JSONObject"
   "return_type": "org.codehaus.jettison.mapped.MappedXMLStreamReader"
   "signature": "[org.codehaus.jettison.mapped.MappedXMLStreamReader].<init>(org.codehaus.jettison.json.JSONObject)"
-- "exceptions":
-  - "org.codehaus.jettison.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.jettison.json.JSONObject].<init>(org.codehaus.jettison.json.JSONObject,java.lang.String[])"
+- "name": "[org.codehaus.jettison.json.JSONObject].<init>(org.codehaus.jettison.json.JSONObject,java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "org.codehaus.jettison.json.JSONObject"

--- a/benchmark-sets/jvm-all/jfreechart.yaml
+++ b/benchmark-sets/jvm-all/jfreechart.yaml
@@ -1,49 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.jfree.chart.internal.CloneUtils].cloneMapValues(java.util.Map<K,V>)"
+- "name": "[org.jfree.chart.internal.CloneUtils].cloneMapValues(java.util.Map<K,V>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Map<K,V>"
   "return_type": "java.util.Map<K,V>"
   "signature": "[org.jfree.chart.internal.CloneUtils].cloneMapValues(java.util.Map<K,V>)"
-- "exceptions":
-  - "java.lang.CloneNotSupportedException"
-  "is_jvm_static": true
-  "name": "[org.jfree.chart.internal.CloneUtils].clone(java.lang.Object)"
+- "name": "[org.jfree.chart.internal.CloneUtils].clone(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[org.jfree.chart.internal.CloneUtils].clone(java.lang.Object)"
-- "exceptions":
-  - "java.lang.CloneNotSupportedException"
-  "is_jvm_static": true
-  "name": "[org.jfree.chart.internal.CloneUtils].copy(java.lang.Object)"
+- "name": "[org.jfree.chart.internal.CloneUtils].copy(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[org.jfree.chart.internal.CloneUtils].copy(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.jfree.chart.internal.CloneUtils].cloneList(java.util.List<T>)"
+- "name": "[org.jfree.chart.internal.CloneUtils].cloneList(java.util.List<T>)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<T>"
   "return_type": "java.util.List<T>"
   "signature": "[org.jfree.chart.internal.CloneUtils].cloneList(java.util.List<T>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jfree.chart.plot.PolarPlot].datasetChanged(org.jfree.data.general.DatasetChangeEvent)"
+- "name": "[org.jfree.chart.plot.PolarPlot].datasetChanged(org.jfree.data.general.DatasetChangeEvent)"
   "params":
   - "name": "arg0"
     "type": "org.jfree.data.general.DatasetChangeEvent"
   "return_type": "void"
   "signature": "[org.jfree.chart.plot.PolarPlot].datasetChanged(org.jfree.data.general.DatasetChangeEvent)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jfree.chart.plot.CombinedDomainXYPlot].datasetChanged(org.jfree.data.general.DatasetChangeEvent)"
+- "name": "[org.jfree.chart.plot.CombinedDomainXYPlot].datasetChanged(org.jfree.data.general.DatasetChangeEvent)"
   "params":
   - "name": "arg0"
     "type": "org.jfree.data.general.DatasetChangeEvent"

--- a/benchmark-sets/jvm-all/jimfs.yaml
+++ b/benchmark-sets/jvm-all/jimfs.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].newByteChannel(java.nio.file.Path,java.util.Set,java.nio.file.attribute.FileAttribute[])"
+- "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].newByteChannel(java.nio.file.Path,java.util.Set,java.nio.file.attribute.FileAttribute[])"
   "params":
   - "name": "arg0"
     "type": "java.nio.file.Path"
@@ -12,10 +9,7 @@
     "type": "java.nio.file.attribute.FileAttribute[]"
   "return_type": "java.nio.channels.SeekableByteChannel"
   "signature": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].newByteChannel(java.nio.file.Path,java.util.Set,java.nio.file.attribute.FileAttribute[])"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption[])"
+- "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption[])"
   "params":
   - "name": "arg0"
     "type": "java.nio.file.Path"
@@ -25,9 +19,7 @@
     "type": "java.nio.file.LinkOption[]"
   "return_type": "java.nio.file.attribute.BasicFileAttributes"
   "signature": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.jimfs.Configuration$Builder].setAttributeViews(java.lang.String,java.lang.String[])"
+- "name": "[com.google.common.jimfs.Configuration$Builder].setAttributeViews(java.lang.String,java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -35,10 +27,7 @@
     "type": "java.lang.String[]"
   "return_type": "com.google.common.jimfs.Configuration$Builder"
   "signature": "[com.google.common.jimfs.Configuration$Builder].setAttributeViews(java.lang.String,java.lang.String[])"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].newDirectoryStream(java.nio.file.Path,java.nio.file.DirectoryStream$Filter)"
+- "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].newDirectoryStream(java.nio.file.Path,java.nio.file.DirectoryStream$Filter)"
   "params":
   - "name": "arg0"
     "type": "java.nio.file.Path"
@@ -46,10 +35,7 @@
     "type": "java.nio.file.DirectoryStream$Filter"
   "return_type": "java.nio.file.DirectoryStream"
   "signature": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].newDirectoryStream(java.nio.file.Path,java.nio.file.DirectoryStream$Filter)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute[])"
+- "name": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute[])"
   "params":
   - "name": "arg0"
     "type": "java.nio.file.Path"
@@ -57,9 +43,7 @@
     "type": "java.nio.file.attribute.FileAttribute[]"
   "return_type": "void"
   "signature": "[com.google.common.jimfs.SystemJimfsFileSystemProvider].createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.common.jimfs.PathType$ParseResult].<init>(java.lang.String,java.lang.Iterable)"
+- "name": "[com.google.common.jimfs.PathType$ParseResult].<init>(java.lang.String,java.lang.Iterable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/joda-convert.yaml
+++ b/benchmark-sets/jvm-all/joda-convert.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.convert.StringConvert].<init>(boolean,org.joda.convert.StringConverterFactory[])"
+- "name": "[org.joda.convert.StringConvert].<init>(boolean,org.joda.convert.StringConverterFactory[])"
   "params":
   - "name": "arg0"
     "type": "boolean"
@@ -9,41 +7,31 @@
     "type": "org.joda.convert.StringConverterFactory[]"
   "return_type": "org.joda.convert.StringConvert"
   "signature": "[org.joda.convert.StringConvert].<init>(boolean,org.joda.convert.StringConverterFactory[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.convert.factory.NumericArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
+- "name": "[org.joda.convert.factory.NumericArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"
   "return_type": "org.joda.convert.StringConverter<?>"
   "signature": "[org.joda.convert.factory.NumericArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.convert.factory.NumericObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
+- "name": "[org.joda.convert.factory.NumericObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"
   "return_type": "org.joda.convert.StringConverter<?>"
   "signature": "[org.joda.convert.factory.NumericObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.convert.factory.BooleanObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
+- "name": "[org.joda.convert.factory.BooleanObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"
   "return_type": "org.joda.convert.StringConverter<?>"
   "signature": "[org.joda.convert.factory.BooleanObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.convert.factory.BooleanArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
+- "name": "[org.joda.convert.factory.BooleanArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"
   "return_type": "org.joda.convert.StringConverter<?>"
   "signature": "[org.joda.convert.factory.BooleanArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.convert.factory.CharObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
+- "name": "[org.joda.convert.factory.CharObjectArrayStringConverterFactory].findConverter(java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"

--- a/benchmark-sets/jvm-all/joda-time.yaml
+++ b/benchmark-sets/jvm-all/joda-time.yaml
@@ -1,24 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.time.format.DateTimeFormatter].print(org.joda.time.ReadableInstant)"
+- "name": "[org.joda.time.format.DateTimeFormatter].print(org.joda.time.ReadableInstant)"
   "params":
   - "name": "arg0"
     "type": "org.joda.time.ReadableInstant"
   "return_type": "java.lang.String"
   "signature": "[org.joda.time.format.DateTimeFormatter].print(org.joda.time.ReadableInstant)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.time.format.DateTimeFormatter].print(org.joda.time.ReadablePartial)"
+- "name": "[org.joda.time.format.DateTimeFormatter].print(org.joda.time.ReadablePartial)"
   "params":
   - "name": "arg0"
     "type": "org.joda.time.ReadablePartial"
   "return_type": "java.lang.String"
   "signature": "[org.joda.time.format.DateTimeFormatter].print(org.joda.time.ReadablePartial)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,org.joda.time.ReadableInstant)"
+- "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,org.joda.time.ReadableInstant)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Appendable"
@@ -26,10 +19,7 @@
     "type": "org.joda.time.ReadableInstant"
   "return_type": "void"
   "signature": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,org.joda.time.ReadableInstant)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,org.joda.time.ReadablePartial)"
+- "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,org.joda.time.ReadablePartial)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Appendable"
@@ -37,9 +27,7 @@
     "type": "org.joda.time.ReadablePartial"
   "return_type": "void"
   "signature": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,org.joda.time.ReadablePartial)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.StringBuffer,long)"
+- "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.StringBuffer,long)"
   "params":
   - "name": "arg0"
     "type": "java.lang.StringBuffer"
@@ -47,10 +35,7 @@
     "type": "long"
   "return_type": "void"
   "signature": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.StringBuffer,long)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,long)"
+- "name": "[org.joda.time.format.DateTimeFormatter].printTo(java.lang.Appendable,long)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Appendable"

--- a/benchmark-sets/jvm-all/jolt.yaml
+++ b/benchmark-sets/jvm-all/jolt.yaml
@@ -1,31 +1,23 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.bazaarvoice.jolt.common.Optional].equals(java.lang.Object)"
+- "name": "[com.bazaarvoice.jolt.common.Optional].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[com.bazaarvoice.jolt.common.Optional].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.bazaarvoice.jolt.common.pathelement.ArrayPathElement].<init>(java.lang.String)"
+- "name": "[com.bazaarvoice.jolt.common.pathelement.ArrayPathElement].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.bazaarvoice.jolt.common.pathelement.ArrayPathElement"
   "signature": "[com.bazaarvoice.jolt.common.pathelement.ArrayPathElement].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.bazaarvoice.jolt.common.pathelement.StarDoublePathElement].<init>(java.lang.String)"
+- "name": "[com.bazaarvoice.jolt.common.pathelement.StarDoublePathElement].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.bazaarvoice.jolt.common.pathelement.StarDoublePathElement"
   "signature": "[com.bazaarvoice.jolt.common.pathelement.StarDoublePathElement].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.bazaarvoice.jolt.modifier.spec.ModifierCompositeSpec].<init>(java.lang.String,java.util.Map,com.bazaarvoice.jolt.modifier.OpMode,com.bazaarvoice.jolt.modifier.TemplatrSpecBuilder)"
+- "name": "[com.bazaarvoice.jolt.modifier.spec.ModifierCompositeSpec].<init>(java.lang.String,java.util.Map,com.bazaarvoice.jolt.modifier.OpMode,com.bazaarvoice.jolt.modifier.TemplatrSpecBuilder)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -37,9 +29,7 @@
     "type": "com.bazaarvoice.jolt.modifier.TemplatrSpecBuilder"
   "return_type": "com.bazaarvoice.jolt.modifier.spec.ModifierCompositeSpec"
   "signature": "[com.bazaarvoice.jolt.modifier.spec.ModifierCompositeSpec].<init>(java.lang.String,java.util.Map,com.bazaarvoice.jolt.modifier.OpMode,com.bazaarvoice.jolt.modifier.TemplatrSpecBuilder)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.bazaarvoice.jolt.removr.spec.RemovrCompositeSpec].<init>(java.lang.String,java.util.Map)"
+- "name": "[com.bazaarvoice.jolt.removr.spec.RemovrCompositeSpec].<init>(java.lang.String,java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -47,9 +37,7 @@
     "type": "java.util.Map"
   "return_type": "com.bazaarvoice.jolt.removr.spec.RemovrCompositeSpec"
   "signature": "[com.bazaarvoice.jolt.removr.spec.RemovrCompositeSpec].<init>(java.lang.String,java.util.Map)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.bazaarvoice.jolt.common.pathelement.StarSinglePathElement].<init>(java.lang.String)"
+- "name": "[com.bazaarvoice.jolt.common.pathelement.StarSinglePathElement].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/joni.yaml
+++ b/benchmark-sets/jvm-all/joni.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joni.ast.EncloseNode].toString(int)"
+- "name": "[org.joni.ast.EncloseNode].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.joni.ast.EncloseNode].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joni.ast.CClassNode].clearNotFlag(org.joni.ScanEnvironment)"
+- "name": "[org.joni.ast.CClassNode].clearNotFlag(org.joni.ScanEnvironment)"
   "params":
   - "name": "arg0"
     "type": "org.joni.ScanEnvironment"
   "return_type": "void"
   "signature": "[org.joni.ast.CClassNode].clearNotFlag(org.joni.ScanEnvironment)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.joni.CodeRangeBuffer].andCodeRange1(org.joni.CodeRangeBuffer,org.joni.ScanEnvironment,int,int,int[],int)"
+- "name": "[org.joni.CodeRangeBuffer].andCodeRange1(org.joni.CodeRangeBuffer,org.joni.ScanEnvironment,int,int,int[],int)"
   "params":
   - "name": "arg0"
     "type": "org.joni.CodeRangeBuffer"
@@ -33,9 +27,7 @@
     "type": "int"
   "return_type": "org.joni.CodeRangeBuffer"
   "signature": "[org.joni.CodeRangeBuffer].andCodeRange1(org.joni.CodeRangeBuffer,org.joni.ScanEnvironment,int,int,int[],int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.joni.CodeRangeBuffer].addAllMultiByteRange(org.joni.ScanEnvironment,org.joni.CodeRangeBuffer)"
+- "name": "[org.joni.CodeRangeBuffer].addAllMultiByteRange(org.joni.ScanEnvironment,org.joni.CodeRangeBuffer)"
   "params":
   - "name": "arg0"
     "type": "org.joni.ScanEnvironment"
@@ -43,17 +35,13 @@
     "type": "org.joni.CodeRangeBuffer"
   "return_type": "org.joni.CodeRangeBuffer"
   "signature": "[org.joni.CodeRangeBuffer].addAllMultiByteRange(org.joni.ScanEnvironment,org.joni.CodeRangeBuffer)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.joni.Option].toString(int)"
+- "name": "[org.joni.Option].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.joni.Option].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joni.Regex].<init>(byte[],int,int,int,int,org.jcodings.Encoding,org.joni.Syntax,org.joni.WarnCallback)"
+- "name": "[org.joni.Regex].<init>(byte[],int,int,int,int,org.jcodings.Encoding,org.joni.Syntax,org.joni.WarnCallback)"
   "params":
   - "name": "arg0"
     "type": "byte[]"

--- a/benchmark-sets/jvm-all/jooq.yaml
+++ b/benchmark-sets/jvm-all/jooq.yaml
@@ -1,47 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jooq.codegen.JavaGenerator].generate0(org.jooq.meta.Database)"
+- "name": "[org.jooq.codegen.JavaGenerator].generate0(org.jooq.meta.Database)"
   "params":
   - "name": "arg0"
     "type": "org.jooq.meta.Database"
   "return_type": "void"
   "signature": "[org.jooq.codegen.JavaGenerator].generate0(org.jooq.meta.Database)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jooq.codegen.XMLGenerator].generate0(org.jooq.meta.Database)"
+- "name": "[org.jooq.codegen.XMLGenerator].generate0(org.jooq.meta.Database)"
   "params":
   - "name": "arg0"
     "type": "org.jooq.meta.Database"
   "return_type": "void"
   "signature": "[org.jooq.codegen.XMLGenerator].generate0(org.jooq.meta.Database)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jooq.impl.TableImpl].as(org.jooq.Name)"
+- "name": "[org.jooq.impl.TableImpl].as(org.jooq.Name)"
   "params":
   - "name": "arg0"
     "type": "org.jooq.Name"
   "return_type": "org.jooq.Table<R>"
   "signature": "[org.jooq.impl.TableImpl].as(org.jooq.Name)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jooq.SchemaMapping].map(org.jooq.Table<R>)"
+- "name": "[org.jooq.SchemaMapping].map(org.jooq.Table<R>)"
   "params":
   - "name": "arg0"
     "type": "org.jooq.Table<R>"
   "return_type": "org.jooq.Table<R>"
   "signature": "[org.jooq.SchemaMapping].map(org.jooq.Table<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jooq.SchemaMapping].map(org.jooq.UDT<R>)"
+- "name": "[org.jooq.SchemaMapping].map(org.jooq.UDT<R>)"
   "params":
   - "name": "arg0"
     "type": "org.jooq.UDT<R>"
   "return_type": "org.jooq.UDT<R>"
   "signature": "[org.jooq.SchemaMapping].map(org.jooq.UDT<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jooq.impl.DefaultDSLContext].connectionResult(org.jooq.ConnectionCallable<T>)"
+- "name": "[org.jooq.impl.DefaultDSLContext].connectionResult(org.jooq.ConnectionCallable<T>)"
   "params":
   - "name": "arg0"
     "type": "org.jooq.ConnectionCallable<T>"

--- a/benchmark-sets/jvm-all/jopt-simple.yaml
+++ b/benchmark-sets/jvm-all/jopt-simple.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[joptsimple.internal.Reflection].convertWith(joptsimple.ValueConverter<V>,java.lang.String)"
+- "name": "[joptsimple.internal.Reflection].convertWith(joptsimple.ValueConverter<V>,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "joptsimple.ValueConverter<V>"
@@ -9,17 +7,13 @@
     "type": "java.lang.String"
   "return_type": "java.lang.Object"
   "signature": "[joptsimple.internal.Reflection].convertWith(joptsimple.ValueConverter<V>,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[joptsimple.util.PathConverter].convert(java.lang.String)"
+- "name": "[joptsimple.util.PathConverter].convert(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.nio.file.Path"
   "signature": "[joptsimple.util.PathConverter].convert(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[jdk.internal.reflect.Reflection].filterMethods(java.lang.Class,java.lang.reflect.Method[])"
+- "name": "[jdk.internal.reflect.Reflection].filterMethods(java.lang.Class,java.lang.reflect.Method[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class"
@@ -27,25 +21,19 @@
     "type": "java.lang.reflect.Method[]"
   "return_type": "java.lang.reflect.Method[]"
   "signature": "[jdk.internal.reflect.Reflection].filterMethods(java.lang.Class,java.lang.reflect.Method[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[joptsimple.OptionParser].<init>(boolean)"
+- "name": "[joptsimple.OptionParser].<init>(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "joptsimple.OptionParser"
   "signature": "[joptsimple.OptionParser].<init>(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[joptsimple.util.DateConverter].convert(java.lang.String)"
+- "name": "[joptsimple.util.DateConverter].convert(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.util.Date"
   "signature": "[joptsimple.util.DateConverter].convert(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[joptsimple.util.RegexMatcher].convert(java.lang.String)"
+- "name": "[joptsimple.util.RegexMatcher].convert(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/jsch.yaml
+++ b/benchmark-sets/jvm-all/jsch.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "com.jcraft.jsch.JSchException"
-  "is_jvm_static": false
-  "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,java.lang.String,int,byte[],java.lang.String)"
+- "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,java.lang.String,int,byte[],java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -16,10 +13,7 @@
     "type": "java.lang.String"
   "return_type": "com.jcraft.jsch.HostKey"
   "signature": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,java.lang.String,int,byte[],java.lang.String)"
-- "exceptions":
-  - "com.jcraft.jsch.JSchException"
-  "is_jvm_static": false
-  "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,int,byte[],java.lang.String)"
+- "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,int,byte[],java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -31,28 +25,19 @@
     "type": "java.lang.String"
   "return_type": "com.jcraft.jsch.HostKey"
   "signature": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,int,byte[],java.lang.String)"
-- "exceptions":
-  - "com.jcraft.jsch.AgentProxyException"
-  "is_jvm_static": false
-  "name": "[com.jcraft.jsch.SSHAgentConnector].<init>(java.nio.file.Path)"
+- "name": "[com.jcraft.jsch.SSHAgentConnector].<init>(java.nio.file.Path)"
   "params":
   - "name": "arg0"
     "type": "java.nio.file.Path"
   "return_type": "com.jcraft.jsch.SSHAgentConnector"
   "signature": "[com.jcraft.jsch.SSHAgentConnector].<init>(java.nio.file.Path)"
-- "exceptions":
-  - "com.jcraft.jsch.AgentProxyException"
-  "is_jvm_static": false
-  "name": "[com.jcraft.jsch.SSHAgentConnector].<init>(com.jcraft.jsch.USocketFactory)"
+- "name": "[com.jcraft.jsch.SSHAgentConnector].<init>(com.jcraft.jsch.USocketFactory)"
   "params":
   - "name": "arg0"
     "type": "USocketFactory"
   "return_type": "com.jcraft.jsch.SSHAgentConnector"
   "signature": "[com.jcraft.jsch.SSHAgentConnector].<init>(com.jcraft.jsch.USocketFactory)"
-- "exceptions":
-  - "com.jcraft.jsch.JSchException"
-  "is_jvm_static": false
-  "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,int,byte[])"
+- "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,int,byte[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -62,10 +47,7 @@
     "type": "byte[]"
   "return_type": "com.jcraft.jsch.HostKey"
   "signature": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,int,byte[])"
-- "exceptions":
-  - "com.jcraft.jsch.JSchException"
-  "is_jvm_static": false
-  "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,byte[])"
+- "name": "[com.jcraft.jsch.HostKey].<init>(java.lang.String,byte[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/jsemver.yaml
+++ b/benchmark-sets/jvm-all/jsemver.yaml
@@ -1,31 +1,23 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.Version$Builder].<init>(java.lang.String)"
+- "name": "[com.github.zafarkhaja.semver.Version$Builder].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.github.zafarkhaja.semver.Version$Builder"
   "signature": "[com.github.zafarkhaja.semver.Version$Builder].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.util.Stream].<init>(java.lang.Object[])"
+- "name": "[com.github.zafarkhaja.semver.util.Stream].<init>(java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
   "return_type": "com.github.zafarkhaja.semver.util.Stream"
   "signature": "[com.github.zafarkhaja.semver.util.Stream].<init>(java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.expr.CompositeExpression].<init>(com.github.zafarkhaja.semver.expr.Expression)"
+- "name": "[com.github.zafarkhaja.semver.expr.CompositeExpression].<init>(com.github.zafarkhaja.semver.expr.Expression)"
   "params":
   - "name": "arg0"
     "type": "com.github.zafarkhaja.semver.expr.Expression"
   "return_type": "com.github.zafarkhaja.semver.expr.CompositeExpression"
   "signature": "[com.github.zafarkhaja.semver.expr.CompositeExpression].<init>(com.github.zafarkhaja.semver.expr.Expression)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.github.zafarkhaja.semver.Version].isValid(java.lang.String,boolean)"
+- "name": "[com.github.zafarkhaja.semver.Version].isValid(java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -33,9 +25,7 @@
     "type": "boolean"
   "return_type": "boolean"
   "signature": "[com.github.zafarkhaja.semver.Version].isValid(java.lang.String,boolean)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.github.zafarkhaja.semver.Version].parse(java.lang.String,boolean)"
+- "name": "[com.github.zafarkhaja.semver.Version].parse(java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -43,9 +33,7 @@
     "type": "boolean"
   "return_type": "com.github.zafarkhaja.semver.Version"
   "signature": "[com.github.zafarkhaja.semver.Version].parse(java.lang.String,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.util.Stream].consume(com.github.zafarkhaja.semver.util.Stream$ElementType[])"
+- "name": "[com.github.zafarkhaja.semver.util.Stream].consume(com.github.zafarkhaja.semver.util.Stream$ElementType[])"
   "params":
   - "name": "arg0"
     "type": "com.github.zafarkhaja.semver.util.Stream$ElementType[]"

--- a/benchmark-sets/jvm-all/jsign.yaml
+++ b/benchmark-sets/jvm-all/jsign.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.jsign.json-io.util.io.JsonWriter].<init>(java.io.OutputStream,java.util.Map)"
+- "name": "[net.jsign.json-io.util.io.JsonWriter].<init>(java.io.OutputStream,java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
@@ -9,35 +7,25 @@
     "type": "java.util.Map"
   "return_type": "net.jsign.json-io.util.io.JsonWriter"
   "signature": "[net.jsign.json-io.util.io.JsonWriter].<init>(java.io.OutputStream,java.util.Map)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.jsign.mscab.MSCabinetFile].<init>(java.nio.channels.SeekableByteChannel)"
+- "name": "[net.jsign.mscab.MSCabinetFile].<init>(java.nio.channels.SeekableByteChannel)"
   "params":
   - "name": "arg0"
     "type": "java.nio.channels.SeekableByteChannel"
   "return_type": "net.jsign.mscab.MSCabinetFile"
   "signature": "[net.jsign.mscab.MSCabinetFile].<init>(java.nio.channels.SeekableByteChannel)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.jsign.json-io.util.io.JsonWriter].<init>(java.io.OutputStream)"
+- "name": "[net.jsign.json-io.util.io.JsonWriter].<init>(java.io.OutputStream)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
   "return_type": "net.jsign.json-io.util.io.JsonWriter"
   "signature": "[net.jsign.json-io.util.io.JsonWriter].<init>(java.io.OutputStream)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.jsign.navx.NAVXFile].createIndirectData(net.jsign.DigestAlgorithm)"
+- "name": "[net.jsign.navx.NAVXFile].createIndirectData(net.jsign.DigestAlgorithm)"
   "params":
   - "name": "arg0"
     "type": "net.jsign.DigestAlgorithm"
   "return_type": "net.jsign.bouncycastle.asn1.ASN1Object"
   "signature": "[net.jsign.navx.NAVXFile].createIndirectData(net.jsign.DigestAlgorithm)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.jsign.jca.GaraSignCredentials].<init>(java.lang.String,java.lang.String,java.lang.String,java.lang.String)"
+- "name": "[net.jsign.jca.GaraSignCredentials].<init>(java.lang.String,java.lang.String,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -49,10 +37,7 @@
     "type": "java.lang.String"
   "return_type": "net.jsign.jca.GaraSignCredentials"
   "signature": "[net.jsign.jca.GaraSignCredentials].<init>(java.lang.String,java.lang.String,java.lang.String,java.lang.String)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.jsign.mscab.MSCabinetFile].<init>(java.io.File)"
+- "name": "[net.jsign.mscab.MSCabinetFile].<init>(java.io.File)"
   "params":
   - "name": "arg0"
     "type": "java.io.File"

--- a/benchmark-sets/jvm-all/json-java.yaml
+++ b/benchmark-sets/jvm-all/json-java.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].toString(int)"
+- "name": "[org.json.JSONArray].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.json.JSONArray].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].<init>(java.lang.Object)"
+- "name": "[org.json.JSONArray].<init>(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/json-sanitizer.yaml
+++ b/benchmark-sets/jvm-all/json-sanitizer.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.google.json.EvalMinifier].minify(java.lang.String,int)"
+- "name": "[com.google.json.EvalMinifier].minify(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.google.json.EvalMinifier].minify(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.google.json.JsonSanitizer].sanitize(java.lang.String,int)"
+- "name": "[com.google.json.JsonSanitizer].sanitize(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/json-smart-v2.yaml
+++ b/benchmark-sets/jvm-all/json-smart-v2.yaml
@@ -1,17 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.minidev.json.writer.UpdaterMapper].convert(java.lang.Object)"
+- "name": "[net.minidev.json.writer.UpdaterMapper].convert(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[net.minidev.json.writer.UpdaterMapper].convert(java.lang.Object)"
-- "exceptions":
-  - "net.minidev.json.parser.ParseException"
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.minidev.json.writer.MapperRemapped].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
+- "name": "[net.minidev.json.writer.MapperRemapped].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -21,11 +15,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[net.minidev.json.writer.MapperRemapped].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
-- "exceptions":
-  - "net.minidev.json.parser.ParseException"
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.minidev.json.writer.UpdaterMapper].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
+- "name": "[net.minidev.json.writer.UpdaterMapper].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -35,11 +25,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[net.minidev.json.writer.UpdaterMapper].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
-- "exceptions":
-  - "net.minidev.json.parser.ParseException"
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.minidev.json.writer.UpdaterMapper].addValue(java.lang.Object,java.lang.Object)"
+- "name": "[net.minidev.json.writer.UpdaterMapper].addValue(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -47,10 +33,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[net.minidev.json.writer.UpdaterMapper].addValue(java.lang.Object,java.lang.Object)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.minidev.json.writer.CompessorMapper].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
+- "name": "[net.minidev.json.writer.CompessorMapper].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -60,10 +43,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[net.minidev.json.writer.CompessorMapper].setValue(java.lang.Object,java.lang.String,java.lang.Object)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.minidev.json.writer.CompessorMapper].addValue(java.lang.Object,java.lang.Object)"
+- "name": "[net.minidev.json.writer.CompessorMapper].addValue(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/jsonp-api.yaml
+++ b/benchmark-sets/jvm-all/jsonp-api.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[ee.jakarta.tck.jsonp.common.MyBufferedReader].read(char[],int,int)"
+- "name": "[ee.jakarta.tck.jsonp.common.MyBufferedReader].read(char[],int,int)"
   "params":
   - "name": "arg0"
     "type": "char[]"
@@ -12,10 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "[ee.jakarta.tck.jsonp.common.MyBufferedReader].read(char[],int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[ee.jakarta.tck.jsonp.common.MyBufferedInputStream].read(byte[],int,int)"
+- "name": "[ee.jakarta.tck.jsonp.common.MyBufferedInputStream].read(byte[],int,int)"
   "params":
   - "name": "arg0"
     "type": "byte[]"
@@ -25,10 +19,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "[ee.jakarta.tck.jsonp.common.MyBufferedInputStream].read(byte[],int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[ee.jakarta.tck.jsonp.common.MyBufferedWriter].write(char[],int,int)"
+- "name": "[ee.jakarta.tck.jsonp.common.MyBufferedWriter].write(char[],int,int)"
   "params":
   - "name": "arg0"
     "type": "char[]"
@@ -38,9 +29,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "[ee.jakarta.tck.jsonp.common.MyBufferedWriter].write(char[],int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[ee.jakarta.tck.jsonp.common.MyBufferedReader].<init>(java.io.Reader,int,boolean)"
+- "name": "[ee.jakarta.tck.jsonp.common.MyBufferedReader].<init>(java.io.Reader,int,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.Reader"
@@ -50,9 +39,7 @@
     "type": "boolean"
   "return_type": "ee.jakarta.tck.jsonp.common.MyBufferedReader"
   "signature": "[ee.jakarta.tck.jsonp.common.MyBufferedReader].<init>(java.io.Reader,int,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[ee.jakarta.tck.jsonp.common.MyBufferedWriter].<init>(java.io.Writer,int,boolean)"
+- "name": "[ee.jakarta.tck.jsonp.common.MyBufferedWriter].<init>(java.io.Writer,int,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.Writer"
@@ -62,9 +49,7 @@
     "type": "boolean"
   "return_type": "ee.jakarta.tck.jsonp.common.MyBufferedWriter"
   "signature": "[ee.jakarta.tck.jsonp.common.MyBufferedWriter].<init>(java.io.Writer,int,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[ee.jakarta.tck.jsonp.common.MyJsonLocation].<init>(long,long,long)"
+- "name": "[ee.jakarta.tck.jsonp.common.MyJsonLocation].<init>(long,long,long)"
   "params":
   - "name": "arg0"
     "type": "long"

--- a/benchmark-sets/jvm-all/jsonpath.yaml
+++ b/benchmark-sets/jvm-all/jsonpath.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.jayway.jsonpath.spi.json.JakartaJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
+- "name": "[com.jayway.jsonpath.spi.json.JakartaJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -11,9 +9,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[com.jayway.jsonpath.spi.json.JakartaJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.jayway.jsonpath.spi.mapper.TapestryMappingProvider].map(java.lang.Object,java.lang.Class<T>,com.jayway.jsonpath.Configuration)"
+- "name": "[com.jayway.jsonpath.spi.mapper.TapestryMappingProvider].map(java.lang.Object,java.lang.Class<T>,com.jayway.jsonpath.Configuration)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -23,9 +19,7 @@
     "type": "com.jayway.jsonpath.Configuration"
   "return_type": "java.lang.Object"
   "signature": "[com.jayway.jsonpath.spi.mapper.TapestryMappingProvider].map(java.lang.Object,java.lang.Class<T>,com.jayway.jsonpath.Configuration)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
+- "name": "[com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -35,9 +29,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.jayway.jsonpath.spi.mapper.JakartaMappingProvider].map(java.lang.Object,java.lang.Class<T>,com.jayway.jsonpath.Configuration)"
+- "name": "[com.jayway.jsonpath.spi.mapper.JakartaMappingProvider].map(java.lang.Object,java.lang.Class<T>,com.jayway.jsonpath.Configuration)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -47,9 +39,7 @@
     "type": "com.jayway.jsonpath.Configuration"
   "return_type": "java.lang.Object"
   "signature": "[com.jayway.jsonpath.spi.mapper.JakartaMappingProvider].map(java.lang.Object,java.lang.Class<T>,com.jayway.jsonpath.Configuration)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.jayway.jsonpath.spi.json.JsonOrgJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
+- "name": "[com.jayway.jsonpath.spi.json.JsonOrgJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -59,9 +49,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[com.jayway.jsonpath.spi.json.JsonOrgJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.jayway.jsonpath.spi.json.GsonJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
+- "name": "[com.jayway.jsonpath.spi.json.GsonJsonProvider].setProperty(java.lang.Object,java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/jsoup.yaml
+++ b/benchmark-sets/jvm-all/jsoup.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.jsoup.select.NodeTraversor].traverse(org.jsoup.select.NodeVisitor,org.jsoup.nodes.Node)"
+- "name": "[org.jsoup.select.NodeTraversor].traverse(org.jsoup.select.NodeVisitor,org.jsoup.nodes.Node)"
   "params":
   - "name": "arg0"
     "type": "org.jsoup.select.NodeVisitor"
@@ -9,9 +7,7 @@
     "type": "org.jsoup.nodes.Node"
   "return_type": "void"
   "signature": "[org.jsoup.select.NodeTraversor].traverse(org.jsoup.select.NodeVisitor,org.jsoup.nodes.Node)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.jsoup.internal.StringUtil].join(java.util.Iterator<?>,java.lang.String)"
+- "name": "[org.jsoup.internal.StringUtil].join(java.util.Iterator<?>,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.util.Iterator<?>"
@@ -19,9 +15,7 @@
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.jsoup.internal.StringUtil].join(java.util.Iterator<?>,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jsoup.safety.Safelist].isSafeAttribute(java.lang.String,org.jsoup.nodes.Element,org.jsoup.nodes.Attribute)"
+- "name": "[org.jsoup.safety.Safelist].isSafeAttribute(java.lang.String,org.jsoup.nodes.Element,org.jsoup.nodes.Attribute)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -31,9 +25,7 @@
     "type": "org.jsoup.nodes.Attribute"
   "return_type": "boolean"
   "signature": "[org.jsoup.safety.Safelist].isSafeAttribute(java.lang.String,org.jsoup.nodes.Element,org.jsoup.nodes.Attribute)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jsoup.helper.W3CDom$W3CBuilder].head(org.jsoup.nodes.Node,int)"
+- "name": "[org.jsoup.helper.W3CDom$W3CBuilder].head(org.jsoup.nodes.Node,int)"
   "params":
   - "name": "arg0"
     "type": "org.jsoup.nodes.Node"
@@ -41,17 +33,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "[org.jsoup.helper.W3CDom$W3CBuilder].head(org.jsoup.nodes.Node,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jsoup.safety.Safelist].getEnforcedAttributes(java.lang.String)"
+- "name": "[org.jsoup.safety.Safelist].getEnforcedAttributes(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.jsoup.nodes.Attributes"
   "signature": "[org.jsoup.safety.Safelist].getEnforcedAttributes(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jsoup.nodes.Attributes].userData(java.lang.String,java.lang.Object)"
+- "name": "[org.jsoup.nodes.Attributes].userData(java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/jts.yaml
+++ b/benchmark-sets/jvm-all/jts.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.locationtech.jts.operation.overlayng.OverlayNGRobust].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int)"
+- "name": "[org.locationtech.jts.operation.overlayng.OverlayNGRobust].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int)"
   "params":
   - "name": "arg0"
     "type": "org.locationtech.jts.geom.Geometry"
@@ -11,9 +9,7 @@
     "type": "int"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.jts.operation.overlayng.OverlayNGRobust].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int,org.locationtech.jts.noding.Noder)"
+- "name": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int,org.locationtech.jts.noding.Noder)"
   "params":
   - "name": "arg0"
     "type": "org.locationtech.jts.geom.Geometry"
@@ -25,9 +21,7 @@
     "type": "org.locationtech.jts.noding.Noder"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int,org.locationtech.jts.noding.Noder)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int,org.locationtech.jts.geom.PrecisionModel)"
+- "name": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int,org.locationtech.jts.geom.PrecisionModel)"
   "params":
   - "name": "arg0"
     "type": "org.locationtech.jts.geom.Geometry"
@@ -39,9 +33,7 @@
     "type": "org.locationtech.jts.geom.PrecisionModel"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int,org.locationtech.jts.geom.PrecisionModel)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int)"
+- "name": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int)"
   "params":
   - "name": "arg0"
     "type": "org.locationtech.jts.geom.Geometry"
@@ -51,9 +43,7 @@
     "type": "int"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.jts.operation.overlayng.OverlayNG].overlay(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.Geometry,int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.locationtech.jts.operation.overlayng.PrecisionReducer].reducePrecision(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.PrecisionModel)"
+- "name": "[org.locationtech.jts.operation.overlayng.PrecisionReducer].reducePrecision(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.PrecisionModel)"
   "params":
   - "name": "arg0"
     "type": "org.locationtech.jts.geom.Geometry"
@@ -61,9 +51,7 @@
     "type": "org.locationtech.jts.geom.PrecisionModel"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.jts.operation.overlayng.PrecisionReducer].reducePrecision(org.locationtech.jts.geom.Geometry,org.locationtech.jts.geom.PrecisionModel)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.locationtech.jts.operation.buffer.BufferOp].bufferOp(org.locationtech.jts.geom.Geometry,double,org.locationtech.jts.operation.buffer.BufferParameters)"
+- "name": "[org.locationtech.jts.operation.buffer.BufferOp].bufferOp(org.locationtech.jts.geom.Geometry,double,org.locationtech.jts.operation.buffer.BufferParameters)"
   "params":
   - "name": "arg0"
     "type": "org.locationtech.jts.geom.Geometry"

--- a/benchmark-sets/jvm-all/jul-to-slf4j.yaml
+++ b/benchmark-sets/jvm-all/jul-to-slf4j.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.NormalizedParameters].<init>(java.lang.String,java.lang.Object[])"
+- "name": "[org.slf4j.helpers.NormalizedParameters].<init>(java.lang.String,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "java.lang.Object[]"
   "return_type": "org.slf4j.helpers.NormalizedParameters"
   "signature": "[org.slf4j.helpers.NormalizedParameters].<init>(java.lang.String,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.event.EventRecordingLogger].<init>(org.slf4j.helpers.SubstituteLogger,java.util.Queue)"
+- "name": "[org.slf4j.event.EventRecordingLogger].<init>(org.slf4j.helpers.SubstituteLogger,java.util.Queue)"
   "params":
   - "name": "arg0"
     "type": "org.slf4j.helpers.SubstituteLogger"
@@ -19,9 +15,7 @@
     "type": "java.util.Queue"
   "return_type": "org.slf4j.event.EventRecordingLogger"
   "signature": "[org.slf4j.event.EventRecordingLogger].<init>(org.slf4j.helpers.SubstituteLogger,java.util.Queue)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.spi.DefaultLoggingEventBuilder].<init>(org.slf4j.Logger,org.slf4j.event.Level)"
+- "name": "[org.slf4j.spi.DefaultLoggingEventBuilder].<init>(org.slf4j.Logger,org.slf4j.event.Level)"
   "params":
   - "name": "arg0"
     "type": "org.slf4j.Logger"
@@ -29,17 +23,13 @@
     "type": "org.slf4j.event.Level"
   "return_type": "org.slf4j.spi.DefaultLoggingEventBuilder"
   "signature": "[org.slf4j.spi.DefaultLoggingEventBuilder].<init>(org.slf4j.Logger,org.slf4j.event.Level)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.FormattingTuple].<init>(java.lang.String)"
+- "name": "[org.slf4j.helpers.FormattingTuple].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.slf4j.helpers.FormattingTuple"
   "signature": "[org.slf4j.helpers.FormattingTuple].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.FormattingTuple].<init>(java.lang.String,java.lang.Object[],java.lang.Throwable)"
+- "name": "[org.slf4j.helpers.FormattingTuple].<init>(java.lang.String,java.lang.Object[],java.lang.Throwable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -49,9 +39,7 @@
     "type": "java.lang.Throwable"
   "return_type": "org.slf4j.helpers.FormattingTuple"
   "signature": "[org.slf4j.helpers.FormattingTuple].<init>(java.lang.String,java.lang.Object[],java.lang.Throwable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.NormalizedParameters].<init>(java.lang.String,java.lang.Object[],java.lang.Throwable)"
+- "name": "[org.slf4j.helpers.NormalizedParameters].<init>(java.lang.String,java.lang.Object[],java.lang.Throwable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/kie-soup.yaml
+++ b/benchmark-sets/jvm-all/kie-soup.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.text.ParseException"
-  "is_jvm_static": false
-  "name": "[org.kie.soup.commons.cron.CronExpression].<init>(java.lang.String)"
+- "name": "[org.kie.soup.commons.cron.CronExpression].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/kryo.yaml
+++ b/benchmark-sets/jvm-all/kryo.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.esotericsoftware.kryo.serializers.CollectionSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
+- "name": "[com.esotericsoftware.kryo.serializers.CollectionSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
   "params":
   - "name": "arg0"
     "type": "com.esotericsoftware.kryo.Kryo"
@@ -11,9 +9,7 @@
     "type": "java.lang.Class<? extends T>"
   "return_type": "java.util.Collection"
   "signature": "[com.esotericsoftware.kryo.serializers.CollectionSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.esotericsoftware.kryo.serializers.MapSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
+- "name": "[com.esotericsoftware.kryo.serializers.MapSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
   "params":
   - "name": "arg0"
     "type": "com.esotericsoftware.kryo.Kryo"
@@ -23,9 +19,7 @@
     "type": "java.lang.Class<? extends T>"
   "return_type": "java.util.Map"
   "signature": "[com.esotericsoftware.kryo.serializers.MapSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.esotericsoftware.kryo.Kryo].readObjectOrNull(com.esotericsoftware.kryo.io.Input,java.lang.Class<T>)"
+- "name": "[com.esotericsoftware.kryo.Kryo].readObjectOrNull(com.esotericsoftware.kryo.io.Input,java.lang.Class<T>)"
   "params":
   - "name": "arg0"
     "type": "com.esotericsoftware.kryo.io.Input"
@@ -33,17 +27,13 @@
     "type": "java.lang.Class<T>"
   "return_type": "java.lang.Object"
   "signature": "[com.esotericsoftware.kryo.Kryo].readObjectOrNull(com.esotericsoftware.kryo.io.Input,java.lang.Class<T>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.esotericsoftware.kryo.Kryo].readClassAndObject(com.esotericsoftware.kryo.io.Input)"
+- "name": "[com.esotericsoftware.kryo.Kryo].readClassAndObject(com.esotericsoftware.kryo.io.Input)"
   "params":
   - "name": "arg0"
     "type": "com.esotericsoftware.kryo.io.Input"
   "return_type": "java.lang.Object"
   "signature": "[com.esotericsoftware.kryo.Kryo].readClassAndObject(com.esotericsoftware.kryo.io.Input)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.esotericsoftware.kryo.serializers.RecordSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
+- "name": "[com.esotericsoftware.kryo.serializers.RecordSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
   "params":
   - "name": "arg0"
     "type": "com.esotericsoftware.kryo.Kryo"
@@ -53,9 +43,7 @@
     "type": "java.lang.Class<? extends T>"
   "return_type": "java.lang.Object"
   "signature": "[com.esotericsoftware.kryo.serializers.RecordSerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class<? extends T>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.esotericsoftware.kryo.serializers.DefaultArraySerializers$ObjectArraySerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class)"
+- "name": "[com.esotericsoftware.kryo.serializers.DefaultArraySerializers$ObjectArraySerializer].read(com.esotericsoftware.kryo.Kryo,com.esotericsoftware.kryo.io.Input,java.lang.Class)"
   "params":
   - "name": "arg0"
     "type": "com.esotericsoftware.kryo.Kryo"

--- a/benchmark-sets/jvm-all/metadata-extractor.yaml
+++ b/benchmark-sets/jvm-all/metadata-extractor.yaml
@@ -1,47 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.drew.metadata.exif.makernotes.OlympusCameraSettingsMakernoteDescriptor].getDescription(int)"
+- "name": "[com.drew.metadata.exif.makernotes.OlympusCameraSettingsMakernoteDescriptor].getDescription(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.drew.metadata.exif.makernotes.OlympusCameraSettingsMakernoteDescriptor].getDescription(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.drew.metadata.exif.makernotes.OlympusMakernoteDescriptor].getDescription(int)"
+- "name": "[com.drew.metadata.exif.makernotes.OlympusMakernoteDescriptor].getDescription(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.drew.metadata.exif.makernotes.OlympusMakernoteDescriptor].getDescription(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.drew.metadata.exif.makernotes.PanasonicMakernoteDescriptor].getDescription(int)"
+- "name": "[com.drew.metadata.exif.makernotes.PanasonicMakernoteDescriptor].getDescription(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.drew.metadata.exif.makernotes.PanasonicMakernoteDescriptor].getDescription(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.drew.metadata.exif.makernotes.NikonType2MakernoteDescriptor].getDescription(int)"
+- "name": "[com.drew.metadata.exif.makernotes.NikonType2MakernoteDescriptor].getDescription(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.drew.metadata.exif.makernotes.NikonType2MakernoteDescriptor].getDescription(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.drew.metadata.photoshop.PhotoshopDescriptor].getDescription(int)"
+- "name": "[com.drew.metadata.photoshop.PhotoshopDescriptor].getDescription(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.drew.metadata.photoshop.PhotoshopDescriptor].getDescription(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.drew.metadata.exif.GpsDescriptor].getDescription(int)"
+- "name": "[com.drew.metadata.exif.GpsDescriptor].getDescription(int)"
   "params":
   - "name": "arg0"
     "type": "int"

--- a/benchmark-sets/jvm-all/netty.yaml
+++ b/benchmark-sets/jvm-all/netty.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.lang.Exception"
-  "is_jvm_static": false
-  "name": "[io.netty.channel.CombinedChannelDuplexHandler].channelRead(io.netty.channel.ChannelHandlerContext,java.lang.Object)"
+- "name": "[io.netty.channel.CombinedChannelDuplexHandler].channelRead(io.netty.channel.ChannelHandlerContext,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "io.netty.channel.ChannelHandlerContext"
@@ -10,9 +7,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[io.netty.channel.CombinedChannelDuplexHandler].channelRead(io.netty.channel.ChannelHandlerContext,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[io.netty.handler.codec.http2.Http2ServerUpgradeCodec].prepareUpgradeResponse(io.netty.channel.ChannelHandlerContext,io.netty.handler.codec.http.FullHttpRequest,io.netty.handler.codec.http.HttpHeaders)"
+- "name": "[io.netty.handler.codec.http2.Http2ServerUpgradeCodec].prepareUpgradeResponse(io.netty.channel.ChannelHandlerContext,io.netty.handler.codec.http.FullHttpRequest,io.netty.handler.codec.http.HttpHeaders)"
   "params":
   - "name": "arg0"
     "type": "io.netty.channel.ChannelHandlerContext"
@@ -22,10 +17,7 @@
     "type": "io.netty.channel.codec.http.HttpHeaders"
   "return_type": "boolean"
   "signature": "[io.netty.handler.codec.http2.Http2ServerUpgradeCodec].prepareUpgradeResponse(io.netty.channel.ChannelHandlerContext,io.netty.handler.codec.http.FullHttpRequest,io.netty.handler.codec.http.HttpHeaders)"
-- "exceptions":
-  - "io.netty.handler.codec.http2.Http2Exception"
-  "is_jvm_static": false
-  "name": "[io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder].decodeFrame(io.netty.channel.ChannelHandlerContext,io.netty.buffer.ByteBuf,java.util.List<Object>)"
+- "name": "[io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder].decodeFrame(io.netty.channel.ChannelHandlerContext,io.netty.buffer.ByteBuf,java.util.List<Object>)"
   "params":
   - "name": "arg0"
     "type": "io.netty.channel.ChannelHandlerContext"
@@ -35,10 +27,7 @@
     "type": "java.util.List<Object>"
   "return_type": "void"
   "signature": "[io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder].decodeFrame(io.netty.channel.ChannelHandlerContext,io.netty.buffer.ByteBuf,java.util.List<Object>)"
-- "exceptions":
-  - "io.netty.handler.codec.http2.Http2Exception"
-  "is_jvm_static": false
-  "name": "[io.netty.handler.codec.http2.Http2InboundFrameLogger].readFrame(io.netty.channel.ChannelHandlerContext,io.netty.buffer.ByteBuf,io.netty.handler.codec.http2.Http2FrameListener)"
+- "name": "[io.netty.handler.codec.http2.Http2InboundFrameLogger].readFrame(io.netty.channel.ChannelHandlerContext,io.netty.buffer.ByteBuf,io.netty.handler.codec.http2.Http2FrameListener)"
   "params":
   - "name": "arg0"
     "type": "io.netty.channel.ChannelHandlerContext"
@@ -48,10 +37,7 @@
     "type": "io.netty.handler.codec.http2.Http2FrameListener"
   "return_type": "void"
   "signature": "[io.netty.handler.codec.http2.Http2InboundFrameLogger].readFrame(io.netty.channel.ChannelHandlerContext,io.netty.buffer.ByteBuf,io.netty.handler.codec.http2.Http2FrameListener)"
-- "exceptions":
-  - "java.lang.Exception"
-  "is_jvm_static": false
-  "name": "[io.netty.channel.CombinedChannelDuplexHandler].write(io.netty.channel.ChannelHandlerContext,java.lang.Object,io.netty.channel.ChannelPromise)"
+- "name": "[io.netty.channel.CombinedChannelDuplexHandler].write(io.netty.channel.ChannelHandlerContext,java.lang.Object,io.netty.channel.ChannelPromise)"
   "params":
   - "name": "arg0"
     "type": "io.netty.channel.ChannelHandlerContext"

--- a/benchmark-sets/jvm-all/open-json.yaml
+++ b/benchmark-sets/jvm-all/open-json.yaml
@@ -1,17 +1,11 @@
 "functions":
-- "exceptions":
-  - "org.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].<init>(java.lang.String)"
+- "name": "[org.json.JSONArray].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.json.JSONArray"
   "signature": "[org.json.JSONArray].<init>(java.lang.String)"
-- "exceptions":
-  - "org.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.json.JSONObject].<init>(java.lang.String)"
+- "name": "[org.json.JSONObject].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/plexus-utils.yaml
+++ b/benchmark-sets/jvm-all/plexus-utils.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.plexus.util.InterpolationFilterReader].read(char[],int,int)"
+- "name": "[org.codehaus.plexus.util.InterpolationFilterReader].read(char[],int,int)"
   "params":
   - "name": "arg0"
     "type": "char[]"
@@ -12,9 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "[org.codehaus.plexus.util.InterpolationFilterReader].read(char[],int,int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.codehaus.plexus.util.StringUtils].join(java.lang.Object[],java.lang.String)"
+- "name": "[org.codehaus.plexus.util.StringUtils].join(java.lang.Object[],java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
@@ -22,17 +17,13 @@
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.codehaus.plexus.util.StringUtils].join(java.lang.Object[],java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.codehaus.plexus.util.cli.shell.Shell].getShellCommandLine(java.lang.String[])"
+- "name": "[org.codehaus.plexus.util.cli.shell.Shell].getShellCommandLine(java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"
   "return_type": "java.util.List<String>"
   "signature": "[org.codehaus.plexus.util.cli.shell.Shell].getShellCommandLine(java.lang.String[])"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.codehaus.plexus.util.Os].isOs(java.lang.String,java.lang.String,java.lang.String,java.lang.String)"
+- "name": "[org.codehaus.plexus.util.Os].isOs(java.lang.String,java.lang.String,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -44,10 +35,7 @@
     "type": "java.lang.String"
   "return_type": "boolean"
   "signature": "[org.codehaus.plexus.util.Os].isOs(java.lang.String,java.lang.String,java.lang.String,java.lang.String)"
-- "exceptions":
-  - "org.codehaus.plexus.util.reflection.ReflectorException"
-  "is_jvm_static": false
-  "name": "[org.codehaus.plexus.util.reflection.Reflector].getObjectProperty(java.lang.Object,java.lang.String)"
+- "name": "[org.codehaus.plexus.util.reflection.Reflector].getObjectProperty(java.lang.Object,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -55,9 +43,7 @@
     "type": "java.lang.String"
   "return_type": "java.lang.Object"
   "signature": "[org.codehaus.plexus.util.reflection.Reflector].getObjectProperty(java.lang.Object,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.codehaus.plexus.util.cli.shell.CmdShell].getCommandLine(java.lang.String,java.lang.String[])"
+- "name": "[org.codehaus.plexus.util.cli.shell.CmdShell].getCommandLine(java.lang.String,java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/protobuf-java.yaml
+++ b/benchmark-sets/jvm-all/protobuf-java.yaml
@@ -1,24 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.protobuf.DebugFormat].toString(com.google.protobuf.MessageOrBuilder)"
+- "name": "[com.google.protobuf.DebugFormat].toString(com.google.protobuf.MessageOrBuilder)"
   "params":
   - "name": "arg0"
     "type": "com.google.protobuf.MessageOrBuilder"
   "return_type": "java.lang.String"
   "signature": "[com.google.protobuf.DebugFormat].toString(com.google.protobuf.MessageOrBuilder)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.protobuf.TextFormat$Printer].printToString(com.google.protobuf.MessageOrBuilder)"
+- "name": "[com.google.protobuf.TextFormat$Printer].printToString(com.google.protobuf.MessageOrBuilder)"
   "params":
   - "name": "arg0"
     "type": "com.google.protobuf.MessageOrBuilder"
   "return_type": "java.lang.String"
   "signature": "[com.google.protobuf.TextFormat$Printer].printToString(com.google.protobuf.MessageOrBuilder)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.protobuf.TextFormat$Printer].print(com.google.protobuf.MessageOrBuilder,java.lang.Appendable)"
+- "name": "[com.google.protobuf.TextFormat$Printer].print(com.google.protobuf.MessageOrBuilder,java.lang.Appendable)"
   "params":
   - "name": "arg0"
     "type": "com.google.protobuf.MessageOrBuilder"
@@ -26,26 +19,19 @@
     "type": "java.lang.Appendable"
   "return_type": "void"
   "signature": "[com.google.protobuf.TextFormat$Printer].print(com.google.protobuf.MessageOrBuilder,java.lang.Appendable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.protobuf.DebugFormat].toString(com.google.protobuf.UnknownFieldSet)"
+- "name": "[com.google.protobuf.DebugFormat].toString(com.google.protobuf.UnknownFieldSet)"
   "params":
   - "name": "arg0"
     "type": "com.google.protobuf.UnknownFieldSet"
   "return_type": "java.lang.String"
   "signature": "[com.google.protobuf.DebugFormat].toString(com.google.protobuf.UnknownFieldSet)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.protobuf.TextFormat$Printer].printToString(com.google.protobuf.UnknownFieldSet)"
+- "name": "[com.google.protobuf.TextFormat$Printer].printToString(com.google.protobuf.UnknownFieldSet)"
   "params":
   - "name": "arg0"
     "type": "com.google.protobuf.UnknownFieldSet"
   "return_type": "java.lang.String"
   "signature": "[com.google.protobuf.TextFormat$Printer].printToString(com.google.protobuf.UnknownFieldSet)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.google.protobuf.TextFormat$Printer].print(com.google.protobuf.UnknownFieldSet,java.lang.Appendable)"
+- "name": "[com.google.protobuf.TextFormat$Printer].print(com.google.protobuf.UnknownFieldSet,java.lang.Appendable)"
   "params":
   - "name": "arg0"
     "type": "com.google.protobuf.UnknownFieldSet"

--- a/benchmark-sets/jvm-all/quartz.yaml
+++ b/benchmark-sets/jvm-all/quartz.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
+- "name": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.quartz.utils.DirtyFlagMap].put(java.lang.Object,java.lang.Object)"
+- "name": "[org.quartz.utils.DirtyFlagMap].put(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/reflections.yaml
+++ b/benchmark-sets/jvm-all/reflections.yaml
@@ -1,39 +1,29 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.reflections.Reflections].<init>(java.lang.Object[])"
+- "name": "[org.reflections.Reflections].<init>(java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
   "return_type": "org.reflections.Reflections"
   "signature": "[org.reflections.Reflections].<init>(java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.reflections.Reflections].<init>(org.reflections.Configuration)"
+- "name": "[org.reflections.Reflections].<init>(org.reflections.Configuration)"
   "params":
   - "name": "arg0"
     "type": "org.reflections.Configuration"
   "return_type": "org.reflections.Reflections"
   "signature": "[org.reflections.Reflections].<init>(org.reflections.Configuration)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.reflections.vfs.SystemDir].<init>(java.io.File)"
+- "name": "[org.reflections.vfs.SystemDir].<init>(java.io.File)"
   "params":
   - "name": "arg0"
     "type": "java.io.File"
   "return_type": "org.reflections.vfs.SystemDir"
   "signature": "[org.reflections.vfs.SystemDir].<init>(java.io.File)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.reflections.scanners.SubTypesScanner].<init>(boolean)"
+- "name": "[org.reflections.scanners.SubTypesScanner].<init>(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "org.reflections.scanners.SubTypesScanner"
   "signature": "[org.reflections.scanners.SubTypesScanner].<init>(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.reflections.Reflections].<init>(java.lang.String,org.reflections.scanners.Scanner[])"
+- "name": "[org.reflections.Reflections].<init>(java.lang.String,org.reflections.scanners.Scanner[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -41,9 +31,7 @@
     "type": "org.reflections.scanners.Scanner[]"
   "return_type": "org.reflections.Reflections"
   "signature": "[org.reflections.Reflections].<init>(java.lang.String,org.reflections.scanners.Scanner[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.reflections.util.FilterBuilder].equals(java.lang.Object)"
+- "name": "[org.reflections.util.FilterBuilder].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/reload4j.yaml
+++ b/benchmark-sets/jvm-all/reload4j.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.log4j.helpers.OptionConverter].selectAndConfigure(java.net.URL,java.lang.String,org.apache.log4j.spi.LoggerRepository)"
+- "name": "[org.apache.log4j.helpers.OptionConverter].selectAndConfigure(java.net.URL,java.lang.String,org.apache.log4j.spi.LoggerRepository)"
   "params":
   - "name": "arg0"
     "type": "java.net.URL"
@@ -11,9 +9,7 @@
     "type": "org.apache.log4j.spi.LoggerRepository"
   "return_type": "void"
   "signature": "[org.apache.log4j.helpers.OptionConverter].selectAndConfigure(java.net.URL,java.lang.String,org.apache.log4j.spi.LoggerRepository)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.log4j.xml.DOMConfigurator].doConfigure(java.lang.String,org.apache.log4j.spi.LoggerRepository)"
+- "name": "[org.apache.log4j.xml.DOMConfigurator].doConfigure(java.lang.String,org.apache.log4j.spi.LoggerRepository)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -21,9 +17,7 @@
     "type": "org.apache.log4j.spi.LoggerRepository"
   "return_type": "void"
   "signature": "[org.apache.log4j.xml.DOMConfigurator].doConfigure(java.lang.String,org.apache.log4j.spi.LoggerRepository)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.log4j.xml.DOMConfigurator].doConfigure(java.net.URL,org.apache.log4j.spi.LoggerRepository)"
+- "name": "[org.apache.log4j.xml.DOMConfigurator].doConfigure(java.net.URL,org.apache.log4j.spi.LoggerRepository)"
   "params":
   - "name": "arg0"
     "type": "java.net.URL"
@@ -31,9 +25,7 @@
     "type": "org.apache.log4j.spi.LoggerRepository"
   "return_type": "void"
   "signature": "[org.apache.log4j.xml.DOMConfigurator].doConfigure(java.net.URL,org.apache.log4j.spi.LoggerRepository)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.lang.String,org.apache.log4j.spi.LoggerRepository)"
+- "name": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.lang.String,org.apache.log4j.spi.LoggerRepository)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -41,9 +33,7 @@
     "type": "org.apache.log4j.spi.LoggerRepository"
   "return_type": "void"
   "signature": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.lang.String,org.apache.log4j.spi.LoggerRepository)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.net.URL,org.apache.log4j.spi.LoggerRepository)"
+- "name": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.net.URL,org.apache.log4j.spi.LoggerRepository)"
   "params":
   - "name": "arg0"
     "type": "java.net.URL"
@@ -51,9 +41,7 @@
     "type": "org.apache.log4j.spi.LoggerRepository"
   "return_type": "void"
   "signature": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.net.URL,org.apache.log4j.spi.LoggerRepository)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.util.Properties,org.apache.log4j.spi.LoggerRepository)"
+- "name": "[org.apache.log4j.PropertyConfigurator].doConfigure(java.util.Properties,org.apache.log4j.spi.LoggerRepository)"
   "params":
   - "name": "arg0"
     "type": "java.util.Properties"

--- a/benchmark-sets/jvm-all/rhino.yaml
+++ b/benchmark-sets/jvm-all/rhino.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.mozilla.javascript.Slot].setValue(java.lang.Object,org.mozilla.javascript.Scriptable,org.mozilla.javascript.Scriptable)"
+- "name": "[org.mozilla.javascript.Slot].setValue(java.lang.Object,org.mozilla.javascript.Scriptable,org.mozilla.javascript.Scriptable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -11,9 +9,7 @@
     "type": "org.mozilla.javascript.Scriptable"
   "return_type": "boolean"
   "signature": "[org.mozilla.javascript.Slot].setValue(java.lang.Object,org.mozilla.javascript.Scriptable,org.mozilla.javascript.Scriptable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.mozilla.javascript.Sorting].median(java.lang.Object[],int,int,java.util.Comparator<Object>)"
+- "name": "[org.mozilla.javascript.Sorting].median(java.lang.Object[],int,int,java.util.Comparator<Object>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
@@ -25,25 +21,19 @@
     "type": "java.util.Comparator<Object>"
   "return_type": "int"
   "signature": "[org.mozilla.javascript.Sorting].median(java.lang.Object[],int,int,java.util.Comparator<Object>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.mozilla.javascript.LambdaSlot].getValue(org.mozilla.javascript.Scriptable)"
+- "name": "[org.mozilla.javascript.LambdaSlot].getValue(org.mozilla.javascript.Scriptable)"
   "params":
   - "name": "arg0"
     "type": "org.mozilla.javascript.Scriptable"
   "return_type": "java.lang.Object"
   "signature": "[org.mozilla.javascript.LambdaSlot].getValue(org.mozilla.javascript.Scriptable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.mozilla.javascript.NativeJavaObject].getDefaultValue(java.lang.Class<?>)"
+- "name": "[org.mozilla.javascript.NativeJavaObject].getDefaultValue(java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Class<?>"
   "return_type": "java.lang.Object"
   "signature": "[org.mozilla.javascript.NativeJavaObject].getDefaultValue(java.lang.Class<?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.mozilla.javascript.AccessorSlot].setValue(java.lang.Object,org.mozilla.javascript.Scriptable,org.mozilla.javascript.Scriptable,boolean)"
+- "name": "[org.mozilla.javascript.AccessorSlot].setValue(java.lang.Object,org.mozilla.javascript.Scriptable,org.mozilla.javascript.Scriptable,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -55,9 +45,7 @@
     "type": "boolean"
   "return_type": "boolean"
   "signature": "[org.mozilla.javascript.AccessorSlot].setValue(java.lang.Object,org.mozilla.javascript.Scriptable,org.mozilla.javascript.Scriptable,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.mozilla.javascript.NativeArray$ElementComparator].compare(java.lang.Object,java.lang.Object)"
+- "name": "[org.mozilla.javascript.NativeArray$ElementComparator].compare(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/roaring-bitmap.yaml
+++ b/benchmark-sets/jvm-all/roaring-bitmap.yaml
@@ -1,47 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.roaringbitmap.ArrayContainer].ixor(org.roaringbitmap.RunContainer)"
+- "name": "[org.roaringbitmap.ArrayContainer].ixor(org.roaringbitmap.RunContainer)"
   "params":
   - "name": "arg0"
     "type": "org.roaringbitmap.RunContainer"
   "return_type": "org.roaringbitmap.Container"
   "signature": "[org.roaringbitmap.ArrayContainer].ixor(org.roaringbitmap.RunContainer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.roaringbitmap.RunContainer].xor(org.roaringbitmap.ArrayContainer)"
+- "name": "[org.roaringbitmap.RunContainer].xor(org.roaringbitmap.ArrayContainer)"
   "params":
   - "name": "arg0"
     "type": "org.roaringbitmap.ArrayContainer"
   "return_type": "org.roaringbitmap.Container"
   "signature": "[org.roaringbitmap.RunContainer].xor(org.roaringbitmap.ArrayContainer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.roaringbitmap.RunContainer].ixor(org.roaringbitmap.ArrayContainer)"
+- "name": "[org.roaringbitmap.RunContainer].ixor(org.roaringbitmap.ArrayContainer)"
   "params":
   - "name": "arg0"
     "type": "org.roaringbitmap.ArrayContainer"
   "return_type": "org.roaringbitmap.Container"
   "signature": "[org.roaringbitmap.RunContainer].ixor(org.roaringbitmap.ArrayContainer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.roaringbitmap.ArrayContainer].ior(org.roaringbitmap.RunContainer)"
+- "name": "[org.roaringbitmap.ArrayContainer].ior(org.roaringbitmap.RunContainer)"
   "params":
   - "name": "arg0"
     "type": "org.roaringbitmap.RunContainer"
   "return_type": "org.roaringbitmap.Container"
   "signature": "[org.roaringbitmap.ArrayContainer].ior(org.roaringbitmap.RunContainer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.roaringbitmap.RunContainer].or(org.roaringbitmap.ArrayContainer)"
+- "name": "[org.roaringbitmap.RunContainer].or(org.roaringbitmap.ArrayContainer)"
   "params":
   - "name": "arg0"
     "type": "org.roaringbitmap.ArrayContainer"
   "return_type": "org.roaringbitmap.Container"
   "signature": "[org.roaringbitmap.RunContainer].or(org.roaringbitmap.ArrayContainer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.roaringbitmap.RunContainer].ior(org.roaringbitmap.ArrayContainer)"
+- "name": "[org.roaringbitmap.RunContainer].ior(org.roaringbitmap.ArrayContainer)"
   "params":
   - "name": "arg0"
     "type": "org.roaringbitmap.ArrayContainer"

--- a/benchmark-sets/jvm-all/rome.yaml
+++ b/benchmark-sets/jvm-all/rome.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.rometools.rome.feed.synd.SyndFeedImpl].<init>(com.rometools.rome.feed.WireFeed,boolean)"
+- "name": "[com.rometools.rome.feed.synd.SyndFeedImpl].<init>(com.rometools.rome.feed.WireFeed,boolean)"
   "params":
   - "name": "arg0"
     "type": "com.rometools.rome.feed.WireFeed"
@@ -9,10 +7,7 @@
     "type": "boolean"
   "return_type": "com.rometools.rome.feed.synd.SyndFeedImpl"
   "signature": "[com.rometools.rome.feed.synd.SyndFeedImpl].<init>(com.rometools.rome.feed.WireFeed,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.rometools.rome.io.XmlReader].<init>(java.net.URLConnection,java.util.Map)"
+- "name": "[com.rometools.rome.io.XmlReader].<init>(java.net.URLConnection,java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "java.net.URLConnection"
@@ -20,11 +15,7 @@
     "type": "java.util.Map"
   "return_type": "com.rometools.rome.io.XmlReader"
   "signature": "[com.rometools.rome.io.XmlReader].<init>(java.net.URLConnection,java.util.Map)"
-- "exceptions":
-  - "java.io.IOException"
-  - "com.rometools.rome.io.XmlReaderException"
-  "is_jvm_static": false
-  "name": "[com.rometools.rome.io.XmlReader].<init>(java.io.InputStream,java.lang.String,boolean,java.lang.String)"
+- "name": "[com.rometools.rome.io.XmlReader].<init>(java.io.InputStream,java.lang.String,boolean,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -36,11 +27,7 @@
     "type": "java.lang.String"
   "return_type": "com.rometools.rome.io.XmlReader"
   "signature": "[com.rometools.rome.io.XmlReader].<init>(java.io.InputStream,java.lang.String,boolean,java.lang.String)"
-- "exceptions":
-  - "java.io.IOException"
-  - "com.rometools.rome.io.XmlReaderException"
-  "is_jvm_static": false
-  "name": "[com.rometools.rome.io.XmlReader].<init>(java.io.InputStream,boolean,java.lang.String)"
+- "name": "[com.rometools.rome.io.XmlReader].<init>(java.io.InputStream,boolean,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -50,9 +37,7 @@
     "type": "java.lang.String"
   "return_type": "com.rometools.rome.io.XmlReader"
   "signature": "[com.rometools.rome.io.XmlReader].<init>(java.io.InputStream,boolean,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.jdom2.Attribute].<init>(java.lang.String,java.lang.String,org.jdom2.AttributeType,org.jdom2.Namespace)"
+- "name": "[org.jdom2.Attribute].<init>(java.lang.String,java.lang.String,org.jdom2.AttributeType,org.jdom2.Namespace)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -64,9 +49,7 @@
     "type": "org.jdom2.Namespace"
   "return_type": "org.jdom2.Attribute"
   "signature": "[org.jdom2.Attribute].<init>(java.lang.String,java.lang.String,org.jdom2.AttributeType,org.jdom2.Namespace)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.rometools.rome.feed.impl.PropertyDescriptor].<init>(java.lang.String,java.lang.reflect.Method,java.lang.reflect.Method)"
+- "name": "[com.rometools.rome.feed.impl.PropertyDescriptor].<init>(java.lang.String,java.lang.reflect.Method,java.lang.reflect.Method)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/servo-core.yaml
+++ b/benchmark-sets/jvm-all/servo-core.yaml
@@ -1,31 +1,23 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.netflix.spectator.api.histogram.BucketTimer].record(java.lang.Runnable)"
+- "name": "[com.netflix.spectator.api.histogram.BucketTimer].record(java.lang.Runnable)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Runnable"
   "return_type": "void"
   "signature": "[com.netflix.spectator.api.histogram.BucketTimer].record(java.lang.Runnable)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.netflix.servo.monitor.BasicGauge].lambda$initializeSpectator$0(com.netflix.servo.monitor.BasicGauge)"
+- "name": "[com.netflix.servo.monitor.BasicGauge].lambda$initializeSpectator$0(com.netflix.servo.monitor.BasicGauge)"
   "params":
   - "name": "arg0"
     "type": "com.netflix.servo.monitor.BasicGauge"
   "return_type": "double"
   "signature": "[com.netflix.servo.monitor.BasicGauge].lambda$initializeSpectator$0(com.netflix.servo.monitor.BasicGauge)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.netflix.servo.monitor.BasicGauge].getValue(int)"
+- "name": "[com.netflix.servo.monitor.BasicGauge].getValue(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.Number"
   "signature": "[com.netflix.servo.monitor.BasicGauge].getValue(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.netflix.servo.publish.JvmMetricPoller].poll(com.netflix.servo.publish.MetricFilter,boolean)"
+- "name": "[com.netflix.servo.publish.JvmMetricPoller].poll(com.netflix.servo.publish.MetricFilter,boolean)"
   "params":
   - "name": "arg0"
     "type": "com.netflix.servo.publish.MetricFilter"
@@ -33,9 +25,7 @@
     "type": "boolean"
   "return_type": "java.util.List<Metric>"
   "signature": "[com.netflix.servo.publish.JvmMetricPoller].poll(com.netflix.servo.publish.MetricFilter,boolean)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.netflix.servo.monitor.DynamicCounter].increment(java.lang.String,java.lang.String[])"
+- "name": "[com.netflix.servo.monitor.DynamicCounter].increment(java.lang.String,java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -43,9 +33,7 @@
     "type": "java.lang.String[]"
   "return_type": "void"
   "signature": "[com.netflix.servo.monitor.DynamicCounter].increment(java.lang.String,java.lang.String[])"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.netflix.servo.SpectatorContext].register(com.netflix.servo.monitor.Monitor<?>)"
+- "name": "[com.netflix.servo.SpectatorContext].register(com.netflix.servo.monitor.Monitor<?>)"
   "params":
   - "name": "arg0"
     "type": "com.netflix.servo.monitor.Monitor<?>"

--- a/benchmark-sets/jvm-all/sketches-core.yaml
+++ b/benchmark-sets/jvm-all/sketches-core.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow].<init>(org.apache.datasketches.partitions.Partitioner$StackElement)"
+- "name": "[org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow].<init>(org.apache.datasketches.partitions.Partitioner$StackElement)"
   "params":
   - "name": "arg0"
     "type": "org.apache.datasketches.partitions.Partitioner$StackElement"
   "return_type": "org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow"
   "signature": "[org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow].<init>(org.apache.datasketches.partitions.Partitioner$StackElement)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.cpc.CpcWrapper].<init>(org.apache.datasketches.memory.Memory)"
+- "name": "[org.apache.datasketches.cpc.CpcWrapper].<init>(org.apache.datasketches.memory.Memory)"
   "params":
   - "name": "arg0"
     "type": "org.apache.datasketches.memory.Memory"
   "return_type": "org.apache.datasketches.cpc.CpcWrapper"
   "signature": "[org.apache.datasketches.cpc.CpcWrapper].<init>(org.apache.datasketches.memory.Memory)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.DoublesSketchSortedView].<init>(double[],long[],org.apache.datasketches.quantilescommon.QuantilesDoublesAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.DoublesSketchSortedView].<init>(double[],long[],org.apache.datasketches.quantilescommon.QuantilesDoublesAPI)"
   "params":
   - "name": "arg0"
     "type": "double[]"
@@ -27,9 +21,7 @@
     "type": "org.apache.datasketches.quantilescommon.QuantilesDoublesAPI"
   "return_type": "org.apache.datasketches.quantilescommon.DoublesSketchSortedView"
   "signature": "[org.apache.datasketches.quantilescommon.DoublesSketchSortedView].<init>(double[],long[],org.apache.datasketches.quantilescommon.QuantilesDoublesAPI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.FloatsSketchSortedView].<init>(float[],long[],org.apache.datasketches.quantilescommon.QuantilesFloatsAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.FloatsSketchSortedView].<init>(float[],long[],org.apache.datasketches.quantilescommon.QuantilesFloatsAPI)"
   "params":
   - "name": "arg0"
     "type": "float[]"
@@ -39,9 +31,7 @@
     "type": "org.apache.datasketches.quantilescommon.QuantilesFloatsAPI"
   "return_type": "org.apache.datasketches.quantilescommon.FloatsSketchSortedView"
   "signature": "[org.apache.datasketches.quantilescommon.FloatsSketchSortedView].<init>(float[],long[],org.apache.datasketches.quantilescommon.QuantilesFloatsAPI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.LongsSketchSortedView].<init>(long[],long[],org.apache.datasketches.quantilescommon.QuantilesLongsAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.LongsSketchSortedView].<init>(long[],long[],org.apache.datasketches.quantilescommon.QuantilesLongsAPI)"
   "params":
   - "name": "arg0"
     "type": "long[]"
@@ -51,9 +41,7 @@
     "type": "org.apache.datasketches.quantilescommon.QuantilesLongsAPI"
   "return_type": "org.apache.datasketches.quantilescommon.LongsSketchSortedView"
   "signature": "[org.apache.datasketches.quantilescommon.LongsSketchSortedView].<init>(long[],long[],org.apache.datasketches.quantilescommon.QuantilesLongsAPI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.ItemsSketchSortedView].<init>(java.lang.Object[],long[],org.apache.datasketches.quantilescommon.QuantilesGenericAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.ItemsSketchSortedView].<init>(java.lang.Object[],long[],org.apache.datasketches.quantilescommon.QuantilesGenericAPI)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"

--- a/benchmark-sets/jvm-all/slf4j-api.yaml
+++ b/benchmark-sets/jvm-all/slf4j-api.yaml
@@ -1,47 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.SubstituteLogger].isEnabledForLevel(org.slf4j.event.Level)"
+- "name": "[org.slf4j.helpers.SubstituteLogger].isEnabledForLevel(org.slf4j.event.Level)"
   "params":
   - "name": "arg0"
     "type": "org.slf4j.event.Level"
   "return_type": "boolean"
   "signature": "[org.slf4j.helpers.SubstituteLogger].isEnabledForLevel(org.slf4j.event.Level)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.slf4j.helpers.Reporter].info(java.lang.String)"
+- "name": "[org.slf4j.helpers.Reporter].info(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.slf4j.helpers.Reporter].info(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.slf4j.helpers.Reporter].warn(java.lang.String)"
+- "name": "[org.slf4j.helpers.Reporter].warn(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.slf4j.helpers.Reporter].warn(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.SubstituteLogger].log(org.slf4j.event.LoggingEvent)"
+- "name": "[org.slf4j.helpers.SubstituteLogger].log(org.slf4j.event.LoggingEvent)"
   "params":
   - "name": "arg0"
     "type": "org.slf4j.event.LoggingEvent"
   "return_type": "void"
   "signature": "[org.slf4j.helpers.SubstituteLogger].log(org.slf4j.event.LoggingEvent)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.helpers.SubstituteLoggerFactory].getLogger(java.lang.String)"
+- "name": "[org.slf4j.helpers.SubstituteLoggerFactory].getLogger(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.slf4j.Logger"
   "signature": "[org.slf4j.helpers.SubstituteLoggerFactory].getLogger(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.slf4j.event.EventRecordingLogger].<init>(org.slf4j.helpers.SubstituteLogger,java.util.Queue)"
+- "name": "[org.slf4j.event.EventRecordingLogger].<init>(org.slf4j.helpers.SubstituteLogger,java.util.Queue)"
   "params":
   - "name": "arg0"
     "type": "org.slf4j.helpers.SubstituteLogger"

--- a/benchmark-sets/jvm-all/snakeyaml.yaml
+++ b/benchmark-sets/jvm-all/snakeyaml.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructScalar].construct(org.yaml.snakeyaml.nodes.Node)"
+- "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructScalar].construct(org.yaml.snakeyaml.nodes.Node)"
   "params":
   - "name": "arg0"
     "type": "org.yaml.snakeyaml.Node"
   "return_type": "java.lang.Object"
   "signature": "[org.yaml.snakeyaml.constructor.Constructor$ConstructScalar].construct(org.yaml.snakeyaml.nodes.Node)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject].construct(org.yaml.snakeyaml.nodes.Node)"
+- "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject].construct(org.yaml.snakeyaml.nodes.Node)"
   "params":
   - "name": "arg0"
     "type": "org.yaml.snakeyaml.Node"
   "return_type": "java.lang.Object"
   "signature": "[org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject].construct(org.yaml.snakeyaml.nodes.Node)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
+- "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "org.yaml.snakeyaml.Node"
@@ -25,9 +19,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor$ConstructCompactObject].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
+- "name": "[org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor$ConstructCompactObject].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "org.yaml.snakeyaml.Node"
@@ -35,9 +27,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[org.yaml.snakeyaml.extensions.compactnotation.CompactConstructor$ConstructCompactObject].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructMapping].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
+- "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructMapping].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "org.yaml.snakeyaml.Node"
@@ -45,9 +35,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[org.yaml.snakeyaml.constructor.Constructor$ConstructMapping].construct2ndStep(org.yaml.snakeyaml.nodes.Node,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructMapping].construct(org.yaml.snakeyaml.nodes.Node)"
+- "name": "[org.yaml.snakeyaml.constructor.Constructor$ConstructMapping].construct(org.yaml.snakeyaml.nodes.Node)"
   "params":
   - "name": "arg0"
     "type": "org.yaml.snakeyaml.Node"

--- a/benchmark-sets/jvm-all/snappy-java.yaml
+++ b/benchmark-sets/jvm-all/snappy-java.yaml
@@ -1,16 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.xerial.snappy.SnappyFramedInputStream].read(java.nio.ByteBuffer)"
+- "name": "[org.xerial.snappy.SnappyFramedInputStream].read(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"
   "return_type": "void"
   "signature": "[org.xerial.snappy.SnappyFramedInputStream].read(java.nio.ByteBuffer)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": true
-  "name": "[org.xerial.snappy.SnappyCodec].readHeader(java.io.InputStream)"
+- "name": "[org.xerial.snappy.SnappyCodec].readHeader(java.io.InputStream)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"

--- a/benchmark-sets/jvm-all/spatial4j.yaml
+++ b/benchmark-sets/jvm-all/spatial4j.yaml
@@ -1,9 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  - "com.fasterxml.jackson.core.JsonProcessingException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.jackson.GeometryDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
+- "name": "[org.locationtech.spatial4j.io.jackson.GeometryDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.JsonParser"
@@ -11,11 +7,7 @@
     "type": "com.fasterxml.jackson.databind.DeserializationContext"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.spatial4j.io.jackson.GeometryDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
-- "exceptions":
-  - "java.io.IOException"
-  - "com.fasterxml.jackson.core.JsonProcessingException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.jackson.ShapeDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
+- "name": "[org.locationtech.spatial4j.io.jackson.ShapeDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.JsonParser"
@@ -23,37 +15,25 @@
     "type": "com.fasterxml.jackson.databind.DeserializationContext"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.jackson.ShapeDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.SupportedFormats].read(java.lang.String)"
+- "name": "[org.locationtech.spatial4j.io.SupportedFormats].read(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.SupportedFormats].read(java.lang.String)"
-- "exceptions":
-  - "org.locationtech.spatial4j.exception.InvalidShapeException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.WKTReader].readIfSupported(java.lang.Object)"
+- "name": "[org.locationtech.spatial4j.io.WKTReader].readIfSupported(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.WKTReader].readIfSupported(java.lang.Object)"
-- "exceptions":
-  - "org.locationtech.spatial4j.exception.InvalidShapeException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.GeoJSONReader].readIfSupported(java.lang.Object)"
+- "name": "[org.locationtech.spatial4j.io.GeoJSONReader].readIfSupported(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.GeoJSONReader].readIfSupported(java.lang.Object)"
-- "exceptions":
-  - "java.io.IOException"
-  - "java.text.ParseException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.GeoJSONReader].read(java.io.Reader)"
+- "name": "[org.locationtech.spatial4j.io.GeoJSONReader].read(java.io.Reader)"
   "params":
   - "name": "arg0"
     "type": "java.io.Reader"

--- a/benchmark-sets/jvm-all/spring-retry.yaml
+++ b/benchmark-sets/jvm-all/spring-retry.yaml
@@ -1,24 +1,17 @@
 "functions":
-- "exceptions":
-  - "java.lang.Throwable"
-  "is_jvm_static": false
-  "name": "[org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor].invoke(org.aopalliance.intercept.MethodInvocation)"
+- "name": "[org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor].invoke(org.aopalliance.intercept.MethodInvocation)"
   "params":
   - "name": "arg0"
     "type": "org.aopalliance.intercept.MethodInvocation"
   "return_type": "java.lang.Object"
   "signature": "[org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor].invoke(org.aopalliance.intercept.MethodInvocation)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.springframework.retry.policy.CompositeRetryPolicy].canRetry(org.springframework.retry.RetryContext)"
+- "name": "[org.springframework.retry.policy.CompositeRetryPolicy].canRetry(org.springframework.retry.RetryContext)"
   "params":
   - "name": "arg0"
     "type": "org.springframework.retry.RetryContext"
   "return_type": "boolean"
   "signature": "[org.springframework.retry.policy.CompositeRetryPolicy].canRetry(org.springframework.retry.RetryContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.springframework.retry.policy.CompositeRetryPolicy].registerThrowable(org.springframework.retry.RetryContext,java.lang.Throwable)"
+- "name": "[org.springframework.retry.policy.CompositeRetryPolicy].registerThrowable(org.springframework.retry.RetryContext,java.lang.Throwable)"
   "params":
   - "name": "arg0"
     "type": "org.springframework.retry.RetryContext"
@@ -26,9 +19,7 @@
     "type": "java.lang.Throwable"
   "return_type": "void"
   "signature": "[org.springframework.retry.policy.CompositeRetryPolicy].registerThrowable(org.springframework.retry.RetryContext,java.lang.Throwable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.springframework.retry.policy.CircuitBreakerRetryPolicy].registerThrowable(org.springframework.retry.RetryContext,java.lang.Throwable)"
+- "name": "[org.springframework.retry.policy.CircuitBreakerRetryPolicy].registerThrowable(org.springframework.retry.RetryContext,java.lang.Throwable)"
   "params":
   - "name": "arg0"
     "type": "org.springframework.retry.RetryContext"
@@ -36,17 +27,13 @@
     "type": "java.lang.Throwable"
   "return_type": "void"
   "signature": "[org.springframework.retry.policy.CircuitBreakerRetryPolicy].registerThrowable(org.springframework.retry.RetryContext,java.lang.Throwable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.springframework.retry.policy.CircuitBreakerRetryPolicy].canRetry(org.springframework.retry.RetryContext)"
+- "name": "[org.springframework.retry.policy.CircuitBreakerRetryPolicy].canRetry(org.springframework.retry.RetryContext)"
   "params":
   - "name": "arg0"
     "type": "org.springframework.retry.RetryContext"
   "return_type": "boolean"
   "signature": "[org.springframework.retry.policy.CircuitBreakerRetryPolicy].canRetry(org.springframework.retry.RetryContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.springframework.classify.BackToBackPatternClassifier].classify(java.lang.Object)"
+- "name": "[org.springframework.classify.BackToBackPatternClassifier].classify(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/spring-webflow.yaml
+++ b/benchmark-sets/jvm-all/spring-webflow.yaml
@@ -1,43 +1,29 @@
 "functions":
-- "exceptions":
-  - "org.springframework.webflow.engine.model.registry.NoSuchFlowModelException"
-  "is_jvm_static": false
-  "name": "[org.springframework.webflow.engine.model.registry.FlowModelRegistryImpl].getFlowModel(java.lang.String)"
+- "name": "[org.springframework.webflow.engine.model.registry.FlowModelRegistryImpl].getFlowModel(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.springframework.webflow.engine.model.FlowModel"
   "signature": "[org.springframework.webflow.engine.model.registry.FlowModelRegistryImpl].getFlowModel(java.lang.String)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.springframework.webflow.engine.Flow].setStartState(java.lang.String)"
+- "name": "[org.springframework.webflow.engine.Flow].setStartState(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.springframework.webflow.engine.Flow].setStartState(java.lang.String)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.springframework.webflow.engine.Flow].setStartState(org.springframework.webflow.engine.State)"
+- "name": "[org.springframework.webflow.engine.Flow].setStartState(org.springframework.webflow.engine.State)"
   "params":
   - "name": "arg0"
     "type": "org.springframework.webflow.engine.State"
   "return_type": "void"
   "signature": "[org.springframework.webflow.engine.Flow].setStartState(org.springframework.webflow.engine.State)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.springframework.core.convert.support.ConvertingPropertyEditorAdapter].setAsText(java.lang.String)"
+- "name": "[org.springframework.core.convert.support.ConvertingPropertyEditorAdapter].setAsText(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[org.springframework.core.convert.support.ConvertingPropertyEditorAdapter].setAsText(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.springframework.webflow.expression.spel.ScopeSearchingPropertyAccessor].write(org.springframework.expression.EvaluationContext,java.lang.Object,java.lang.String,java.lang.Object)"
+- "name": "[org.springframework.webflow.expression.spel.ScopeSearchingPropertyAccessor].write(org.springframework.expression.EvaluationContext,java.lang.Object,java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "org.springframework.expression.EvaluationContext"
@@ -49,10 +35,7 @@
     "type": "java.lang.Object"
   "return_type": "void"
   "signature": "[org.springframework.webflow.expression.spel.ScopeSearchingPropertyAccessor].write(org.springframework.expression.EvaluationContext,java.lang.Object,java.lang.String,java.lang.Object)"
-- "exceptions":
-  - "org.springframework.binding.convert.ConversionExecutorNotFoundException"
-  "is_jvm_static": false
-  "name": "[org.springframework.binding.convert.service.GenericConversionService].getConversionExecutor(java.lang.String,java.lang.Class<?>,java.lang.Class<?>)"
+- "name": "[org.springframework.binding.convert.service.GenericConversionService].getConversionExecutor(java.lang.String,java.lang.Class<?>,java.lang.Class<?>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/sqlite-jdbc.yaml
+++ b/benchmark-sets/jvm-all/sqlite-jdbc.yaml
@@ -1,25 +1,17 @@
 "functions":
-- "exceptions":
-  - "java.sql.SQLException"
-  "is_jvm_static": true
-  "name": "[org.sqlite.ExtendedCommand$BackupCommand].parse(java.lang.String)"
+- "name": "[org.sqlite.ExtendedCommand$BackupCommand].parse(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.sqlite.ExtendedCommand$BackupCommand"
   "signature": "[org.sqlite.ExtendedCommand$BackupCommand].parse(java.lang.String)"
-- "exceptions":
-  - "java.sql.SQLException"
-  "is_jvm_static": true
-  "name": "[org.sqlite.ExtendedCommand$RestoreCommand].parse(java.lang.String)"
+- "name": "[org.sqlite.ExtendedCommand$RestoreCommand].parse(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.sqlite.ExtendedCommand$RestoreCommand"
   "signature": "[org.sqlite.ExtendedCommand$RestoreCommand].parse(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.sqlite.SQLiteConnectionConfig].<init>(org.sqlite.SQLiteConfig$DateClass,org.sqlite.SQLiteConfig$DatePrecision,java.lang.String,int,org.sqlite.SQLiteConfig$TransactionMode,boolean)"
+- "name": "[org.sqlite.SQLiteConnectionConfig].<init>(org.sqlite.SQLiteConfig$DateClass,org.sqlite.SQLiteConfig$DatePrecision,java.lang.String,int,org.sqlite.SQLiteConfig$TransactionMode,boolean)"
   "params":
   - "name": "arg0"
     "type": "org.sqlite.SQLiteConfig$DateClass"
@@ -35,26 +27,19 @@
     "type": "boolean"
   "return_type": "org.sqlite.SQLiteConnectionConfig"
   "signature": "[org.sqlite.SQLiteConnectionConfig].<init>(org.sqlite.SQLiteConfig$DateClass,org.sqlite.SQLiteConfig$DatePrecision,java.lang.String,int,org.sqlite.SQLiteConfig$TransactionMode,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.sqlite.SQLiteConfig].<init>(java.util.Properties)"
+- "name": "[org.sqlite.SQLiteConfig].<init>(java.util.Properties)"
   "params":
   - "name": "arg0"
     "type": "java.util.Properties"
   "return_type": "org.sqlite.SQLiteConfig"
   "signature": "[org.sqlite.SQLiteConfig].<init>(java.util.Properties)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.sqlite.ExtendedCommand].removeQuotation(java.lang.String)"
+- "name": "[org.sqlite.ExtendedCommand].removeQuotation(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.sqlite.ExtendedCommand].removeQuotation(java.lang.String)"
-- "exceptions":
-  - "java.sql.SQLException"
-  "is_jvm_static": false
-  "name": "[org.sqlite.ExtendedCommand$RestoreCommand].execute(org.sqlite.core.DB)"
+- "name": "[org.sqlite.ExtendedCommand$RestoreCommand].execute(org.sqlite.core.DB)"
   "params":
   - "name": "arg0"
     "type": "org.sqlite.core.DB"

--- a/benchmark-sets/jvm-all/stringtemplate4.yaml
+++ b/benchmark-sets/jvm-all/stringtemplate4.yaml
@@ -1,25 +1,17 @@
 "functions":
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.compiler.CodeGenerator].ifstat(org.antlr.runtime.tree.CommonTree)"
+- "name": "[org.stringtemplate.v4.compiler.CodeGenerator].ifstat(org.antlr.runtime.tree.CommonTree)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.runtime.tree.CommonTree"
   "return_type": "void"
   "signature": "[org.stringtemplate.v4.compiler.CodeGenerator].ifstat(org.antlr.runtime.tree.CommonTree)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.compiler.CodeGenerator].compoundElement(org.antlr.runtime.tree.CommonTree)"
+- "name": "[org.stringtemplate.v4.compiler.CodeGenerator].compoundElement(org.antlr.runtime.tree.CommonTree)"
   "params":
   - "name": "arg0"
     "type": "org.antlr.runtime.tree.CommonTree"
   "return_type": "void"
   "signature": "[org.stringtemplate.v4.compiler.CodeGenerator].compoundElement(org.antlr.runtime.tree.CommonTree)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.STGroup].defineTemplateOrRegion(java.lang.String,java.lang.String,org.antlr.runtime.Token,java.lang.String,org.antlr.runtime.Token,java.util.List<FormalArgument>)"
+- "name": "[org.stringtemplate.v4.STGroup].defineTemplateOrRegion(java.lang.String,java.lang.String,org.antlr.runtime.Token,java.lang.String,org.antlr.runtime.Token,java.util.List<FormalArgument>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -35,9 +27,7 @@
     "type": "java.util.List<FormalArgument>"
   "return_type": "void"
   "signature": "[org.stringtemplate.v4.STGroup].defineTemplateOrRegion(java.lang.String,java.lang.String,org.antlr.runtime.Token,java.lang.String,org.antlr.runtime.Token,java.util.List<FormalArgument>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.STGroup].defineRegion(java.lang.String,org.antlr.runtime.Token,java.lang.String,org.antlr.runtime.Token)"
+- "name": "[org.stringtemplate.v4.STGroup].defineRegion(java.lang.String,org.antlr.runtime.Token,java.lang.String,org.antlr.runtime.Token)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -49,27 +39,19 @@
     "type": "org.antlr.runtime.Token"
   "return_type": "org.stringtemplate.v4.compiler.CompiledST"
   "signature": "[org.stringtemplate.v4.STGroup].defineRegion(java.lang.String,org.antlr.runtime.Token,java.lang.String,org.antlr.runtime.Token)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.compiler.GroupParser].defaultValuePair(java.util.Map<String,Object>)"
+- "name": "[org.stringtemplate.v4.compiler.GroupParser].defaultValuePair(java.util.Map<String,Object>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Map<String,Object>"
   "return_type": "void"
   "signature": "[org.stringtemplate.v4.compiler.GroupParser].defaultValuePair(java.util.Map<String,Object>)"
-- "exceptions":
-  - "org.antlr.runtime.RecognitionException"
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.compiler.GroupParser].keyValuePair(java.util.Map<String,Object>)"
+- "name": "[org.stringtemplate.v4.compiler.GroupParser].keyValuePair(java.util.Map<String,Object>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Map<String,Object>"
   "return_type": "void"
   "signature": "[org.stringtemplate.v4.compiler.GroupParser].keyValuePair(java.util.Map<String,Object>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.ST].<init>(org.stringtemplate.v4.STGroup,java.lang.String)"
+- "name": "[org.stringtemplate.v4.ST].<init>(org.stringtemplate.v4.STGroup,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "org.stringtemplate.v4.STGroup"
@@ -77,9 +59,7 @@
     "type": "java.lang.String"
   "return_type": "org.stringtemplate.v4.ST"
   "signature": "[org.stringtemplate.v4.ST].<init>(org.stringtemplate.v4.STGroup,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.stringtemplate.v4.ST].<init>(java.lang.String)"
+- "name": "[org.stringtemplate.v4.ST].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/struts.yaml
+++ b/benchmark-sets/jvm-all/struts.yaml
@@ -1,53 +1,35 @@
 "functions":
-- "exceptions":
-  - "org.apache.jasper.JasperException"
-  "is_jvm_static": false
-  "name": "[org.apache.jasper.compiler.Node$Nodes].visit(org.apache.jasper.compiler.Node$Visitor)"
+- "name": "[org.apache.jasper.compiler.Node$Nodes].visit(org.apache.jasper.compiler.Node$Visitor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.jasper.compiler.Node$Visitor"
   "return_type": "void"
   "signature": "[org.apache.jasper.compiler.Node$Nodes].visit(org.apache.jasper.compiler.Node$Visitor)"
-- "exceptions":
-  - "org.apache.jasper.JasperException"
-  "is_jvm_static": false
-  "name": "[org.apache.jasper.compiler.Node$NamedAttribute].accept(org.apache.jasper.compiler.Node$Visitor)"
+- "name": "[org.apache.jasper.compiler.Node$NamedAttribute].accept(org.apache.jasper.compiler.Node$Visitor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.jasper.compiler.Node$Visitor"
   "return_type": "void"
   "signature": "[org.apache.jasper.compiler.Node$NamedAttribute].accept(org.apache.jasper.compiler.Node$Visitor)"
-- "exceptions":
-  - "org.apache.jasper.JasperException"
-  "is_jvm_static": false
-  "name": "[org.apache.jasper.compiler.Node$Visitor].visit(org.apache.jasper.compiler.Node$NamedAttribute)"
+- "name": "[org.apache.jasper.compiler.Node$Visitor].visit(org.apache.jasper.compiler.Node$NamedAttribute)"
   "params":
   - "name": "arg0"
     "type": "org.apache.jasper.compiler.Node$NamedAttribute"
   "return_type": "void"
   "signature": "[org.apache.jasper.compiler.Node$Visitor].visit(org.apache.jasper.compiler.Node$NamedAttribute)"
-- "exceptions":
-  - "org.apache.jasper.JasperException"
-  "is_jvm_static": false
-  "name": "[org.apache.jasper.compiler.Node$AttributeGenerator].accept(org.apache.jasper.compiler.Node$Visitor)"
+- "name": "[org.apache.jasper.compiler.Node$AttributeGenerator].accept(org.apache.jasper.compiler.Node$Visitor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.jasper.compiler.Node$Visitor"
   "return_type": "void"
   "signature": "[org.apache.jasper.compiler.Node$AttributeGenerator].accept(org.apache.jasper.compiler.Node$Visitor)"
-- "exceptions":
-  - "org.apache.jasper.JasperException"
-  "is_jvm_static": false
-  "name": "[org.apache.jasper.compiler.Node$Visitor].visit(org.apache.jasper.compiler.Node$AttributeGenerator)"
+- "name": "[org.apache.jasper.compiler.Node$Visitor].visit(org.apache.jasper.compiler.Node$AttributeGenerator)"
   "params":
   - "name": "arg0"
     "type": "org.apache.jasper.compiler.Node$AttributeGenerator"
   "return_type": "void"
   "signature": "[org.apache.jasper.compiler.Node$Visitor].visit(org.apache.jasper.compiler.Node$AttributeGenerator)"
-- "exceptions":
-  - "org.apache.jasper.JasperException"
-  "is_jvm_static": false
-  "name": "[org.apache.jasper.compiler.Node$DoBodyAction].accept(org.apache.jasper.compiler.Node$Visitor)"
+- "name": "[org.apache.jasper.compiler.Node$DoBodyAction].accept(org.apache.jasper.compiler.Node$Visitor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.jasper.compiler.Node$Visitor"

--- a/benchmark-sets/jvm-all/threetenbp.yaml
+++ b/benchmark-sets/jvm-all/threetenbp.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.format.DateTimeFormatter].format(org.threeten.bp.temporal.TemporalAccessor)"
+- "name": "[org.threeten.bp.format.DateTimeFormatter].format(org.threeten.bp.temporal.TemporalAccessor)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalAccessor"
   "return_type": "java.lang.String"
   "signature": "[org.threeten.bp.format.DateTimeFormatter].format(org.threeten.bp.temporal.TemporalAccessor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.format.DateTimeFormatter].formatTo(org.threeten.bp.temporal.TemporalAccessor,java.lang.Appendable)"
+- "name": "[org.threeten.bp.format.DateTimeFormatter].formatTo(org.threeten.bp.temporal.TemporalAccessor,java.lang.Appendable)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalAccessor"
@@ -17,41 +13,31 @@
     "type": "java.lang.Appendable"
   "return_type": "void"
   "signature": "[org.threeten.bp.format.DateTimeFormatter].formatTo(org.threeten.bp.temporal.TemporalAccessor,java.lang.Appendable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.Instant].query(org.threeten.bp.temporal.TemporalQuery<R>)"
+- "name": "[org.threeten.bp.Instant].query(org.threeten.bp.temporal.TemporalQuery<R>)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalQuery<R>"
   "return_type": "java.lang.Object"
   "signature": "[org.threeten.bp.Instant].query(org.threeten.bp.temporal.TemporalQuery<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.ZoneOffset].query(org.threeten.bp.temporal.TemporalQuery<R>)"
+- "name": "[org.threeten.bp.ZoneOffset].query(org.threeten.bp.temporal.TemporalQuery<R>)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalQuery<R>"
   "return_type": "java.lang.Object"
   "signature": "[org.threeten.bp.ZoneOffset].query(org.threeten.bp.temporal.TemporalQuery<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.LocalTime].query(org.threeten.bp.temporal.TemporalQuery<R>)"
+- "name": "[org.threeten.bp.LocalTime].query(org.threeten.bp.temporal.TemporalQuery<R>)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalQuery<R>"
   "return_type": "java.lang.Object"
   "signature": "[org.threeten.bp.LocalTime].query(org.threeten.bp.temporal.TemporalQuery<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.Duration].addTo(org.threeten.bp.temporal.Temporal)"
+- "name": "[org.threeten.bp.Duration].addTo(org.threeten.bp.temporal.Temporal)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.Temporal"
   "return_type": "org.threeten.bp.temporal.Temporal"
   "signature": "[org.threeten.bp.Duration].addTo(org.threeten.bp.temporal.Temporal)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.threeten.bp.ZonedDateTime].ofInstant(org.threeten.bp.Instant,org.threeten.bp.ZoneId)"
+- "name": "[org.threeten.bp.ZonedDateTime].ofInstant(org.threeten.bp.Instant,org.threeten.bp.ZoneId)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.Instant"
@@ -59,25 +45,19 @@
     "type": "org.threeten.bp.ZoneId"
   "return_type": "org.threeten.bp.ZonedDateTime"
   "signature": "[org.threeten.bp.ZonedDateTime].ofInstant(org.threeten.bp.Instant,org.threeten.bp.ZoneId)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.LocalDate].minusYears(long)"
+- "name": "[org.threeten.bp.LocalDate].minusYears(long)"
   "params":
   - "name": "arg0"
     "type": "long"
   "return_type": "org.threeten.bp.LocalDate"
   "signature": "[org.threeten.bp.LocalDate].minusYears(long)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.chrono.JapaneseChronology].dateEpochDay(long)"
+- "name": "[org.threeten.bp.chrono.JapaneseChronology].dateEpochDay(long)"
   "params":
   - "name": "arg0"
     "type": "long"
   "return_type": "org.threeten.bp.chrono.JapaneseDate"
   "signature": "[org.threeten.bp.chrono.JapaneseChronology].dateEpochDay(long)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.chrono.HijrahChronology].dateEpochDay(long)"
+- "name": "[org.threeten.bp.chrono.HijrahChronology].dateEpochDay(long)"
   "params":
   - "name": "arg0"
     "type": "long"

--- a/benchmark-sets/jvm-all/twelve-monkeys.yaml
+++ b/benchmark-sets/jvm-all/twelve-monkeys.yaml
@@ -1,41 +1,29 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.util.TimeFormat].<init>(java.lang.String)"
+- "name": "[com.twelvemonkeys.util.TimeFormat].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.twelvemonkeys.util.TimeFormat"
   "signature": "[com.twelvemonkeys.util.TimeFormat].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.imageio.spi.ProviderInfo].<init>(java.lang.Package)"
+- "name": "[com.twelvemonkeys.imageio.spi.ProviderInfo].<init>(java.lang.Package)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Package"
   "return_type": "com.twelvemonkeys.imageio.spi.ProviderInfo"
   "signature": "[com.twelvemonkeys.imageio.spi.ProviderInfo].<init>(java.lang.Package)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.io.ole2.CompoundDocument].<init>(java.io.File)"
+- "name": "[com.twelvemonkeys.io.ole2.CompoundDocument].<init>(java.io.File)"
   "params":
   - "name": "arg0"
     "type": "java.io.File"
   "return_type": "com.twelvemonkeys.io.ole2.CompoundDocument"
   "signature": "[com.twelvemonkeys.io.ole2.CompoundDocument].<init>(java.io.File)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.io.ole2.CompoundDocument].<init>(javax.imageio.stream.ImageInputStream)"
+- "name": "[com.twelvemonkeys.io.ole2.CompoundDocument].<init>(javax.imageio.stream.ImageInputStream)"
   "params":
   - "name": "arg0"
     "type": "javax.imageio.stream.ImageInputStream"
   "return_type": "com.twelvemonkeys.io.ole2.CompoundDocument"
   "signature": "[com.twelvemonkeys.io.ole2.CompoundDocument].<init>(javax.imageio.stream.ImageInputStream)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.image.ResampleOp].<init>(int,int,java.awt.RenderingHints)"
+- "name": "[com.twelvemonkeys.image.ResampleOp].<init>(int,int,java.awt.RenderingHints)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -45,9 +33,7 @@
     "type": "java.awt.RenderingHints"
   "return_type": "com.twelvemonkeys.image.ResampleOp"
   "signature": "[com.twelvemonkeys.image.ResampleOp].<init>(int,int,java.awt.RenderingHints)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.imageio.metadata.tiff.TIFFEntry].<init>(int,java.lang.Object)"
+- "name": "[com.twelvemonkeys.imageio.metadata.tiff.TIFFEntry].<init>(int,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -55,17 +41,13 @@
     "type": "java.lang.Object"
   "return_type": "com.twelvemonkeys.imageio.metadata.tiff.TIFFEntry"
   "signature": "[com.twelvemonkeys.imageio.metadata.tiff.TIFFEntry].<init>(int,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.image.BufferedImageIcon].<init>(java.awt.image.BufferedImage)"
+- "name": "[com.twelvemonkeys.image.BufferedImageIcon].<init>(java.awt.image.BufferedImage)"
   "params":
   - "name": "arg0"
     "type": "java.awt.image.BufferedImage"
   "return_type": "com.twelvemonkeys.image.BufferedImageIcon"
   "signature": "[com.twelvemonkeys.image.BufferedImageIcon].<init>(java.awt.image.BufferedImage)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.twelvemonkeys.image.BrightnessContrastFilter].<init>(float,float)"
+- "name": "[com.twelvemonkeys.image.BrightnessContrastFilter].<init>(float,float)"
   "params":
   - "name": "arg0"
     "type": "float"

--- a/benchmark-sets/jvm-all/twitter4j.yaml
+++ b/benchmark-sets/jvm-all/twitter4j.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.TimeSpanConverter].<init>(java.util.Locale)"
+- "name": "[twitter4j.TimeSpanConverter].<init>(java.util.Locale)"
   "params":
   - "name": "arg0"
     "type": "java.util.Locale"
   "return_type": "twitter4j.TimeSpanConverter"
   "signature": "[twitter4j.TimeSpanConverter].<init>(java.util.Locale)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.management.APIStatistics].<init>(int)"
+- "name": "[twitter4j.management.APIStatistics].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "twitter4j.management.APIStatistics"
   "signature": "[twitter4j.management.APIStatistics].<init>(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.management.InvocationStatisticsCalculator].<init>(java.lang.String,int)"
+- "name": "[twitter4j.management.InvocationStatisticsCalculator].<init>(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -25,9 +19,7 @@
     "type": "int"
   "return_type": "twitter4j.management.InvocationStatisticsCalculator"
   "signature": "[twitter4j.management.InvocationStatisticsCalculator].<init>(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.OAuth2Token].<init>(java.lang.String,java.lang.String)"
+- "name": "[twitter4j.OAuth2Token].<init>(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -35,17 +27,13 @@
     "type": "java.lang.String"
   "return_type": "twitter4j.OAuth2Token"
   "signature": "[twitter4j.OAuth2Token].<init>(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.management.APIStatisticsOpenMBean].<init>(twitter4j.management.APIStatistics)"
+- "name": "[twitter4j.management.APIStatisticsOpenMBean].<init>(twitter4j.management.APIStatistics)"
   "params":
   - "name": "arg0"
     "type": "twitter4j.management.APIStatistics"
   "return_type": "twitter4j.management.APIStatisticsOpenMBean"
   "signature": "[twitter4j.management.APIStatisticsOpenMBean].<init>(twitter4j.management.APIStatistics)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[twitter4j.v1.QuickReply].of(java.lang.String,java.lang.String,java.lang.String)"
+- "name": "[twitter4j.v1.QuickReply].of(java.lang.String,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/undertow.yaml
+++ b/benchmark-sets/jvm-all/undertow.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[io.undertow.server.protocol.http.PipeliningBufferingStreamSinkConduit].awaitWritable(long,java.util.concurrent.TimeUnit)"
+- "name": "[io.undertow.server.protocol.http.PipeliningBufferingStreamSinkConduit].awaitWritable(long,java.util.concurrent.TimeUnit)"
   "params":
   - "name": "arg0"
     "type": "long"
@@ -10,10 +7,7 @@
     "type": "java.util.concurrent.TimeUnit"
   "return_type": "void"
   "signature": "[io.undertow.server.protocol.http.PipeliningBufferingStreamSinkConduit].awaitWritable(long,java.util.concurrent.TimeUnit)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[io.undertow.conduits.PreChunkedStreamSinkConduit].awaitWritable(long,java.util.concurrent.TimeUnit)"
+- "name": "[io.undertow.conduits.PreChunkedStreamSinkConduit].awaitWritable(long,java.util.concurrent.TimeUnit)"
   "params":
   - "name": "arg0"
     "type": "long"
@@ -21,10 +15,7 @@
     "type": "java.util.concurrent.TimeUnit"
   "return_type": "void"
   "signature": "[io.undertow.conduits.PreChunkedStreamSinkConduit].awaitWritable(long,java.util.concurrent.TimeUnit)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[io.undertow.conduits.FixedLengthStreamSourceConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
+- "name": "[io.undertow.conduits.FixedLengthStreamSourceConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
   "params":
   - "name": "arg0"
     "type": "long"
@@ -32,10 +23,7 @@
     "type": "java.util.concurrent.TimeUnit"
   "return_type": "void"
   "signature": "[io.undertow.conduits.FixedLengthStreamSourceConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.xnio.conduits.InflatingStreamSourceConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
+- "name": "[org.xnio.conduits.InflatingStreamSourceConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
   "params":
   - "name": "arg0"
     "type": "long"
@@ -43,10 +31,7 @@
     "type": "java.util.concurrent.TimeUnit"
   "return_type": "void"
   "signature": "[org.xnio.conduits.InflatingStreamSourceConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[io.undertow.server.protocol.ajp.AjpServerRequestConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
+- "name": "[io.undertow.server.protocol.ajp.AjpServerRequestConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
   "params":
   - "name": "arg0"
     "type": "long"
@@ -54,10 +39,7 @@
     "type": "java.util.concurrent.TimeUnit"
   "return_type": "void"
   "signature": "[io.undertow.server.protocol.ajp.AjpServerRequestConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[io.undertow.conduits.IdleTimeoutConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
+- "name": "[io.undertow.conduits.IdleTimeoutConduit].awaitReadable(long,java.util.concurrent.TimeUnit)"
   "params":
   - "name": "arg0"
     "type": "long"

--- a/benchmark-sets/jvm-all/xmlpull.yaml
+++ b/benchmark-sets/jvm-all/xmlpull.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[CloneableFileReader].read(char[],int,int)"
+- "name": "[CloneableFileReader].read(char[],int,int)"
   "params":
   - "name": "arg0"
     "type": "char[]"
@@ -12,43 +9,31 @@
     "type": "int"
   "return_type": "int"
   "signature": "[CloneableFileReader].read(char[],int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[BestDeal].<init>(int)"
+- "name": "[BestDeal].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "BestDeal"
   "signature": "[BestDeal].<init>(int)"
-- "exceptions":
-  - "java.io.FileNotFoundException"
-  "is_jvm_static": false
-  "name": "[CloneableFileReader].<init>(java.lang.String)"
+- "name": "[CloneableFileReader].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "CloneableFileReader"
   "signature": "[CloneableFileReader].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[CloneParser$CloenableCharArrayReader].<init>(char[])"
+- "name": "[CloneParser$CloenableCharArrayReader].<init>(char[])"
   "params":
   - "name": "arg0"
     "type": "char[]"
   "return_type": "CloneParser$CloenableCharArrayReader"
   "signature": "[CloneParser$CloenableCharArrayReader].<init>(char[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.xmlpull.v1.XmlPullParserFactory].setNamespaceAware(boolean)"
+- "name": "[org.xmlpull.v1.XmlPullParserFactory].setNamespaceAware(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "void"
   "signature": "[org.xmlpull.v1.XmlPullParserFactory].setNamespaceAware(boolean)"
-- "exceptions":
-  - "org.xmlpull.v1.XmlPullParserException"
-  "is_jvm_static": true
-  "name": "[org.xmlpull.v1.XmlPullParserFactory].newInstance(java.lang.String,java.lang.Class)"
+- "name": "[org.xmlpull.v1.XmlPullParserFactory].newInstance(java.lang.String,java.lang.Class)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -56,10 +41,7 @@
     "type": "Class"
   "return_type": "org.xmlpull.v1.XmlPullParserFactory"
   "signature": "[org.xmlpull.v1.XmlPullParserFactory].newInstance(java.lang.String,java.lang.Class)"
-- "exceptions":
-  - "org.xmlpull.v1.XmlPullParserException"
-  "is_jvm_static": false
-  "name": "[org.xmlpull.v1.XmlPullParserFactory].setFeature(java.lang.String,boolean)"
+- "name": "[org.xmlpull.v1.XmlPullParserFactory].setFeature(java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-all/xnio-api.yaml
+++ b/benchmark-sets/jvm-all/xnio-api.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.xnio.streams.LimitedInputStream].read(byte[],int,int)"
+- "name": "[org.xnio.streams.LimitedInputStream].read(byte[],int,int)"
   "params":
   - "name": "arg0"
     "type": "byte[]"
@@ -12,10 +9,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "[org.xnio.streams.LimitedInputStream].read(byte[],int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.xnio.conduits.FramingMessageSourceConduit].receive(java.nio.ByteBuffer[],int,int)"
+- "name": "[org.xnio.conduits.FramingMessageSourceConduit].receive(java.nio.ByteBuffer[],int,int)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer[]"
@@ -25,19 +19,13 @@
     "type": "int"
   "return_type": "long"
   "signature": "[org.xnio.conduits.FramingMessageSourceConduit].receive(java.nio.ByteBuffer[],int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.xnio.conduits.FramingMessageSourceConduit].receive(java.nio.ByteBuffer)"
+- "name": "[org.xnio.conduits.FramingMessageSourceConduit].receive(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"
   "return_type": "int"
   "signature": "[org.xnio.conduits.FramingMessageSourceConduit].receive(java.nio.ByteBuffer)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.xnio.channels.FixedLengthStreamSourceChannel].read(java.nio.ByteBuffer[],int,int)"
+- "name": "[org.xnio.channels.FixedLengthStreamSourceChannel].read(java.nio.ByteBuffer[],int,int)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer[]"
@@ -47,10 +35,7 @@
     "type": "int"
   "return_type": "long"
   "signature": "[org.xnio.channels.FixedLengthStreamSourceChannel].read(java.nio.ByteBuffer[],int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": true
-  "name": "[org.xnio.channels.Channels].drain(java.nio.channels.FileChannel,long,long)"
+- "name": "[org.xnio.channels.Channels].drain(java.nio.channels.FileChannel,long,long)"
   "params":
   - "name": "arg0"
     "type": "java.nio.channels.FileChannel"
@@ -60,10 +45,7 @@
     "type": "long"
   "return_type": "long"
   "signature": "[org.xnio.channels.Channels].drain(java.nio.channels.FileChannel,long,long)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": true
-  "name": "[org.xnio.channels.Channels].drain(org.xnio.channels.StreamSourceChannel,long)"
+- "name": "[org.xnio.channels.Channels].drain(org.xnio.channels.StreamSourceChannel,long)"
   "params":
   - "name": "arg0"
     "type": "org.xnio.channels.StreamSourceChannel"

--- a/benchmark-sets/jvm-all/xstream.yaml
+++ b/benchmark-sets/jvm-all/xstream.yaml
@@ -1,25 +1,17 @@
 "functions":
-- "exceptions":
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[com.thoughtworks.xstream.io.xml.SaxWriter].parse(java.lang.String)"
+- "name": "[com.thoughtworks.xstream.io.xml.SaxWriter].parse(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "void"
   "signature": "[com.thoughtworks.xstream.io.xml.SaxWriter].parse(java.lang.String)"
-- "exceptions":
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[com.thoughtworks.xstream.io.xml.SaxWriter].parse(org.xml.sax.InputSource)"
+- "name": "[com.thoughtworks.xstream.io.xml.SaxWriter].parse(org.xml.sax.InputSource)"
   "params":
   - "name": "arg0"
     "type": "org.xml.sax.InputSource"
   "return_type": "void"
   "signature": "[com.thoughtworks.xstream.io.xml.SaxWriter].parse(org.xml.sax.InputSource)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.thoughtworks.xstream.converters.extended.NamedMapConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
+- "name": "[com.thoughtworks.xstream.converters.extended.NamedMapConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -29,9 +21,7 @@
     "type": "com.thoughtworks.xstream.converters.MarshallingContext"
   "return_type": "void"
   "signature": "[com.thoughtworks.xstream.converters.extended.NamedMapConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.thoughtworks.xstream.converters.reflection.SerializableConverter].doMarshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
+- "name": "[com.thoughtworks.xstream.converters.reflection.SerializableConverter].doMarshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -41,9 +31,7 @@
     "type": "com.thoughtworks.xstream.converters.MarshallingContext"
   "return_type": "void"
   "signature": "[com.thoughtworks.xstream.converters.reflection.SerializableConverter].doMarshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.thoughtworks.xstream.converters.reflection.CGLIBEnhancedConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
+- "name": "[com.thoughtworks.xstream.converters.reflection.CGLIBEnhancedConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -53,9 +41,7 @@
     "type": "com.thoughtworks.xstream.converters.MarshallingContext"
   "return_type": "void"
   "signature": "[com.thoughtworks.xstream.converters.reflection.CGLIBEnhancedConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.thoughtworks.xstream.converters.extended.NamedArrayConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
+- "name": "[com.thoughtworks.xstream.converters.extended.NamedArrayConverter].marshal(java.lang.Object,com.thoughtworks.xstream.io.HierarchicalStreamWriter,com.thoughtworks.xstream.converters.MarshallingContext)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-all/xz-java.yaml
+++ b/benchmark-sets/jvm-all/xz-java.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,boolean,org.tukaani.xz.ArrayCache)"
+- "name": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,boolean,org.tukaani.xz.ArrayCache)"
   "params":
   - "name": "arg0"
     "type": "org.tukaani.xz.SeekableInputStream"
@@ -14,10 +11,7 @@
     "type": "org.tukaani.xz.ArrayCache"
   "return_type": "org.tukaani.xz.SeekableXZInputStream"
   "signature": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,boolean,org.tukaani.xz.ArrayCache)"
-- "exceptions":
-  - "org.tukaani.xz.UnsupportedOptionsException"
-  "is_jvm_static": false
-  "name": "[org.tukaani.xz.LZMA2Options].<init>(int,int,int,int,int,int,int,int)"
+- "name": "[org.tukaani.xz.LZMA2Options].<init>(int,int,int,int,int,int,int,int)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -37,10 +31,7 @@
     "type": "int"
   "return_type": "org.tukaani.xz.LZMA2Options"
   "signature": "[org.tukaani.xz.LZMA2Options].<init>(int,int,int,int,int,int,int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,boolean)"
+- "name": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,boolean)"
   "params":
   - "name": "arg0"
     "type": "org.tukaani.xz.SeekableInputStream"
@@ -50,10 +41,7 @@
     "type": "boolean"
   "return_type": "org.tukaani.xz.SeekableXZInputStream"
   "signature": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,org.tukaani.xz.ArrayCache)"
+- "name": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,org.tukaani.xz.ArrayCache)"
   "params":
   - "name": "arg0"
     "type": "org.tukaani.xz.SeekableInputStream"
@@ -63,10 +51,7 @@
     "type": "org.tukaani.xz.ArrayCache"
   "return_type": "org.tukaani.xz.SeekableXZInputStream"
   "signature": "[org.tukaani.xz.SeekableXZInputStream].<init>(org.tukaani.xz.SeekableInputStream,int,org.tukaani.xz.ArrayCache)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.tukaani.xz.LZMAInputStream].<init>(java.io.InputStream,long,int,int,int,int,byte[])"
+- "name": "[org.tukaani.xz.LZMAInputStream].<init>(java.io.InputStream,long,int,int,int,int,byte[])"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -84,10 +69,7 @@
     "type": "byte[]"
   "return_type": "org.tukaani.xz.LZMAInputStream"
   "signature": "[org.tukaani.xz.LZMAInputStream].<init>(java.io.InputStream,long,int,int,int,int,byte[])"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.tukaani.xz.index.IndexDecoder].<init>(org.tukaani.xz.SeekableInputStream,org.tukaani.xz.common.StreamFlags,long,int)"
+- "name": "[org.tukaani.xz.index.IndexDecoder].<init>(org.tukaani.xz.SeekableInputStream,org.tukaani.xz.common.StreamFlags,long,int)"
   "params":
   - "name": "arg0"
     "type": "org.tukaani.xz.SeekableInputStream"

--- a/benchmark-sets/jvm-all/zip4j.yaml
+++ b/benchmark-sets/jvm-all/zip4j.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "net.lingala.zip4j.exception.ZipException"
-  "is_jvm_static": true
-  "name": "[net.lingala.zip4j.crypto.AesCipherUtil].derivePasswordBasedKey(byte[],char[],net.lingala.zip4j.model.enums.AesKeyStrength,boolean)"
+- "name": "[net.lingala.zip4j.crypto.AesCipherUtil].derivePasswordBasedKey(byte[],char[],net.lingala.zip4j.model.enums.AesKeyStrength,boolean)"
   "params":
   - "name": "arg0"
     "type": "byte[]"
@@ -14,9 +11,7 @@
     "type": "boolean"
   "return_type": "byte[]"
   "signature": "[net.lingala.zip4j.crypto.AesCipherUtil].derivePasswordBasedKey(byte[],char[],net.lingala.zip4j.model.enums.AesKeyStrength,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.lingala.zip4j.crypto.PBKDF2.PBKDF2Engine].deriveKey(char[],int,boolean)"
+- "name": "[net.lingala.zip4j.crypto.PBKDF2.PBKDF2Engine].deriveKey(char[],int,boolean)"
   "params":
   - "name": "arg0"
     "type": "char[]"
@@ -26,18 +21,13 @@
     "type": "boolean"
   "return_type": "byte[]"
   "signature": "[net.lingala.zip4j.crypto.PBKDF2.PBKDF2Engine].deriveKey(char[],int,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.lingala.zip4j.model.ZipParameters].<init>(net.lingala.zip4j.model.ZipParameters)"
+- "name": "[net.lingala.zip4j.model.ZipParameters].<init>(net.lingala.zip4j.model.ZipParameters)"
   "params":
   - "name": "arg0"
     "type": "net.lingala.zip4j.model.ZipParameters"
   "return_type": "net.lingala.zip4j.model.ZipParameters"
   "signature": "[net.lingala.zip4j.model.ZipParameters].<init>(net.lingala.zip4j.model.ZipParameters)"
-- "exceptions":
-  - "net.lingala.zip4j.exception.ZipException"
-  "is_jvm_static": false
-  "name": "[net.lingala.zip4j.crypto.AESDecrypter].decryptData(byte[],int,int)"
+- "name": "[net.lingala.zip4j.crypto.AESDecrypter].decryptData(byte[],int,int)"
   "params":
   - "name": "arg0"
     "type": "byte[]"
@@ -47,10 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "[net.lingala.zip4j.crypto.AESDecrypter].decryptData(byte[],int,int)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[net.lingala.zip4j.io.outputstream.ZipOutputStream].<init>(java.io.OutputStream,char[],net.lingala.zip4j.model.Zip4jConfig,net.lingala.zip4j.model.ZipModel)"
+- "name": "[net.lingala.zip4j.io.outputstream.ZipOutputStream].<init>(java.io.OutputStream,char[],net.lingala.zip4j.model.Zip4jConfig,net.lingala.zip4j.model.ZipModel)"
   "params":
   - "name": "arg0"
     "type": "java.io.OutputStream"
@@ -62,9 +49,7 @@
     "type": "net.lingala.zip4j.model.ZipModel"
   "return_type": "net.lingala.zip4j.io.outputstream.ZipOutputStream"
   "signature": "[net.lingala.zip4j.io.outputstream.ZipOutputStream].<init>(java.io.OutputStream,char[],net.lingala.zip4j.model.Zip4jConfig,net.lingala.zip4j.model.ZipModel)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.lingala.zip4j.crypto.engine.ZipCryptoEngine].initKeys(char[],boolean)"
+- "name": "[net.lingala.zip4j.crypto.engine.ZipCryptoEngine].initKeys(char[],boolean)"
   "params":
   - "name": "arg0"
     "type": "char[]"

--- a/benchmark-sets/jvm-all/zookeeper.yaml
+++ b/benchmark-sets/jvm-all/zookeeper.yaml
@@ -1,16 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.zookeeper.server.FinalRequestProcessor].processRequest(org.apache.zookeeper.server.Request)"
+- "name": "[org.apache.zookeeper.server.FinalRequestProcessor].processRequest(org.apache.zookeeper.server.Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.zookeeper.server.Request"
   "return_type": "void"
   "signature": "[org.apache.zookeeper.server.FinalRequestProcessor].processRequest(org.apache.zookeeper.server.Request)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.zookeeper.server.persistence.FileSnap].serialize(org.apache.zookeeper.server.DataTree,java.util.Map<Long,Integer>,java.io.File,boolean)"
+- "name": "[org.apache.zookeeper.server.persistence.FileSnap].serialize(org.apache.zookeeper.server.DataTree,java.util.Map<Long,Integer>,java.io.File,boolean)"
   "params":
   - "name": "arg0"
     "type": "org.apache.zookeeper.server.DataTree"
@@ -22,9 +17,7 @@
     "type": "boolean"
   "return_type": "void"
   "signature": "[org.apache.zookeeper.server.persistence.FileSnap].serialize(org.apache.zookeeper.server.DataTree,java.util.Map<Long,Integer>,java.io.File,boolean)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.zookeeper.common.IOUtils].cleanup(org.slf4j.Logger,java.io.Closeable[])"
+- "name": "[org.apache.zookeeper.common.IOUtils].cleanup(org.slf4j.Logger,java.io.Closeable[])"
   "params":
   - "name": "arg0"
     "type": "org.slf4j.Logger"
@@ -32,10 +25,7 @@
     "type": "java.io.Closeable[]"
   "return_type": "void"
   "signature": "[org.apache.zookeeper.common.IOUtils].cleanup(org.slf4j.Logger,java.io.Closeable[])"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": true
-  "name": "[org.apache.zookeeper.server.persistence.SnapStream].getOutputStream(java.io.File,boolean)"
+- "name": "[org.apache.zookeeper.server.persistence.SnapStream].getOutputStream(java.io.File,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.io.File"
@@ -43,10 +33,7 @@
     "type": "boolean"
   "return_type": "java.util.zip.CheckedOutputStream"
   "signature": "[org.apache.zookeeper.server.persistence.SnapStream].getOutputStream(java.io.File,boolean)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": true
-  "name": "[org.apache.commons.io.IOUtils].close(java.io.Closeable,org.apache.commons.io.function.IOConsumer)"
+- "name": "[org.apache.commons.io.IOUtils].close(java.io.Closeable,org.apache.commons.io.function.IOConsumer)"
   "params":
   - "name": "arg0"
     "type": "java.io.Closeable"
@@ -54,9 +41,7 @@
     "type": "org.apache.commons.io.function.IOConsumer"
   "return_type": "void"
   "signature": "[org.apache.commons.io.IOUtils].close(java.io.Closeable,org.apache.commons.io.function.IOConsumer)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.io.IOUtils].closeQuietly(java.io.Closeable,java.util.function.Consumer)"
+- "name": "[org.apache.commons.io.IOUtils].closeQuietly(java.io.Closeable,java.util.function.Consumer)"
   "params":
   - "name": "arg0"
     "type": "java.io.Closeable"

--- a/benchmark-sets/jvm-all/zxing.yaml
+++ b/benchmark-sets/jvm-all/zxing.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "com.google.zxing.NotFoundException"
-  "is_jvm_static": false
-  "name": "[com.google.zxing.MultiFormatReader].decode(com.google.zxing.BinaryBitmap,java.util.Map<DecodeHintType,?>)"
+- "name": "[com.google.zxing.MultiFormatReader].decode(com.google.zxing.BinaryBitmap,java.util.Map<DecodeHintType,?>)"
   "params":
   - "name": "arg0"
     "type": "com.google.zxing.BinaryBitmap"
@@ -10,9 +7,7 @@
     "type": "java.util.Map<DecodeHintType,?>"
   "return_type": "com.google.zxing.Result"
   "signature": "[com.google.zxing.MultiFormatReader].decode(com.google.zxing.BinaryBitmap,java.util.Map<DecodeHintType,?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.zxing.common.MinimalECIInput].<init>(java.lang.String,java.nio.charset.Charset,int)"
+- "name": "[com.google.zxing.common.MinimalECIInput].<init>(java.lang.String,java.nio.charset.Charset,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -22,20 +17,13 @@
     "type": "int"
   "return_type": "com.google.zxing.common.MinimalECIInput"
   "signature": "[com.google.zxing.common.MinimalECIInput].<init>(java.lang.String,java.nio.charset.Charset,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.zxing.oned.MultiFormatOneDReader].<init>(java.util.Map)"
+- "name": "[com.google.zxing.oned.MultiFormatOneDReader].<init>(java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "java.util.Map"
   "return_type": "com.google.zxing.oned.MultiFormatOneDReader"
   "signature": "[com.google.zxing.oned.MultiFormatOneDReader].<init>(java.util.Map)"
-- "exceptions":
-  - "com.google.zxing.NotFoundException"
-  - "com.google.zxing.ChecksumException"
-  - "com.google.zxing.FormatException"
-  "is_jvm_static": false
-  "name": "[com.google.zxing.multi.ByQuadrantReader].decode(com.google.zxing.BinaryBitmap,java.util.Map<DecodeHintType,?>)"
+- "name": "[com.google.zxing.multi.ByQuadrantReader].decode(com.google.zxing.BinaryBitmap,java.util.Map<DecodeHintType,?>)"
   "params":
   - "name": "arg0"
     "type": "com.google.zxing.BinaryBitmap"
@@ -43,9 +31,7 @@
     "type": "java.util.Map<DecodeHintType,?>"
   "return_type": "com.google.zxing.Result"
   "signature": "[com.google.zxing.multi.ByQuadrantReader].decode(com.google.zxing.BinaryBitmap,java.util.Map<DecodeHintType,?>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.google.zxing.common.ECIEncoderSet].<init>(java.lang.String,java.nio.charset.Charset,int)"
+- "name": "[com.google.zxing.common.ECIEncoderSet].<init>(java.lang.String,java.nio.charset.Charset,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-medium/apache-commons-cli.yaml
+++ b/benchmark-sets/jvm-medium/apache-commons-cli.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String,boolean,java.lang.String)"
+- "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String,boolean,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -14,10 +11,7 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.cli.Option"
   "signature": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String,boolean,java.lang.String)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,boolean,java.lang.String)"
+- "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,boolean,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -27,10 +21,7 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.cli.Option"
   "signature": "[org.apache.commons.cli.Option].<init>(java.lang.String,boolean,java.lang.String)"
-- "exceptions":
-  - "java.lang.IllegalArgumentException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String)"
+- "name": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -38,25 +29,19 @@
     "type": "java.lang.String"
   "return_type": "org.apache.commons.cli.Option"
   "signature": "[org.apache.commons.cli.Option].<init>(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.TypeHandler].<init>(java.util.Map)"
+- "name": "[org.apache.commons.cli.TypeHandler].<init>(java.util.Map)"
   "params":
   - "name": "arg0"
     "type": "Map"
   "return_type": "org.apache.commons.cli.TypeHandler"
   "signature": "[org.apache.commons.cli.TypeHandler].<init>(java.util.Map)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.DefaultParser].<init>(boolean)"
+- "name": "[org.apache.commons.cli.DefaultParser].<init>(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "org.apache.commons.cli.DefaultParser"
   "signature": "[org.apache.commons.cli.DefaultParser].<init>(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.cli.CommandLine].hasOption(java.lang.String)"
+- "name": "[org.apache.commons.cli.CommandLine].hasOption(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-medium/apache-commons-codec.yaml
+++ b/benchmark-sets/jvm-medium/apache-commons-codec.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.language.bm.Rule].<init>(java.lang.String,java.lang.String,java.lang.String,org.apache.commons.codec.language.bm.Rule$PhonemeExpr)"
+- "name": "[org.apache.commons.codec.language.bm.Rule].<init>(java.lang.String,java.lang.String,java.lang.String,org.apache.commons.codec.language.bm.Rule$PhonemeExpr)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -13,9 +11,7 @@
     "type": "org.apache.commons.codec.language.bm.Rule$PhonemeExpr"
   "return_type": "org.apache.commons.codec.language.bm.Rule"
   "signature": "[org.apache.commons.codec.language.bm.Rule].<init>(java.lang.String,java.lang.String,java.lang.String,org.apache.commons.codec.language.bm.Rule$PhonemeExpr)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean,org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean,org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -27,9 +23,7 @@
     "type": "org.apache.commons.codec.CodecPolicy"
   "return_type": "org.apache.commons.codec.binary.Base64"
   "signature": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean,org.apache.commons.codec.CodecPolicy)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean)"
+- "name": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -39,9 +33,7 @@
     "type": "boolean"
   "return_type": "org.apache.commons.codec.binary.Base64"
   "signature": "[org.apache.commons.codec.binary.Base64].<init>(int,byte[],boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base32].<init>(int,byte[],boolean,byte,org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base32].<init>(int,byte[],boolean,byte,org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -55,9 +47,7 @@
     "type": "org.apache.commons.codec.CodecPolicy"
   "return_type": "org.apache.commons.codec.binary.Base32"
   "signature": "[org.apache.commons.codec.binary.Base32].<init>(int,byte[],boolean,byte,org.apache.commons.codec.CodecPolicy)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base32InputStream].<init>(java.io.InputStream,boolean,int,byte[],org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base32InputStream].<init>(java.io.InputStream,boolean,int,byte[],org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"
@@ -71,9 +61,7 @@
     "type": "org.apache.commons.codec.CodecPolicy"
   "return_type": "org.apache.commons.codec.binary.Base32InputStream"
   "signature": "[org.apache.commons.codec.binary.Base32InputStream].<init>(java.io.InputStream,boolean,int,byte[],org.apache.commons.codec.CodecPolicy)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.codec.binary.Base16InputStream].<init>(java.io.InputStream,boolean,boolean,org.apache.commons.codec.CodecPolicy)"
+- "name": "[org.apache.commons.codec.binary.Base16InputStream].<init>(java.io.InputStream,boolean,boolean,org.apache.commons.codec.CodecPolicy)"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream"

--- a/benchmark-sets/jvm-medium/apache-commons-collections.yaml
+++ b/benchmark-sets/jvm-medium/apache-commons-collections.yaml
@@ -1,39 +1,29 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BitMapExtractor)"
+- "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BitMapExtractor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections4.bloomfilter.BitMapExtractor"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BitMapExtractor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.collection.IndexedCollection].removeIf(java.util.function.Predicate<? super C>)"
+- "name": "[org.apache.commons.collections4.collection.IndexedCollection].removeIf(java.util.function.Predicate<? super C>)"
   "params":
   - "name": "arg0"
     "type": "java.util.function.Predicate<? super C>"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.collection.IndexedCollection].removeIf(java.util.function.Predicate<? super C>)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.collections4.CollectionUtils].getCardinalityMap(java.lang.Iterable<? extends O>)"
+- "name": "[org.apache.commons.collections4.CollectionUtils].getCardinalityMap(java.lang.Iterable<? extends O>)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Iterable<? extends O>"
   "return_type": "java.util.Map<O,Integer>"
   "signature": "[org.apache.commons.collections4.CollectionUtils].getCardinalityMap(java.lang.Iterable<? extends O>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.IndexExtractor)"
+- "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.IndexExtractor)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections4.bloomfilter.IndexExtractor"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.IndexExtractor)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.collections4.CollectionUtils].addAll(java.util.Collection<C>,java.lang.Iterable<? extends C>)"
+- "name": "[org.apache.commons.collections4.CollectionUtils].addAll(java.util.Collection<C>,java.lang.Iterable<? extends C>)"
   "params":
   - "name": "arg0"
     "type": "java.util.Collection<C>"
@@ -41,9 +31,7 @@
     "type": "java.lang.Iterable<? extends C>"
   "return_type": "boolean"
   "signature": "[org.apache.commons.collections4.CollectionUtils].addAll(java.util.Collection<C>,java.lang.Iterable<? extends C>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BloomFilter)"
+- "name": "[org.apache.commons.collections4.bloomfilter.LayeredBloomFilter].contains(org.apache.commons.collections4.bloomfilter.BloomFilter)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections4.bloomfilter.BloomFilter"

--- a/benchmark-sets/jvm-medium/apache-commons-csv.yaml
+++ b/benchmark-sets/jvm-medium/apache-commons-csv.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVParser].<init>(java.io.Reader,org.apache.commons.csv.CSVFormat,long,long)"
+- "name": "[org.apache.commons.csv.CSVParser].<init>(java.io.Reader,org.apache.commons.csv.CSVFormat,long,long)"
   "params":
   - "name": "arg0"
     "type": "java.io.Reader"
@@ -14,10 +11,7 @@
     "type": "long"
   "return_type": "org.apache.commons.csv.CSVParser"
   "signature": "[org.apache.commons.csv.CSVParser].<init>(java.io.Reader,org.apache.commons.csv.CSVFormat,long,long)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVPrinter].<init>(java.lang.Appendable,org.apache.commons.csv.CSVFormat)"
+- "name": "[org.apache.commons.csv.CSVPrinter].<init>(java.lang.Appendable,org.apache.commons.csv.CSVFormat)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Appendable"
@@ -25,34 +19,25 @@
     "type": "org.apache.commons.csv.CSVFormat"
   "return_type": "org.apache.commons.csv.CSVPrinter"
   "signature": "[org.apache.commons.csv.CSVPrinter].<init>(java.lang.Appendable,org.apache.commons.csv.CSVFormat)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVPrinter].close(boolean)"
+- "name": "[org.apache.commons.csv.CSVPrinter].close(boolean)"
   "params":
   - "name": "arg0"
     "type": "boolean"
   "return_type": "void"
   "signature": "[org.apache.commons.csv.CSVPrinter].close(boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(char)"
+- "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(char)"
   "params":
   - "name": "arg0"
     "type": "char"
   "return_type": "org.apache.commons.csv.CSVFormat$Builder"
   "signature": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(char)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVFormat$Builder].setDelimiter(char)"
+- "name": "[org.apache.commons.csv.CSVFormat$Builder].setDelimiter(char)"
   "params":
   - "name": "arg0"
     "type": "char"
   "return_type": "org.apache.commons.csv.CSVFormat$Builder"
   "signature": "[org.apache.commons.csv.CSVFormat$Builder].setDelimiter(char)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(java.lang.Character)"
+- "name": "[org.apache.commons.csv.CSVFormat$Builder].setEscape(java.lang.Character)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Character"

--- a/benchmark-sets/jvm-medium/apache-commons-jxpath.yaml
+++ b/benchmark-sets/jvm-medium/apache-commons-jxpath.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.functions.ConstructorFunction].invoke(org.apache.commons.jxpath.ExpressionContext,java.lang.Object[])"
+- "name": "[org.apache.commons.jxpath.functions.ConstructorFunction].invoke(org.apache.commons.jxpath.ExpressionContext,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.jxpath.ExpressionContext"
@@ -9,9 +7,7 @@
     "type": "java.lang.Object[]"
   "return_type": "java.lang.Object"
   "signature": "[org.apache.commons.jxpath.functions.ConstructorFunction].invoke(org.apache.commons.jxpath.ExpressionContext,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.ClassFunctions].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
+- "name": "[org.apache.commons.jxpath.ClassFunctions].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -21,9 +17,7 @@
     "type": "java.lang.Object[]"
   "return_type": "org.apache.commons.jxpath.Function"
   "signature": "[org.apache.commons.jxpath.ClassFunctions].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.FunctionLibrary].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
+- "name": "[org.apache.commons.jxpath.FunctionLibrary].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -33,9 +27,7 @@
     "type": "java.lang.Object[]"
   "return_type": "org.apache.commons.jxpath.Function"
   "signature": "[org.apache.commons.jxpath.FunctionLibrary].getFunction(java.lang.String,java.lang.String,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.util.JXPath11CompatibleTypeConverter].convert(java.lang.Object,java.lang.Class)"
+- "name": "[org.apache.commons.jxpath.util.JXPath11CompatibleTypeConverter].convert(java.lang.Object,java.lang.Class)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -43,17 +35,13 @@
     "type": "java.lang.Class"
   "return_type": "java.lang.Object"
   "signature": "[org.apache.commons.jxpath.util.JXPath11CompatibleTypeConverter].convert(java.lang.Object,java.lang.Class)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.ri.NamespaceResolver].getPrefix(java.lang.String)"
+- "name": "[org.apache.commons.jxpath.ri.NamespaceResolver].getPrefix(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "java.lang.String"
   "signature": "[org.apache.commons.jxpath.ri.NamespaceResolver].getPrefix(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.jxpath.ri.model.container.ContainerPointer].attributeIterator(org.apache.commons.jxpath.ri.QName)"
+- "name": "[org.apache.commons.jxpath.ri.model.container.ContainerPointer].attributeIterator(org.apache.commons.jxpath.ri.QName)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.jxpath.ri.QName"

--- a/benchmark-sets/jvm-medium/apache-commons-validator.yaml
+++ b/benchmark-sets/jvm-medium/apache-commons-validator.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.routines.CreditCardValidator].<init>(long)"
+- "name": "[org.apache.commons.validator.routines.CreditCardValidator].<init>(long)"
   "params":
   - "name": "arg0"
     "type": "long"
   "return_type": "org.apache.commons.validator.routines.CreditCardValidator"
   "signature": "[org.apache.commons.validator.routines.CreditCardValidator].<init>(long)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long)"
+- "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"
@@ -19,9 +15,7 @@
     "type": "long"
   "return_type": "org.apache.commons.validator.routines.UrlValidator"
   "signature": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long,org.apache.commons.validator.routines.DomainValidator)"
+- "name": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long,org.apache.commons.validator.routines.DomainValidator)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"
@@ -33,29 +27,19 @@
     "type": "org.apache.commons.validator.routines.DomainValidator"
   "return_type": "org.apache.commons.validator.routines.UrlValidator"
   "signature": "[org.apache.commons.validator.routines.UrlValidator].<init>(java.lang.String[],org.apache.commons.validator.routines.RegexValidator,long,org.apache.commons.validator.routines.DomainValidator)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.apache.commons.validator.util.ValidatorUtils].copyFastHashMap(org.apache.commons.collections.FastHashMap)"
+- "name": "[org.apache.commons.validator.util.ValidatorUtils].copyFastHashMap(org.apache.commons.collections.FastHashMap)"
   "params":
   - "name": "arg0"
     "type": "org.apache.commons.collections.FastHashMap"
   "return_type": "org.apache.commons.collections.FastHashMap"
   "signature": "[org.apache.commons.validator.util.ValidatorUtils].copyFastHashMap(org.apache.commons.collections.FastHashMap)"
-- "exceptions":
-  - "java.io.IOException"
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.io.InputStream[])"
+- "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.io.InputStream[])"
   "params":
   - "name": "arg0"
     "type": "java.io.InputStream[]"
   "return_type": "org.apache.commons.validator.ValidatorResources"
   "signature": "[org.apache.commons.validator.ValidatorResources].<init>(java.io.InputStream[])"
-- "exceptions":
-  - "java.io.IOException"
-  - "org.xml.sax.SAXException"
-  "is_jvm_static": false
-  "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.lang.String[])"
+- "name": "[org.apache.commons.validator.ValidatorResources].<init>(java.lang.String[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.String[]"

--- a/benchmark-sets/jvm-medium/calcite-avatica.yaml
+++ b/benchmark-sets/jvm-medium/calcite-avatica.yaml
@@ -1,50 +1,35 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.LocalProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
+- "name": "[org.apache.calcite.avatica.remote.LocalProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Request"
   "return_type": "org.apache.calcite.avatica.remote.Service$Response"
   "signature": "[org.apache.calcite.avatica.remote.LocalProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.RemoteProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
+- "name": "[org.apache.calcite.avatica.remote.RemoteProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Request"
   "return_type": "org.apache.calcite.avatica.remote.Service$Response"
   "signature": "[org.apache.calcite.avatica.remote.RemoteProtobufService]._apply(org.apache.calcite.avatica.remote.Service$Request)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeResponse(org.apache.calcite.avatica.remote.Service$Response)"
+- "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeResponse(org.apache.calcite.avatica.remote.Service$Response)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Response"
   "return_type": "byte[]"
   "signature": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeResponse(org.apache.calcite.avatica.remote.Service$Response)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeRequest(org.apache.calcite.avatica.remote.Service$Request)"
+- "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeRequest(org.apache.calcite.avatica.remote.Service$Request)"
   "params":
   - "name": "arg0"
     "type": "org.apache.calcite.avatica.remote.Service$Request"
   "return_type": "byte[]"
   "signature": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].serializeRequest(org.apache.calcite.avatica.remote.Service$Request)"
-- "exceptions":
-  - "java.io.IOException"
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].parseRequest(byte[])"
+- "name": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].parseRequest(byte[])"
   "params":
   - "name": "arg0"
     "type": "byte[]"
   "return_type": "org.apache.calcite.avatica.remote.Service$Request"
   "signature": "[org.apache.calcite.avatica.remote.ProtobufTranslationImpl].parseRequest(byte[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.calcite.avatica.Meta$Frame].equals(java.lang.Object)"
+- "name": "[org.apache.calcite.avatica.Meta$Frame].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-medium/cglib.yaml
+++ b/benchmark-sets/jvm-medium/cglib.yaml
@@ -1,49 +1,35 @@
 "functions":
-- "exceptions":
-  - "java.lang.Exception"
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.transform.TransformingClassGenerator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.transform.TransformingClassGenerator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.transform.TransformingClassGenerator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.reflect.MulticastDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.reflect.MulticastDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.reflect.MulticastDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.core.KeyFactory$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.core.KeyFactory$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.core.KeyFactory$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.beans.BeanCopier$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.beans.BeanCopier$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.beans.BeanCopier$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.beans.ImmutableBean$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.beans.ImmutableBean$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"
   "return_type": "void"
   "signature": "[net.sf.cglib.beans.ImmutableBean$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
-- "exceptions":
-  - "java.lang.NoSuchMethodException"
-  "is_jvm_static": false
-  "name": "[net.sf.cglib.reflect.MethodDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
+- "name": "[net.sf.cglib.reflect.MethodDelegate$Generator].generateClass(org.objectweb.asm.ClassVisitor)"
   "params":
   - "name": "arg0"
     "type": "org.objectweb.asm.ClassVisitor"

--- a/benchmark-sets/jvm-medium/exp4j.yaml
+++ b/benchmark-sets/jvm-medium/exp4j.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.ExpressionBuilder].<init>(java.lang.String)"
+- "name": "[net.objecthunter.exp4j.ExpressionBuilder].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "net.objecthunter.exp4j.ExpressionBuilder"
   "signature": "[net.objecthunter.exp4j.ExpressionBuilder].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set,boolean)"
+- "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -23,9 +19,7 @@
     "type": "boolean"
   "return_type": "net.objecthunter.exp4j.tokenizer.Tokenizer"
   "signature": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set)"
+- "name": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -37,9 +31,7 @@
     "type": "java.util.Set"
   "return_type": "net.objecthunter.exp4j.tokenizer.Tokenizer"
   "signature": "[net.objecthunter.exp4j.tokenizer.Tokenizer].<init>(java.lang.String,java.util.Map,java.util.Map,java.util.Set)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.ValidationResult].<init>(boolean,java.util.List)"
+- "name": "[net.objecthunter.exp4j.ValidationResult].<init>(boolean,java.util.List)"
   "params":
   - "name": "arg0"
     "type": "boolean"
@@ -47,17 +39,13 @@
     "type": "java.util.List"
   "return_type": "net.objecthunter.exp4j.ValidationResult"
   "signature": "[net.objecthunter.exp4j.ValidationResult].<init>(boolean,java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.FunctionToken].<init>(net.objecthunter.exp4j.function.Function)"
+- "name": "[net.objecthunter.exp4j.tokenizer.FunctionToken].<init>(net.objecthunter.exp4j.function.Function)"
   "params":
   - "name": "arg0"
     "type": "net.objecthunter.exp4j.function.Function"
   "return_type": "net.objecthunter.exp4j.tokenizer.FunctionToken"
   "signature": "[net.objecthunter.exp4j.tokenizer.FunctionToken].<init>(net.objecthunter.exp4j.function.Function)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[net.objecthunter.exp4j.tokenizer.OperatorToken].<init>(net.objecthunter.exp4j.operator.Operator)"
+- "name": "[net.objecthunter.exp4j.tokenizer.OperatorToken].<init>(net.objecthunter.exp4j.operator.Operator)"
   "params":
   - "name": "arg0"
     "type": "net.objecthunter.exp4j.operator.Operator"

--- a/benchmark-sets/jvm-medium/fuzzywuzzy.yaml
+++ b/benchmark-sets/jvm-medium/fuzzywuzzy.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
+- "name": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -13,9 +11,7 @@
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.model.BoundExtractedResult"
   "signature": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
+- "name": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -25,17 +21,13 @@
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.model.ExtractedResult"
   "signature": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
+- "name": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.Extractor"
   "signature": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
+- "name": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -43,9 +35,7 @@
     "type": "java.lang.String"
   "return_type": "me.xdrop.diffutils.structs.MatchingBlock[]"
   "signature": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
+- "name": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-medium/java-diff-utils.yaml
+++ b/benchmark-sets/jvm-medium/java-diff-utils.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.algorithm.myers.MyersDiffWithLinearSpace].computeDiff(java.util.List<T>,java.util.List<T>,com.github.difflib.algorithm.DiffAlgorithmListener)"
+- "name": "[com.github.difflib.algorithm.myers.MyersDiffWithLinearSpace].computeDiff(java.util.List<T>,java.util.List<T>,com.github.difflib.algorithm.DiffAlgorithmListener)"
   "params":
   - "name": "arg0"
     "type": "java.util.List<T>"
@@ -11,9 +9,7 @@
     "type": "com.github.difflib.algorithm.DiffAlgorithmListener"
   "return_type": "java.util.List<Change>"
   "signature": "[com.github.difflib.algorithm.myers.MyersDiffWithLinearSpace].computeDiff(java.util.List<T>,java.util.List<T>,com.github.difflib.algorithm.DiffAlgorithmListener)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.algorithm.myers.PathNode].<init>(int,int,boolean,boolean,com.github.difflib.algorithm.myers.PathNode)"
+- "name": "[com.github.difflib.algorithm.myers.PathNode].<init>(int,int,boolean,boolean,com.github.difflib.algorithm.myers.PathNode)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -27,17 +23,13 @@
     "type": "com.github.difflib.algorithm.myers.PathNode"
   "return_type": "com.github.difflib.algorithm.myers.PathNode"
   "signature": "[com.github.difflib.algorithm.myers.PathNode].<init>(int,int,boolean,boolean,com.github.difflib.algorithm.myers.PathNode)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.text.DiffRow].equals(java.lang.Object)"
+- "name": "[com.github.difflib.text.DiffRow].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "boolean"
   "signature": "[com.github.difflib.text.DiffRow].equals(java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.patch.Chunk].<init>(int,java.util.List)"
+- "name": "[com.github.difflib.patch.Chunk].<init>(int,java.util.List)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -45,9 +37,7 @@
     "type": "java.util.List"
   "return_type": "com.github.difflib.patch.Chunk"
   "signature": "[com.github.difflib.patch.Chunk].<init>(int,java.util.List)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.patch.Chunk].<init>(int,java.lang.Object[])"
+- "name": "[com.github.difflib.patch.Chunk].<init>(int,java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -55,9 +45,7 @@
     "type": "java.lang.Object[]"
   "return_type": "com.github.difflib.patch.Chunk"
   "signature": "[com.github.difflib.patch.Chunk].<init>(int,java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.difflib.patch.Chunk].equals(java.lang.Object)"
+- "name": "[com.github.difflib.patch.Chunk].equals(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-medium/javacpp.yaml
+++ b/benchmark-sets/jvm-medium/javacpp.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.tools.InfoMap].put(org.bytedeco.javacpp.tools.Info)"
+- "name": "[org.bytedeco.javacpp.tools.InfoMap].put(org.bytedeco.javacpp.tools.Info)"
   "params":
   - "name": "arg0"
     "type": "org.bytedeco.javacpp.tools.Info"
   "return_type": "org.bytedeco.javacpp.tools.InfoMap"
   "signature": "[org.bytedeco.javacpp.tools.InfoMap].put(org.bytedeco.javacpp.tools.Info)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.tools.InfoMap].put(int,org.bytedeco.javacpp.tools.Info)"
+- "name": "[org.bytedeco.javacpp.tools.InfoMap].put(int,org.bytedeco.javacpp.tools.Info)"
   "params":
   - "name": "arg0"
     "type": "int"
@@ -17,33 +13,25 @@
     "type": "org.bytedeco.javacpp.tools.Info"
   "return_type": "org.bytedeco.javacpp.tools.InfoMap"
   "signature": "[org.bytedeco.javacpp.tools.InfoMap].put(int,org.bytedeco.javacpp.tools.Info)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.ClassProperties].<init>(java.util.Properties)"
+- "name": "[org.bytedeco.javacpp.ClassProperties].<init>(java.util.Properties)"
   "params":
   - "name": "arg0"
     "type": "java.util.Properties"
   "return_type": "org.bytedeco.javacpp.ClassProperties"
   "signature": "[org.bytedeco.javacpp.ClassProperties].<init>(java.util.Properties)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.BooleanPointer].<init>(java.nio.ByteBuffer)"
+- "name": "[org.bytedeco.javacpp.BooleanPointer].<init>(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"
   "return_type": "org.bytedeco.javacpp.BooleanPointer"
   "signature": "[org.bytedeco.javacpp.BooleanPointer].<init>(java.nio.ByteBuffer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.BytePointer].<init>(java.nio.ByteBuffer)"
+- "name": "[org.bytedeco.javacpp.BytePointer].<init>(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"
   "return_type": "org.bytedeco.javacpp.BytePointer"
   "signature": "[org.bytedeco.javacpp.BytePointer].<init>(java.nio.ByteBuffer)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.bytedeco.javacpp.DoublePointer].<init>(java.nio.DoubleBuffer)"
+- "name": "[org.bytedeco.javacpp.DoublePointer].<init>(java.nio.DoubleBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.DoubleBuffer"

--- a/benchmark-sets/jvm-medium/joni.yaml
+++ b/benchmark-sets/jvm-medium/joni.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joni.ast.EncloseNode].toString(int)"
+- "name": "[org.joni.ast.EncloseNode].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.joni.ast.EncloseNode].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joni.ast.CClassNode].clearNotFlag(org.joni.ScanEnvironment)"
+- "name": "[org.joni.ast.CClassNode].clearNotFlag(org.joni.ScanEnvironment)"
   "params":
   - "name": "arg0"
     "type": "org.joni.ScanEnvironment"
   "return_type": "void"
   "signature": "[org.joni.ast.CClassNode].clearNotFlag(org.joni.ScanEnvironment)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.joni.CodeRangeBuffer].andCodeRange1(org.joni.CodeRangeBuffer,org.joni.ScanEnvironment,int,int,int[],int)"
+- "name": "[org.joni.CodeRangeBuffer].andCodeRange1(org.joni.CodeRangeBuffer,org.joni.ScanEnvironment,int,int,int[],int)"
   "params":
   - "name": "arg0"
     "type": "org.joni.CodeRangeBuffer"
@@ -33,9 +27,7 @@
     "type": "int"
   "return_type": "org.joni.CodeRangeBuffer"
   "signature": "[org.joni.CodeRangeBuffer].andCodeRange1(org.joni.CodeRangeBuffer,org.joni.ScanEnvironment,int,int,int[],int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.joni.CodeRangeBuffer].addAllMultiByteRange(org.joni.ScanEnvironment,org.joni.CodeRangeBuffer)"
+- "name": "[org.joni.CodeRangeBuffer].addAllMultiByteRange(org.joni.ScanEnvironment,org.joni.CodeRangeBuffer)"
   "params":
   - "name": "arg0"
     "type": "org.joni.ScanEnvironment"
@@ -43,17 +35,13 @@
     "type": "org.joni.CodeRangeBuffer"
   "return_type": "org.joni.CodeRangeBuffer"
   "signature": "[org.joni.CodeRangeBuffer].addAllMultiByteRange(org.joni.ScanEnvironment,org.joni.CodeRangeBuffer)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[org.joni.Option].toString(int)"
+- "name": "[org.joni.Option].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.joni.Option].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.joni.Regex].<init>(byte[],int,int,int,int,org.jcodings.Encoding,org.joni.Syntax,org.joni.WarnCallback)"
+- "name": "[org.joni.Regex].<init>(byte[],int,int,int,int,org.jcodings.Encoding,org.joni.Syntax,org.joni.WarnCallback)"
   "params":
   - "name": "arg0"
     "type": "byte[]"

--- a/benchmark-sets/jvm-medium/jsemver.yaml
+++ b/benchmark-sets/jvm-medium/jsemver.yaml
@@ -1,31 +1,23 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.Version$Builder].<init>(java.lang.String)"
+- "name": "[com.github.zafarkhaja.semver.Version$Builder].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "com.github.zafarkhaja.semver.Version$Builder"
   "signature": "[com.github.zafarkhaja.semver.Version$Builder].<init>(java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.util.Stream].<init>(java.lang.Object[])"
+- "name": "[com.github.zafarkhaja.semver.util.Stream].<init>(java.lang.Object[])"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"
   "return_type": "com.github.zafarkhaja.semver.util.Stream"
   "signature": "[com.github.zafarkhaja.semver.util.Stream].<init>(java.lang.Object[])"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.expr.CompositeExpression].<init>(com.github.zafarkhaja.semver.expr.Expression)"
+- "name": "[com.github.zafarkhaja.semver.expr.CompositeExpression].<init>(com.github.zafarkhaja.semver.expr.Expression)"
   "params":
   - "name": "arg0"
     "type": "com.github.zafarkhaja.semver.expr.Expression"
   "return_type": "com.github.zafarkhaja.semver.expr.CompositeExpression"
   "signature": "[com.github.zafarkhaja.semver.expr.CompositeExpression].<init>(com.github.zafarkhaja.semver.expr.Expression)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.github.zafarkhaja.semver.Version].isValid(java.lang.String,boolean)"
+- "name": "[com.github.zafarkhaja.semver.Version].isValid(java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -33,9 +25,7 @@
     "type": "boolean"
   "return_type": "boolean"
   "signature": "[com.github.zafarkhaja.semver.Version].isValid(java.lang.String,boolean)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.github.zafarkhaja.semver.Version].parse(java.lang.String,boolean)"
+- "name": "[com.github.zafarkhaja.semver.Version].parse(java.lang.String,boolean)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -43,9 +33,7 @@
     "type": "boolean"
   "return_type": "com.github.zafarkhaja.semver.Version"
   "signature": "[com.github.zafarkhaja.semver.Version].parse(java.lang.String,boolean)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[com.github.zafarkhaja.semver.util.Stream].consume(com.github.zafarkhaja.semver.util.Stream$ElementType[])"
+- "name": "[com.github.zafarkhaja.semver.util.Stream].consume(com.github.zafarkhaja.semver.util.Stream$ElementType[])"
   "params":
   - "name": "arg0"
     "type": "com.github.zafarkhaja.semver.util.Stream$ElementType[]"

--- a/benchmark-sets/jvm-medium/json-java.yaml
+++ b/benchmark-sets/jvm-medium/json-java.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].toString(int)"
+- "name": "[org.json.JSONArray].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.json.JSONArray].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].<init>(java.lang.Object)"
+- "name": "[org.json.JSONArray].<init>(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-medium/json-sanitizer.yaml
+++ b/benchmark-sets/jvm-medium/json-sanitizer.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.google.json.EvalMinifier].minify(java.lang.String,int)"
+- "name": "[com.google.json.EvalMinifier].minify(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[com.google.json.EvalMinifier].minify(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[com.google.json.JsonSanitizer].sanitize(java.lang.String,int)"
+- "name": "[com.google.json.JsonSanitizer].sanitize(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-medium/kie-soup.yaml
+++ b/benchmark-sets/jvm-medium/kie-soup.yaml
@@ -1,8 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.text.ParseException"
-  "is_jvm_static": false
-  "name": "[org.kie.soup.commons.cron.CronExpression].<init>(java.lang.String)"
+- "name": "[org.kie.soup.commons.cron.CronExpression].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-medium/open-json.yaml
+++ b/benchmark-sets/jvm-medium/open-json.yaml
@@ -1,17 +1,11 @@
 "functions":
-- "exceptions":
-  - "org.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].<init>(java.lang.String)"
+- "name": "[org.json.JSONArray].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.json.JSONArray"
   "signature": "[org.json.JSONArray].<init>(java.lang.String)"
-- "exceptions":
-  - "org.json.JSONException"
-  "is_jvm_static": false
-  "name": "[org.json.JSONObject].<init>(java.lang.String)"
+- "name": "[org.json.JSONObject].<init>(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-medium/quartz.yaml
+++ b/benchmark-sets/jvm-medium/quartz.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
+- "name": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.quartz.utils.DirtyFlagMap].put(java.lang.Object,java.lang.Object)"
+- "name": "[org.quartz.utils.DirtyFlagMap].put(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-medium/sketches-core.yaml
+++ b/benchmark-sets/jvm-medium/sketches-core.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow].<init>(org.apache.datasketches.partitions.Partitioner$StackElement)"
+- "name": "[org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow].<init>(org.apache.datasketches.partitions.Partitioner$StackElement)"
   "params":
   - "name": "arg0"
     "type": "org.apache.datasketches.partitions.Partitioner$StackElement"
   "return_type": "org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow"
   "signature": "[org.apache.datasketches.partitions.Partitioner$PartitionBoundsRow].<init>(org.apache.datasketches.partitions.Partitioner$StackElement)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.cpc.CpcWrapper].<init>(org.apache.datasketches.memory.Memory)"
+- "name": "[org.apache.datasketches.cpc.CpcWrapper].<init>(org.apache.datasketches.memory.Memory)"
   "params":
   - "name": "arg0"
     "type": "org.apache.datasketches.memory.Memory"
   "return_type": "org.apache.datasketches.cpc.CpcWrapper"
   "signature": "[org.apache.datasketches.cpc.CpcWrapper].<init>(org.apache.datasketches.memory.Memory)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.DoublesSketchSortedView].<init>(double[],long[],org.apache.datasketches.quantilescommon.QuantilesDoublesAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.DoublesSketchSortedView].<init>(double[],long[],org.apache.datasketches.quantilescommon.QuantilesDoublesAPI)"
   "params":
   - "name": "arg0"
     "type": "double[]"
@@ -27,9 +21,7 @@
     "type": "org.apache.datasketches.quantilescommon.QuantilesDoublesAPI"
   "return_type": "org.apache.datasketches.quantilescommon.DoublesSketchSortedView"
   "signature": "[org.apache.datasketches.quantilescommon.DoublesSketchSortedView].<init>(double[],long[],org.apache.datasketches.quantilescommon.QuantilesDoublesAPI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.FloatsSketchSortedView].<init>(float[],long[],org.apache.datasketches.quantilescommon.QuantilesFloatsAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.FloatsSketchSortedView].<init>(float[],long[],org.apache.datasketches.quantilescommon.QuantilesFloatsAPI)"
   "params":
   - "name": "arg0"
     "type": "float[]"
@@ -39,9 +31,7 @@
     "type": "org.apache.datasketches.quantilescommon.QuantilesFloatsAPI"
   "return_type": "org.apache.datasketches.quantilescommon.FloatsSketchSortedView"
   "signature": "[org.apache.datasketches.quantilescommon.FloatsSketchSortedView].<init>(float[],long[],org.apache.datasketches.quantilescommon.QuantilesFloatsAPI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.LongsSketchSortedView].<init>(long[],long[],org.apache.datasketches.quantilescommon.QuantilesLongsAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.LongsSketchSortedView].<init>(long[],long[],org.apache.datasketches.quantilescommon.QuantilesLongsAPI)"
   "params":
   - "name": "arg0"
     "type": "long[]"
@@ -51,9 +41,7 @@
     "type": "org.apache.datasketches.quantilescommon.QuantilesLongsAPI"
   "return_type": "org.apache.datasketches.quantilescommon.LongsSketchSortedView"
   "signature": "[org.apache.datasketches.quantilescommon.LongsSketchSortedView].<init>(long[],long[],org.apache.datasketches.quantilescommon.QuantilesLongsAPI)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.apache.datasketches.quantilescommon.ItemsSketchSortedView].<init>(java.lang.Object[],long[],org.apache.datasketches.quantilescommon.QuantilesGenericAPI)"
+- "name": "[org.apache.datasketches.quantilescommon.ItemsSketchSortedView].<init>(java.lang.Object[],long[],org.apache.datasketches.quantilescommon.QuantilesGenericAPI)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object[]"

--- a/benchmark-sets/jvm-medium/snappy-java.yaml
+++ b/benchmark-sets/jvm-medium/snappy-java.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.xerial.snappy.SnappyFramedInputStream].read(java.nio.ByteBuffer)"
+- "name": "[org.xerial.snappy.SnappyFramedInputStream].read(java.nio.ByteBuffer)"
   "params":
   - "name": "arg0"
     "type": "java.nio.ByteBuffer"

--- a/benchmark-sets/jvm-medium/spatial4j.yaml
+++ b/benchmark-sets/jvm-medium/spatial4j.yaml
@@ -1,9 +1,5 @@
 "functions":
-- "exceptions":
-  - "java.io.IOException"
-  - "com.fasterxml.jackson.core.JsonProcessingException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.jackson.GeometryDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
+- "name": "[org.locationtech.spatial4j.io.jackson.GeometryDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.JsonParser"
@@ -11,11 +7,7 @@
     "type": "com.fasterxml.jackson.databind.DeserializationContext"
   "return_type": "org.locationtech.jts.geom.Geometry"
   "signature": "[org.locationtech.spatial4j.io.jackson.GeometryDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
-- "exceptions":
-  - "java.io.IOException"
-  - "com.fasterxml.jackson.core.JsonProcessingException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.jackson.ShapeDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
+- "name": "[org.locationtech.spatial4j.io.jackson.ShapeDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
   "params":
   - "name": "arg0"
     "type": "com.fasterxml.jackson.core.JsonParser"
@@ -23,37 +15,25 @@
     "type": "com.fasterxml.jackson.databind.DeserializationContext"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.jackson.ShapeDeserializer].deserialize(com.fasterxml.jackson.core.JsonParser,com.fasterxml.jackson.databind.DeserializationContext)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.SupportedFormats].read(java.lang.String)"
+- "name": "[org.locationtech.spatial4j.io.SupportedFormats].read(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.SupportedFormats].read(java.lang.String)"
-- "exceptions":
-  - "org.locationtech.spatial4j.exception.InvalidShapeException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.WKTReader].readIfSupported(java.lang.Object)"
+- "name": "[org.locationtech.spatial4j.io.WKTReader].readIfSupported(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.WKTReader].readIfSupported(java.lang.Object)"
-- "exceptions":
-  - "org.locationtech.spatial4j.exception.InvalidShapeException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.GeoJSONReader].readIfSupported(java.lang.Object)"
+- "name": "[org.locationtech.spatial4j.io.GeoJSONReader].readIfSupported(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
   "return_type": "org.locationtech.spatial4j.shape.Shape"
   "signature": "[org.locationtech.spatial4j.io.GeoJSONReader].readIfSupported(java.lang.Object)"
-- "exceptions":
-  - "java.io.IOException"
-  - "java.text.ParseException"
-  "is_jvm_static": false
-  "name": "[org.locationtech.spatial4j.io.GeoJSONReader].read(java.io.Reader)"
+- "name": "[org.locationtech.spatial4j.io.GeoJSONReader].read(java.io.Reader)"
   "params":
   - "name": "arg0"
     "type": "java.io.Reader"

--- a/benchmark-sets/jvm-medium/threetenbp.yaml
+++ b/benchmark-sets/jvm-medium/threetenbp.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.format.DateTimeFormatter].format(org.threeten.bp.temporal.TemporalAccessor)"
+- "name": "[org.threeten.bp.format.DateTimeFormatter].format(org.threeten.bp.temporal.TemporalAccessor)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalAccessor"
   "return_type": "java.lang.String"
   "signature": "[org.threeten.bp.format.DateTimeFormatter].format(org.threeten.bp.temporal.TemporalAccessor)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.format.DateTimeFormatter].formatTo(org.threeten.bp.temporal.TemporalAccessor,java.lang.Appendable)"
+- "name": "[org.threeten.bp.format.DateTimeFormatter].formatTo(org.threeten.bp.temporal.TemporalAccessor,java.lang.Appendable)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalAccessor"
@@ -17,33 +13,25 @@
     "type": "java.lang.Appendable"
   "return_type": "void"
   "signature": "[org.threeten.bp.format.DateTimeFormatter].formatTo(org.threeten.bp.temporal.TemporalAccessor,java.lang.Appendable)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.Instant].query(org.threeten.bp.temporal.TemporalQuery<R>)"
+- "name": "[org.threeten.bp.Instant].query(org.threeten.bp.temporal.TemporalQuery<R>)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalQuery<R>"
   "return_type": "java.lang.Object"
   "signature": "[org.threeten.bp.Instant].query(org.threeten.bp.temporal.TemporalQuery<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.ZoneOffset].query(org.threeten.bp.temporal.TemporalQuery<R>)"
+- "name": "[org.threeten.bp.ZoneOffset].query(org.threeten.bp.temporal.TemporalQuery<R>)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalQuery<R>"
   "return_type": "java.lang.Object"
   "signature": "[org.threeten.bp.ZoneOffset].query(org.threeten.bp.temporal.TemporalQuery<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.LocalTime].query(org.threeten.bp.temporal.TemporalQuery<R>)"
+- "name": "[org.threeten.bp.LocalTime].query(org.threeten.bp.temporal.TemporalQuery<R>)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.TemporalQuery<R>"
   "return_type": "java.lang.Object"
   "signature": "[org.threeten.bp.LocalTime].query(org.threeten.bp.temporal.TemporalQuery<R>)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.threeten.bp.Duration].addTo(org.threeten.bp.temporal.Temporal)"
+- "name": "[org.threeten.bp.Duration].addTo(org.threeten.bp.temporal.Temporal)"
   "params":
   - "name": "arg0"
     "type": "org.threeten.bp.temporal.Temporal"

--- a/benchmark-sets/jvm-medium/twitter4j.yaml
+++ b/benchmark-sets/jvm-medium/twitter4j.yaml
@@ -1,23 +1,17 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.TimeSpanConverter].<init>(java.util.Locale)"
+- "name": "[twitter4j.TimeSpanConverter].<init>(java.util.Locale)"
   "params":
   - "name": "arg0"
     "type": "java.util.Locale"
   "return_type": "twitter4j.TimeSpanConverter"
   "signature": "[twitter4j.TimeSpanConverter].<init>(java.util.Locale)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.management.APIStatistics].<init>(int)"
+- "name": "[twitter4j.management.APIStatistics].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "twitter4j.management.APIStatistics"
   "signature": "[twitter4j.management.APIStatistics].<init>(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.management.InvocationStatisticsCalculator].<init>(java.lang.String,int)"
+- "name": "[twitter4j.management.InvocationStatisticsCalculator].<init>(java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -25,9 +19,7 @@
     "type": "int"
   "return_type": "twitter4j.management.InvocationStatisticsCalculator"
   "signature": "[twitter4j.management.InvocationStatisticsCalculator].<init>(java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.OAuth2Token].<init>(java.lang.String,java.lang.String)"
+- "name": "[twitter4j.OAuth2Token].<init>(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -35,17 +27,13 @@
     "type": "java.lang.String"
   "return_type": "twitter4j.OAuth2Token"
   "signature": "[twitter4j.OAuth2Token].<init>(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[twitter4j.management.APIStatisticsOpenMBean].<init>(twitter4j.management.APIStatistics)"
+- "name": "[twitter4j.management.APIStatisticsOpenMBean].<init>(twitter4j.management.APIStatistics)"
   "params":
   - "name": "arg0"
     "type": "twitter4j.management.APIStatistics"
   "return_type": "twitter4j.management.APIStatisticsOpenMBean"
   "signature": "[twitter4j.management.APIStatisticsOpenMBean].<init>(twitter4j.management.APIStatistics)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[twitter4j.v1.QuickReply].of(java.lang.String,java.lang.String,java.lang.String)"
+- "name": "[twitter4j.v1.QuickReply].of(java.lang.String,java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-small/fuzzywuzzy.yaml
+++ b/benchmark-sets/jvm-small/fuzzywuzzy.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
+- "name": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"
@@ -13,9 +11,7 @@
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.model.BoundExtractedResult"
   "signature": "[me.xdrop.fuzzywuzzy.model.BoundExtractedResult].<init>(java.lang.Object,java.lang.String,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
+- "name": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -25,17 +21,13 @@
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.model.ExtractedResult"
   "signature": "[me.xdrop.fuzzywuzzy.model.ExtractedResult].<init>(java.lang.String,int,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
+- "name": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "me.xdrop.fuzzywuzzy.Extractor"
   "signature": "[me.xdrop.fuzzywuzzy.Extractor].<init>(int)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
+- "name": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -43,9 +35,7 @@
     "type": "java.lang.String"
   "return_type": "me.xdrop.diffutils.structs.MatchingBlock[]"
   "signature": "[me.xdrop.diffutils.DiffUtils].getMatchingBlocks(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
+- "name": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -53,9 +43,7 @@
     "type": "java.lang.String"
   "return_type": "me.xdrop.diffutils.structs.EditOp[]"
   "signature": "[me.xdrop.diffutils.DiffUtils].getEditOps(java.lang.String,java.lang.String)"
-- "exceptions": []
-  "is_jvm_static": true
-  "name": "[me.xdrop.diffutils.DiffUtils].levEditDistance(java.lang.String,java.lang.String,int)"
+- "name": "[me.xdrop.diffutils.DiffUtils].levEditDistance(java.lang.String,java.lang.String,int)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -65,9 +53,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "[me.xdrop.diffutils.DiffUtils].levEditDistance(java.lang.String,java.lang.String,int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[me.xdrop.fuzzywuzzy.algorithms.DefaultStringProcessor].process(java.lang.String)"
+- "name": "[me.xdrop.fuzzywuzzy.algorithms.DefaultStringProcessor].process(java.lang.String)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"

--- a/benchmark-sets/jvm-small/json-java.yaml
+++ b/benchmark-sets/jvm-small/json-java.yaml
@@ -1,15 +1,11 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].toString(int)"
+- "name": "[org.json.JSONArray].toString(int)"
   "params":
   - "name": "arg0"
     "type": "int"
   "return_type": "java.lang.String"
   "signature": "[org.json.JSONArray].toString(int)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.json.JSONArray].<init>(java.lang.Object)"
+- "name": "[org.json.JSONArray].<init>(java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/jvm-small/quartz.yaml
+++ b/benchmark-sets/jvm-small/quartz.yaml
@@ -1,7 +1,5 @@
 "functions":
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
+- "name": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.String"
@@ -9,9 +7,7 @@
     "type": "java.lang.Object"
   "return_type": "java.lang.Object"
   "signature": "[org.quartz.utils.StringKeyDirtyFlagMap].put(java.lang.String,java.lang.Object)"
-- "exceptions": []
-  "is_jvm_static": false
-  "name": "[org.quartz.utils.DirtyFlagMap].put(java.lang.Object,java.lang.Object)"
+- "name": "[org.quartz.utils.DirtyFlagMap].put(java.lang.Object,java.lang.Object)"
   "params":
   - "name": "arg0"
     "type": "java.lang.Object"

--- a/benchmark-sets/minor-for-ci/htslib.yaml
+++ b/benchmark-sets/minor-for-ci/htslib.yaml
@@ -1,6 +1,5 @@
 "functions":
-- "exceptions": []
-  "name": "bam_index_build"
+- "name": "bam_index_build"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -8,8 +7,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int bam_index_build(const char *, int)"
-- "exceptions": []
-  "name": "sam_index_build2"
+- "name": "sam_index_build2"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -19,8 +17,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sam_index_build2(const char *, const char *, int)"
-- "exceptions": []
-  "name": "sam_index_build"
+- "name": "sam_index_build"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -28,8 +25,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sam_index_build(const char *, int)"
-- "exceptions": []
-  "name": "sam_index_build3"
+- "name": "sam_index_build3"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -41,8 +37,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int sam_index_build3(const char *, const char *, int, int)"
-- "exceptions": []
-  "name": "bcf_index_build"
+- "name": "bcf_index_build"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -50,8 +45,7 @@
     "type": "int"
   "return_type": "int"
   "signature": "int bcf_index_build(const char *, int)"
-- "exceptions": []
-  "name": "hts_parse_region"
+- "name": "hts_parse_region"
   "params":
   - "name": "s"
     "type": "bool "
@@ -69,8 +63,7 @@
     "type": "int"
   "return_type": "void"
   "signature": "const char * hts_parse_region(const char *, int *, hts_pos_t *, hts_pos_t *, hts_name2id_f, void *, int)"
-- "exceptions": []
-  "name": "hts_parse_decimal"
+- "name": "hts_parse_decimal"
   "params":
   - "name": "str"
     "type": "bool "
@@ -80,8 +73,7 @@
     "type": "int"
   "return_type": "size_t"
   "signature": "long long hts_parse_decimal(const char *, char **, int)"
-- "exceptions": []
-  "name": "hts_parse_reg"
+- "name": "hts_parse_reg"
   "params":
   - "name": "s"
     "type": "bool "
@@ -91,8 +83,7 @@
     "type": "bool "
   "return_type": "void"
   "signature": "const char * hts_parse_reg(const char *, int *, int *)"
-- "exceptions": []
-  "name": "hfile_list_plugins"
+- "name": "hfile_list_plugins"
   "params":
   - "name": "plist"
     "type": "bool "
@@ -100,8 +91,7 @@
     "type": "bool "
   "return_type": "int"
   "signature": "int hfile_list_plugins(const char **, int *)"
-- "exceptions": []
-  "name": "hts_idx_load"
+- "name": "hts_idx_load"
   "params":
   - "name": "fn"
     "type": "bool "
@@ -109,15 +99,13 @@
     "type": "int"
   "return_type": "void"
   "signature": "hts_idx_t * hts_idx_load(const char *, int)"
-- "exceptions": []
-  "name": "hts_file_type"
+- "name": "hts_file_type"
   "params":
   - "name": "fname"
     "type": "bool "
   "return_type": "int"
   "signature": "int hts_file_type(const char *)"
-- "exceptions": []
-  "name": "sam_hdr_remove_lines"
+- "name": "sam_hdr_remove_lines"
   "params":
   - "name": "bh"
     "type": "bool "


### PR DESCRIPTION
Following #531, some JVM-specific properties have been removed from the Benchmark object. Thus these properties are no longer needed in all those project benchmark YAML files. This PR removes those properties from all the existing benchmark YAML files.