### PR TITLE
Grid-search Temperature

### DIFF
--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -118,7 +118,7 @@ fi
 
 if [[ "$VARY_TEMPERATURE" = "true" ]]
 then
-    VARY_TEMPERATURE=(0.0 0.1 0.2 0.3 0.4)
+    VARY_TEMPERATURE=(0.5 0.6 0.7 0.8 0.9)
 else
     VARY_TEMPERATURE=()
 fi


### PR DESCRIPTION
[08-07](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-08-07-weekly-all/) experiment, with temperature 0-0.4, did not perform well either.
Given we have a weekly experiment scheduled tmr and only very few temperature values were untested, I'd propose doing a "grid search" on the rest.

Current ranking is:
1. [07-06](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-07-06-weekly-all/) with constant temperature 0.4: 1042 successful builds.
2. [08-03](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-08-03-weekly-all/) with constant temperature 1: 960 builds.
3. [08-07](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-08-07-weekly-all/) with vary temperature 0-0.4: 898 builds.

The new experiment will test 0.5-0.9 so that we have some data for each.