### PR TITLE
Display triage prompt on web

### DIFF
--- a/report/common.py
+++ b/report/common.py
@@ -321,7 +321,7 @@ class Results:
     fixed_dir = os.path.join(self._results_dir, benchmark, 'fixed_targets')
     triage_dir = os.path.join(fixed_dir, f'{sample}-triage')
     if not os.path.exists(triage_dir):
-      return Triage[result, triager_prompt]
+      return Triage(result, triager_prompt)
 
     for name in os.listdir(triage_dir):
       if name == 'prompt.txt':
@@ -334,9 +334,9 @@ class Results:
       if name.endswith('.txt') and name != 'prompt.txt':
         triage_path = os.path.join(triage_dir, name)
         with open(triage_path) as f:
-          return f.read()
+          result = f.read()
 
-    return Triage[result, triager_prompt]
+    return Triage(result, triager_prompt)
 
   def get_targets(self, benchmark: str, sample: str) -> list[Target]:
     """Gets the targets of benchmark |benchmark| with sample ID |sample|."""

--- a/report/common.py
+++ b/report/common.py
@@ -117,6 +117,7 @@ class Target:
   code: str
   fixer_prompt: Optional[str] = None
 
+
 @dataclasses.dataclass
 class Triage:
   result: str

--- a/report/templates/crash.json
+++ b/report/templates/crash.json
@@ -9,6 +9,7 @@
         "crashes": "{{ sample.result.crashes }}",
         "crash_reason": "{{ sample.result.semantic_error }}",
         "bug": "{{ not sample.result.is_semantic_error }}",
+        "triage": "{{ sample.result.triage }}",
         "coverage": "{{ sample.result.coverage | percent }}",
         "coverage_diff": "{{ sample.result.line_coverage_diff }}",
         "coverage_report": "{{ sample.result.coverage_report_path | cov_report_link }}",

--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -23,11 +23,21 @@ Crash reason: {{ sample.result.semantic_error }}
 <br>
 <br>
 
+{% if triage.result %}
 <h2>Triage</h2>
 <pre>
-{{ triage }}
+{{ triage.result }}
 </pre>
 <br>
+{% endif %}
+
+{% if triage.triager_prompt %}
+<h3>Triager prompt</h3>
+<pre>
+{{ triage.triager_prompt }}
+</pre>
+<br>
+{% endif %}
 
 {% for target in targets %}
 {% if target.fixer_prompt %}


### PR DESCRIPTION
This PR displays the triage prompt on the web, making it easier to read and evaluate the factors affecting LLM triage.