### PR TITLE
oss-fuzz-checkout: reuse cached image over multiple runs

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -211,6 +211,10 @@ def _prepare_image_cache(project: str) -> bool:
 
   logger.info('Creating a cached images')
   for sanitizer in ['address', 'coverage']:
+    if is_image_cached(project, sanitizer):
+        logger.info('%s %s is already cached, reusing existing cache.',
+                project, sanitizer)
+        continue
     # Create cached image by building using OSS-Fuzz with set variable
     command = [
         'python3', 'infra/helper.py', 'build_fuzzers', project, '--sanitizer',

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -212,9 +212,9 @@ def _prepare_image_cache(project: str) -> bool:
   logger.info('Creating a cached images')
   for sanitizer in ['address', 'coverage']:
     if is_image_cached(project, sanitizer):
-        logger.info('%s %s is already cached, reusing existing cache.',
-                project, sanitizer)
-        continue
+      logger.info('%s::%s is already cached, reusing existing cache.', project,
+                  sanitizer)
+      continue
     # Create cached image by building using OSS-Fuzz with set variable
     command = [
         'python3', 'infra/helper.py', 'build_fuzzers', project, '--sanitizer',


### PR DESCRIPTION
This allows us to reuse the cached images over multiple experiments, without having to rebuild at any point.