### PR TITLE
benchmark: fix naming to avoid web report inconsistency

### DIFF
--- a/experiment/benchmark.py
+++ b/experiment/benchmark.py
@@ -91,8 +91,8 @@ class Benchmark:
       for test_file in test_files:
         max_len = os.pathconf('/', 'PC_NAME_MAX') - len('output-')
         test_file_path = test_file.get('test_file_path')
-        normalized_test_path = test_file_path.replace("/",
-                                                      "_").replace(".", "_")
+        normalized_test_path = test_file_path.replace('/',
+                                                      '_').replace('.', '_').replace('-', '_')
         truncated_id = f'{project_name}-{normalized_test_path}'[:max_len]
 
         benchmarks.append(

--- a/experiment/benchmark.py
+++ b/experiment/benchmark.py
@@ -91,8 +91,8 @@ class Benchmark:
       for test_file in test_files:
         max_len = os.pathconf('/', 'PC_NAME_MAX') - len('output-')
         test_file_path = test_file.get('test_file_path')
-        normalized_test_path = test_file_path.replace('/',
-                                                      '_').replace('.', '_').replace('-', '_')
+        normalized_test_path = test_file_path.replace('/', '_').replace(
+            '.', '_').replace('-', '_')
         truncated_id = f'{project_name}-{normalized_test_path}'[:max_len]
 
         benchmarks.append(


### PR DESCRIPTION
Otherwise the naming looks weird in the html report because we rely on splitting `-`. As such, when a testfile has `-` in the name it goes into the project name in the web report. This fixes it.

Ref: https://github.com/google/oss-fuzz-gen/blob/feb19caf287d0a1cbdd13af70e56b3f91997a7c9/report/common.py#L513