### PR TITLE
Add support for Azure's GPT model

### DIFF
--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -287,9 +287,9 @@ class AzureGPT(GPT):
 
   def _get_client(self):
     """Returns the Azure client."""
-    return openai.AzureOpenAI(azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-                              api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-                              api_version="2024-02-01")
+    return openai.AzureOpenAI(azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
+                              api_key=os.getenv("AZURE_OPENAI_API_KEY", "YOUR_AZURE_OPENAI_API_KEY"),
+                              api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-01"))
 
 
 class AzureGPT4(AzureGPT):

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -290,12 +290,12 @@ class AzureGPT(GPT):
     num_tokens += 3
     return num_tokens
 
+
     # ============================== Generation ============================== #
   def query_llm(self,
                 prompt: prompts.Prompt,
                 response_dir: str,
-                log_output: bool = False,
-                build_spec=False) -> None:
+                log_output: bool = False) -> None:
     """Queries OpenAI's API and stores response in |response_dir|."""
     if self.ai_binary:
       raise ValueError(f'OpenAI does not use local AI binary: {self.ai_binary}')
@@ -309,22 +309,11 @@ class AzureGPT(GPT):
                                                   "YOUR_API_KEY"),
                                 api_version="2024-02-01")
 
-    if build_spec:
-      completion = self.with_retry_on_error(
-          lambda: client.chat.completions.create(messages=prompt.get(),
-                                                 model=self.name,
-                                                 n=1,
-                                                 temperature=self.temperature,
-                                                 max_tokens=self.max_tokens,
-                                                 stop=None), openai.OpenAIError)
-
-    else:
-
-      completion = self.with_retry_on_error(
-          lambda: client.chat.completions.create(messages=prompt.get(),
-                                                 model=self.name,
-                                                 n=self.num_samples,
-                                                 temperature=self.temperature),
+    completion = self.with_retry_on_error(
+        lambda: client.chat.completions.create(messages=prompt.get(),
+                                                model=self.name,
+                                                n=self.num_samples,
+                                                temperature=self.temperature),
           openai.OpenAIError)
 
     # TODO: Add a default value for completion.

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -289,8 +289,7 @@ class AzureGPT(GPT):
     """Returns the Azure client."""
     return openai.AzureOpenAI(azure_endpoint=os.getenv(
         "AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
-                              api_key=os.getenv("AZURE_OPENAI_API_KEY",
-                                                "YOUR_AZURE_OPENAI_API_KEY"),
+                              api_key=os.getenv("AZURE_OPENAI_API_KEY"),
                               api_version=os.getenv("AZURE_OPENAI_API_VERSION",
                                                     "2024-02-01"))
 

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -263,7 +263,6 @@ class GPT4o(GPT):
   name = 'gpt-4o'
 
 
-
 class AzureGPT(GPT):
   """Azure's GPT model."""
 

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -237,11 +237,11 @@ class GPT(LLM):
 
     if self.name.endswith('azure'):
       client = openai.AzureOpenAI(azure_endpoint=os.getenv(
-        "AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
-                                api_key=os.getenv("AZURE_OPENAI_API_KEY",
-                                                  "YOUR_API_KEY"),
-                                api_version="2024-02-01")
-    else:    
+          "AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
+                                  api_key=os.getenv("AZURE_OPENAI_API_KEY",
+                                                    "YOUR_API_KEY"),
+                                  api_version="2024-02-01")
+    else:
       client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
 
     completion = self.with_retry_on_error(

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -329,7 +329,7 @@ class AzureGPT4(AzureGPT):
   name = 'gpt-4-azure'
 
 
-class AzureGPT4oAzure(AzureGPT):
+class AzureGPT4o(AzureGPT):
   """Azure's GPTi-4 model."""
 
   name = 'gpt-4o-azure'

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -199,15 +199,25 @@ class GPT(LLM):
 
   name = 'gpt-3.5-turbo'
 
+  def _get_tiktoken_encoding(self):
+    """Returns the tiktoken encoding for the model."""
+    try:
+      return tiktoken.encoding_for_model(self.name)
+    except KeyError:
+      logger.info('Could not get a tiktoken encoding for %s.', self.name)
+      return tiktoken.get_encoding('cl100k_base')
+    
+  def _get_client(self):
+    """Returns the OpenAI client."""
+    return openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+  
+  
   # ================================ Prompt ================================ #
   def estimate_token_num(self, text) -> int:
     """Estimates the number of tokens in |text|."""
     # https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
-    try:
-      encoder = tiktoken.encoding_for_model(self.name.replace('-azure', ''))
-    except KeyError:
-      logger.info('Could not get a tiktoken encoding for %s.', self.name)
-      encoder = tiktoken.get_encoding('cl100k_base')
+
+    encoder = self._get_tiktoken_encoding()
 
     num_tokens = 0
     for message in text:
@@ -235,14 +245,7 @@ class GPT(LLM):
       logger.info('OpenAI does not allow temperature list: %s',
                   self.temperature_list)
 
-    if self.name.endswith('azure'):
-      client = openai.AzureOpenAI(azure_endpoint=os.getenv(
-          "AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
-                                  api_key=os.getenv("AZURE_OPENAI_API_KEY",
-                                                    "YOUR_API_KEY"),
-                                  api_version="2024-02-01")
-    else:
-      client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+    client = self._get_client()
 
     completion = self.with_retry_on_error(
         lambda: client.chat.completions.create(messages=prompt.get(),
@@ -272,17 +275,31 @@ class GPT4o(GPT):
 
 class AzureGPT(GPT):
   """Azure's GPT model."""
-
+  
   name = 'gpt-3.5-turbo-azure'
+  
+  def _get_tiktoken_encoding(self):
+    """Returns the tiktoken encoding for the model."""
+    try:
+      return tiktoken.encoding_for_model(self.name.replace('-azure', ''))
+    except KeyError:
+      logger.info('Could not get a tiktoken encoding for %s.', self.name)
+      return tiktoken.get_encoding('cl100k_base')
+    
+  def _get_client(self):
+    """Returns the Azure client."""
+    return openai.AzureOpenAI(azure_endpoint=os.getenv(
+        "AZURE_OPENAI_ENDPOINT"),
+                              api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+                              api_version="2024-02-01")
 
-
-class AzureGPT4(GPT):
+class AzureGPT4(AzureGPT):
   """Azure's GPTi-4 model."""
 
   name = 'gpt-4-azure'
 
 
-class AzureGPT4o(GPT):
+class AzureGPT4o(AzureGPT):
   """Azure's GPTi-4 model."""
 
   name = 'gpt-4o-azure'

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -290,7 +290,6 @@ class AzureGPT(GPT):
     num_tokens += 3
     return num_tokens
 
-
     # ============================== Generation ============================== #
   def query_llm(self,
                 prompt: prompts.Prompt,
@@ -311,10 +310,10 @@ class AzureGPT(GPT):
 
     completion = self.with_retry_on_error(
         lambda: client.chat.completions.create(messages=prompt.get(),
-                                                model=self.name,
-                                                n=self.num_samples,
-                                                temperature=self.temperature),
-          openai.OpenAIError)
+                                               model=self.name,
+                                               n=self.num_samples,
+                                               temperature=self.temperature),
+        openai.OpenAIError)
 
     # TODO: Add a default value for completion.
     if log_output:

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -287,9 +287,12 @@ class AzureGPT(GPT):
 
   def _get_client(self):
     """Returns the Azure client."""
-    return openai.AzureOpenAI(azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
-                              api_key=os.getenv("AZURE_OPENAI_API_KEY", "YOUR_AZURE_OPENAI_API_KEY"),
-                              api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-01"))
+    return openai.AzureOpenAI(azure_endpoint=os.getenv(
+        "AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
+                              api_key=os.getenv("AZURE_OPENAI_API_KEY",
+                                                "YOUR_AZURE_OPENAI_API_KEY"),
+                              api_version=os.getenv("AZURE_OPENAI_API_VERSION",
+                                                    "2024-02-01"))
 
 
 class AzureGPT4(AzureGPT):

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -263,6 +263,91 @@ class GPT4o(GPT):
   name = 'gpt-4o'
 
 
+
+class AzureGPT(GPT):
+  """Azure's GPT model."""
+
+  name = 'gpt-3.5-turbo-azure'
+
+  # ================================ Prompt ================================ #
+  def estimate_token_num(self, text) -> int:
+    """Estimates the number of tokens in |text|."""
+    # https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
+    try:
+
+      encoder = tiktoken.encoding_for_model(self.name.replace('-azure', ''))
+
+    except KeyError:
+      logger.info('Could not get a tiktoken encoding for %s.', self.name)
+      encoder = tiktoken.get_encoding('cl100k_base')
+
+    num_tokens = 0
+    for message in text:
+      num_tokens += 3
+      for key, value in message.items():
+        num_tokens += len(encoder.encode(value))
+        if key == 'name':
+          num_tokens += 1
+    num_tokens += 3
+    return num_tokens
+
+    # ============================== Generation ============================== #
+  def query_llm(self,
+                prompt: prompts.Prompt,
+                response_dir: str,
+                log_output: bool = False,
+                build_spec=False) -> None:
+    """Queries OpenAI's API and stores response in |response_dir|."""
+    if self.ai_binary:
+      raise ValueError(f'OpenAI does not use local AI binary: {self.ai_binary}')
+    if self.temperature_list:
+      logger.info('OpenAI does not allow temperature list: %s',
+                  self.temperature_list)
+
+    client = openai.AzureOpenAI(azure_endpoint=os.getenv(
+        "AZURE_OPENAI_ENDPOINT", "https://api.openai.com"),
+                                api_key=os.getenv("AZURE_OPENAI_API_KEY",
+                                                  "YOUR_API_KEY"),
+                                api_version="2024-02-01")
+
+    if build_spec:
+      completion = self.with_retry_on_error(
+          lambda: client.chat.completions.create(messages=prompt.get(),
+                                                 model=self.name,
+                                                 n=1,
+                                                 temperature=self.temperature,
+                                                 max_tokens=self.max_tokens,
+                                                 stop=None), openai.OpenAIError)
+
+    else:
+
+      completion = self.with_retry_on_error(
+          lambda: client.chat.completions.create(messages=prompt.get(),
+                                                 model=self.name,
+                                                 n=self.num_samples,
+                                                 temperature=self.temperature),
+          openai.OpenAIError)
+
+    # TODO: Add a default value for completion.
+    if log_output:
+      logger.info(completion)
+    for index, choice in enumerate(completion.choices):  # type: ignore
+      content = choice.message.content
+      self._save_output(index, content, response_dir)
+
+
+class AzureGPT4(AzureGPT):
+  """Azure's GPTi-4 model."""
+
+  name = 'gpt-4-azure'
+
+
+class AzureGPT4oAzure(AzureGPT):
+  """Azure's GPTi-4 model."""
+
+  name = 'gpt-4o-azure'
+
+
 class Claude(LLM):
   """Anthropic's Claude model encapsulator."""
 

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -206,12 +206,11 @@ class GPT(LLM):
     except KeyError:
       logger.info('Could not get a tiktoken encoding for %s.', self.name)
       return tiktoken.get_encoding('cl100k_base')
-    
+
   def _get_client(self):
     """Returns the OpenAI client."""
     return openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
-  
-  
+
   # ================================ Prompt ================================ #
   def estimate_token_num(self, text) -> int:
     """Estimates the number of tokens in |text|."""
@@ -275,9 +274,9 @@ class GPT4o(GPT):
 
 class AzureGPT(GPT):
   """Azure's GPT model."""
-  
+
   name = 'gpt-3.5-turbo-azure'
-  
+
   def _get_tiktoken_encoding(self):
     """Returns the tiktoken encoding for the model."""
     try:
@@ -285,13 +284,13 @@ class AzureGPT(GPT):
     except KeyError:
       logger.info('Could not get a tiktoken encoding for %s.', self.name)
       return tiktoken.get_encoding('cl100k_base')
-    
+
   def _get_client(self):
     """Returns the Azure client."""
-    return openai.AzureOpenAI(azure_endpoint=os.getenv(
-        "AZURE_OPENAI_ENDPOINT"),
+    return openai.AzureOpenAI(azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
                               api_key=os.getenv("AZURE_OPENAI_API_KEY"),
                               api_version="2024-02-01")
+
 
 class AzureGPT4(AzureGPT):
   """Azure's GPTi-4 model."""


### PR DESCRIPTION
Added classes to support Azure's GPT model usage, which inherits from the class `GPT` according to the tutorial of Azure: 
[Create a new Python application](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line%2Cpython-new&pivots=programming-language-python#create-a-new-python-application)

Our changes: 
- overwrite the function `query_llm`, since the client is a bit different from the original GPT calling.
- overwrite the function `estimate_token_num` because we added a suffix (i.e., `-azure`) for the model name to distinguish the GPT model from the original GPT model (`gpt-3.5-turbo`, `gpt-4`, and `gpt-4o`). 

We have tested it in my local environment, it works well for all of the above Azure's GPT models.

Hope it helps.
