### PR TITLE
Display triage prompt on web (#538)

### DIFF
--- a/report/common.py
+++ b/report/common.py
@@ -118,6 +118,12 @@ class Target:
   fixer_prompt: Optional[str] = None
 
 
+@dataclasses.dataclass
+class Triage:
+  result: str
+  triager_prompt: str
+
+
 class FileSystem:
   """
   FileSystem provides a wrapper over standard library and GCS client and
@@ -309,20 +315,29 @@ class Results:
 
     return ''
 
-  def get_triage(self, benchmark: str, sample: str) -> str:
+  def get_triage(self, benchmark: str, sample: str) -> Triage:
     """Gets the triage of benchmark |benchmark| with sample ID |sample|."""
+    result = ''
+    triager_prompt = ''
     fixed_dir = os.path.join(self._results_dir, benchmark, 'fixed_targets')
     triage_dir = os.path.join(fixed_dir, f'{sample}-triage')
     if not os.path.exists(triage_dir):
-      return ''
+      return Triage(result, triager_prompt)
 
     for name in os.listdir(triage_dir):
+      if name == 'prompt.txt':
+        with FileSystem(os.path.join(triage_dir, name)).open() as f:
+          triager_prompt = f.read()
+
+        # Prepare prompt for being used in HTML.
+        triager_prompt = self._prepare_prompt_for_html_text(triager_prompt)
+
       if name.endswith('.txt') and name != 'prompt.txt':
         triage_path = os.path.join(triage_dir, name)
         with open(triage_path) as f:
-          return f.read()
+          result = f.read()
 
-    return ''
+    return Triage(result, triager_prompt)
 
   def get_targets(self, benchmark: str, sample: str) -> list[Target]:
     """Gets the targets of benchmark |benchmark| with sample ID |sample|."""
@@ -485,7 +500,7 @@ class Results:
 
     return targets
 
-  def _get_fixed_target(self, path: str):
+  def _get_fixed_target(self, path: str) -> Target:
     """Gets the fixed fuzz target from the benchmark's result |path|."""
     code = ''
     fixer_prompt = ''
@@ -494,8 +509,8 @@ class Results:
         with FileSystem(os.path.join(path, name)).open() as f:
           fixer_prompt = f.read()
 
-      # Prepare prompt for being used in HTML.
-      fixer_prompt = self._prepare_prompt_for_html_text(fixer_prompt)
+        # Prepare prompt for being used in HTML.
+        fixer_prompt = self._prepare_prompt_for_html_text(fixer_prompt)
 
       if name.endswith('.rawoutput'):
         with FileSystem(os.path.join(path, name)).open() as f:

--- a/report/templates/crash.json
+++ b/report/templates/crash.json
@@ -9,6 +9,7 @@
         "crashes": "{{ sample.result.crashes }}",
         "crash_reason": "{{ sample.result.semantic_error }}",
         "bug": "{{ not sample.result.is_semantic_error }}",
+        "triage": "{{ sample.result.triage }}",
         "coverage": "{{ sample.result.coverage | percent }}",
         "coverage_diff": "{{ sample.result.line_coverage_diff }}",
         "coverage_report": "{{ sample.result.coverage_report_path | cov_report_link }}",

--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -23,11 +23,21 @@ Crash reason: {{ sample.result.semantic_error }}
 <br>
 <br>
 
+{% if triage.result %}
 <h2>Triage</h2>
 <pre>
-{{ triage }}
+{{ triage.result }}
 </pre>
 <br>
+{% endif %}
+
+{% if triage.triager_prompt %}
+<h3>Triager prompt</h3>
+<pre>
+{{ triage.triager_prompt }}
+</pre>
+<br>
+{% endif %}
 
 {% for target in targets %}
 {% if target.fixer_prompt %}


### PR DESCRIPTION
From #538: This PR displays the triage prompt on the web, making it easier to read and evaluate the factors affecting LLM triage.