### PR TITLE
make it possible to run projects not in OSS-Fuzz upstream

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -83,7 +83,8 @@ def load_existing_textcov(project: str) -> textcov.Textcov:
 
   if not blobs.prefixes:  # type: ignore
     # No existing coverage reports.
-    raise RuntimeError(f'No existing coverage reports for {project}')
+    logger.info('No existing coverage report. Using empty.')
+    return textcov.Textcov()
 
   # Find the latest generated textcov date.
   latest_dir = sorted(blobs.prefixes)[-1]  # type: ignore
@@ -137,7 +138,8 @@ def load_existing_coverage_summary(project: str) -> dict:
 
   if not blobs.prefixes:  # type: ignore
     # No existing coverage reports.
-    raise RuntimeError(f'No existing coverage reports for {project}')
+    logger.info('No existing coverage reports, using empty one.')
+    return {}
 
   latest_dir = sorted(blobs.prefixes)[-1]  # type: ignore
   blob = bucket.blob(f'{latest_dir}linux/summary.json')
@@ -418,8 +420,12 @@ class Evaluator:
     # Gets line coverage (diff) details.
     coverage_summary = self._load_existing_coverage_summary()
 
-    total_lines = _compute_total_lines_without_fuzz_targets(
+    if coverage_summary:
+      total_lines = _compute_total_lines_without_fuzz_targets(
         coverage_summary, generated_target_name)
+    else:
+      total_lines = 0
+
     if self.benchmark.language == 'jvm':
       # The Jacoco.xml coverage report used to generate
       # summary.json on OSS-Fuzz for JVM projects does

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -422,7 +422,7 @@ class Evaluator:
 
     if coverage_summary:
       total_lines = _compute_total_lines_without_fuzz_targets(
-        coverage_summary, generated_target_name)
+          coverage_summary, generated_target_name)
     else:
       total_lines = 0
 

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -35,6 +35,7 @@ ENABLE_CACHING = bool(int(os.getenv('OFG_USE_CACHING', '0')))
 # This will change if temp_dir is used.
 OSS_FUZZ_DIR: str = os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'oss-fuzz')
+CLEAN_UP_OSS_FUZZ = bool(int(os.getenv('OFG_CLEAN_UP_OSS_FUZZ', '1')))
 
 VENV_DIR: str = 'venv'
 
@@ -90,13 +91,14 @@ def clone_oss_fuzz(oss_fuzz_dir: str = ''):
 
   if not os.path.exists(OSS_FUZZ_DIR):
     _clone_oss_fuzz_repo()
-  # Remove existing targets.
-  clean_command = ['git', 'clean', '-fxd', '-e', VENV_DIR, '-e', BUILD_DIR]
-  sp.run(clean_command,
-         capture_output=True,
-         stdin=sp.DEVNULL,
-         check=True,
-         cwd=OSS_FUZZ_DIR)
+
+  if CLEAN_UP_OSS_FUZZ:
+    clean_command = ['git', 'clean', '-fxd', '-e', VENV_DIR, '-e', BUILD_DIR]
+    sp.run(clean_command,
+           capture_output=True,
+           stdin=sp.DEVNULL,
+           check=True,
+           cwd=OSS_FUZZ_DIR)
 
 
 def postprocess_oss_fuzz() -> None:


### PR DESCRIPTION
This makes it possible to run OSS-Fuzz-gen on projects that are in a local OSS-Fuzz folder, but that are not in upstream OSS-Fuzz. This needs to use a local deployment of Fuzz Introspector.

Will follow-up with PRs for experimental that merges the two with scripts.

Ref: https://github.com/google/oss-fuzz-gen/issues/498