### PR TITLE
experimental: make harness build cmd into a loop

### DIFF
--- a/experimental/c-cpp/manager.py
+++ b/experimental/c-cpp/manager.py
@@ -1319,8 +1319,8 @@ def convert_fuzz_build_line_to_loop(clean_build_content: str,
   """
   split_lines = clean_build_content.split('\n')
   target_line_idx = -1
-  for idx in range(len(split_lines)):
-    if '/src/generated-fuzzer' in split_lines[idx]:
+  for idx, tmp_line in enumerate(split_lines):
+    if '/src/generated-fuzzer' in tmp_line:
       target_line_idx = idx
       break
   if target_line_idx == -1:

--- a/experimental/c-cpp/templates.py
+++ b/experimental/c-cpp/templates.py
@@ -132,9 +132,11 @@ main_repo: 'https://github.com/google/oss-fuzz'
 
 # Docker file used for OSS-Fuzz integrations.
 CLEAN_OSS_FUZZ_DOCKER = BASE_DOCKER_HEAD + '''
-COPY *.sh *.cpp *.c $SRC/
+COPY *.sh $SRC/
+RUN mkdir $SRC/fuzzers
+COPY *.cpp *.c $SRC/fuzzers/
 RUN git clone --recurse-submodules {repo_url} {project_repo_dir}
-WORKDIR {project_repo_dir}
+WORKDIR $SRC/{project_repo_dir}
 '''
 
 CLEAN_DOCKER_CFLITE = BASE_DOCKER_HEAD + '''
@@ -142,5 +144,5 @@ COPY . $SRC/{project_repo_dir}
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
 COPY .clusterfuzzlite/*.cpp $SRC/
 COPY .clusterfuzzlite/*.c $SRC/
-WORKDIR {project_repo_dir}
+WORKDIR $SRC/{project_repo_dir}
 '''


### PR DESCRIPTION
This will make it easy to migrate any number of harnesses into the generated project