### PR TITLE
test-to-harness: use new API endpoint to extract test code

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -100,7 +100,8 @@ def set_introspector_endpoints(endpoint):
       INTROSPECTOR_ALL_JVM_SOURCE_PATH, INTROSPECTOR_ORACLE_OPTIMAL, \
       INTROSPECTOR_HEADERS_FOR_FUNC, \
       INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE, \
-      INTROSPECTOR_ORACLE_ALL_TESTS, INTROSPECTOR_JVM_PROPERTIES
+      INTROSPECTOR_ORACLE_ALL_TESTS, INTROSPECTOR_JVM_PROPERTIES, \
+      INTROSPECTOR_TEST_SOURCE
 
   INTROSPECTOR_ENDPOINT = endpoint
 
@@ -116,6 +117,7 @@ def set_introspector_endpoints(endpoint):
   INTROSPECTOR_ORACLE_OPTIMAL = f'{INTROSPECTOR_ENDPOINT}/optimal-targets'
   INTROSPECTOR_FUNCTION_SOURCE = f'{INTROSPECTOR_ENDPOINT}/function-source-code'
   INTROSPECTOR_PROJECT_SOURCE = f'{INTROSPECTOR_ENDPOINT}/project-source-code'
+  INTROSPECTOR_TEST_SOURCE = f'{INTROSPECTOR_ENDPOINT}/project-test-code'
   INTROSPECTOR_XREF = f'{INTROSPECTOR_ENDPOINT}/all-cross-references'
   INTROSPECTOR_TYPE = f'{INTROSPECTOR_ENDPOINT}/type-info'
   INTROSPECTOR_FUNC_SIG = f'{INTROSPECTOR_ENDPOINT}/function-signature'
@@ -323,6 +325,16 @@ def query_introspector_source_code(project: str, filepath: str, begin_line: int,
           'end_line': end_line,
       })
 
+  return _get_data(resp, 'source_code', '')
+
+
+def query_introspector_test_source(project: str, filepath: str) -> str:
+  """Queries the source code of a test file from."""
+  resp = _query_introspector(
+          INTROSPECTOR_TEST_SOURCE, {
+          'project': project,
+          'filepath': filepath
+  })
   return _get_data(resp, 'source_code', '')
 
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -66,6 +66,7 @@ INTROSPECTOR_FUNC_SIG = ''
 INTROSPECTOR_ADDR_TYPE = ''
 INTROSPECTOR_ALL_HEADER_FILES = ''
 INTROSPECTOR_ALL_FUNC_TYPES = ''
+INTROSPECTOR_TEST_SOURCE = ''
 
 INTROSPECTOR_HEADERS_FOR_FUNC = ''
 INTROSPECTOR_SAMPLE_XREFS = ''
@@ -330,10 +331,9 @@ def query_introspector_source_code(project: str, filepath: str, begin_line: int,
 
 def query_introspector_test_source(project: str, filepath: str) -> str:
   """Queries the source code of a test file from."""
-  resp = _query_introspector(
-          INTROSPECTOR_TEST_SOURCE, {
-          'project': project,
-          'filepath': filepath
+  resp = _query_introspector(INTROSPECTOR_TEST_SOURCE, {
+      'project': project,
+      'filepath': filepath
   })
   return _get_data(resp, 'source_code', '')
 

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1197,9 +1197,9 @@ class TestToHarnessConverter(PromptBuilder):
     # Format the priming
     target_repository = oss_fuzz_checkout.get_project_repository(
         self.benchmark.project)
-    test_source_code = introspector.query_introspector_source_code(
+    test_source_code = introspector.query_introspector_test_source(
         self.benchmark.project,
-        self.benchmark.test_file_path.replace('//', '/'), 0, 9999999)
+        self.benchmark.test_file_path.replace('//', '/'))
 
     included_header_files = self.extract_header_files(test_source_code)
 


### PR DESCRIPTION
This makes it possible to extract a subset of test, for example when a test file is too long.