### PR TITLE
report: start project count from 0

### DIFF
--- a/report/common.py
+++ b/report/common.py
@@ -72,7 +72,7 @@ class Benchmark:
 class Project:
   """Results for a project entire."""
   name: str
-  count: int = 1
+  count: int = 0
   coverage_gain: float = 0.0
 
 


### PR DESCRIPTION
project.count indicates how many targets were run for each project. This starts at 1 meaning we're off by one each time, since we increment the count per target.