### PR TITLE
run_all_experiments: update project summary data on-the-fly

### DIFF
--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -313,7 +313,6 @@ def _print_and_dump_experiment_result(result: Result):
   add_to_json_report(WORK_DIR, 'project_summary', coverage_gain_dict)
 
 
-
 def _print_experiment_results(results: list[Result],
                               cov_gain: dict[str, dict[str, Any]]):
   """Prints the |results| of multiple experiments."""
@@ -440,9 +439,9 @@ def main():
     experiment_tasks = []
     with Pool(NUM_EXP) as p:
       for target_benchmark in experiment_targets:
-        experiment_task = p.apply_async(run_experiments,
-                                        (target_benchmark, args),
-                                        callback=_print_and_dump_experiment_result)
+        experiment_task = p.apply_async(
+            run_experiments, (target_benchmark, args),
+            callback=_print_and_dump_experiment_result)
         experiment_tasks.append(experiment_task)
         time.sleep(args.delay)
       # Signal that no more work will be submitte to the pool.


### PR DESCRIPTION
Prior to this commit project summary stats were generated only when all experiments had compled, i.e. all benchmarks running should terminate. This causes issues when, for some reason, some benchmarks may not terminate properly or terminate at all. This was observed on some large-scale experiments where 10-20 benchmarks did not finish, and, consequently the full run_experiment_all didn't terminate proper. However, in this case we stil want project summary stats for the 1000+ other benchmarks that have been analyzed.

This fixes it by updated benchmarks stats after each completed benchmark run.