### PR TITLE
report: fix java coverage links

### DIFF
--- a/report/web.py
+++ b/report/web.py
@@ -55,7 +55,7 @@ class JinjaEnv:
     # Check if this is a java benchmark, which will always have a period in
     # the path, where C/C++ wont.
     # TODO(David) refactor to have paths for links more controlled.
-    is_jvm = '.' in path:
+    if '.' in path:
         return link_path + 'index.html'
     return link_path + 'report.html'
 

--- a/report/web.py
+++ b/report/web.py
@@ -50,7 +50,14 @@ class JinjaEnv:
       return '#'
 
     path = link.removeprefix('gs://oss-fuzz-gcb-experiment-run-logs/')
-    return f'https://llm-exp.oss-fuzz.com/{path}/report/linux/report.html'
+    link_path = f'https://llm-exp.oss-fuzz.com/{path}/report/linux/'
+
+    # Check if this is a java benchmark, which will always have a period in
+    # the path, where C/C++ wont.
+    # TODO(David) refactor to have paths for links more controlled.
+    is_jvm = '.' in path:
+        return link_path + 'index.html'
+    return link_path + 'report.html'
 
   def __init__(self, template_globals: Optional[Dict[str, Any]] = None):
     self._env = jinja2.Environment(

--- a/report/web.py
+++ b/report/web.py
@@ -56,7 +56,7 @@ class JinjaEnv:
     # the path, where C/C++ wont.
     # TODO(David) refactor to have paths for links more controlled.
     if '.' in path:
-        return link_path + 'index.html'
+      return link_path + 'index.html'
     return link_path + 'report.html'
 
   def __init__(self, template_globals: Optional[Dict[str, Any]] = None):


### PR DESCRIPTION
Links are not working for Java coverage reports because of mismatch with report/index.html