### PR TITLE
JVM: Fix wrong query parameter bug

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -391,7 +391,7 @@ def query_introspector_matching_function_constructor_type(
 
   resp = _query_introspector(INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE, {
       'project': project,
-      'return_type': return_type
+      'return-type': return_type
   })
 
   if is_function:


### PR DESCRIPTION
The introspector query for jvm return type searching has a wrong parameter name. This PR fixes that.