### PR TITLE
JVM: Fix handling for empty coverage report

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -116,7 +116,8 @@ def load_existing_jvm_textcov(project: str) -> textcov.Textcov:
 
   if not blobs.prefixes:  # type: ignore
     # No existing coverage reports.
-    raise RuntimeError(f'No existing coverage reports for {project}')
+    logger.info('No existing coverage report. Using empty.')
+    return textcov.Textcov()
 
   latest_dir = sorted(blobs.prefixes)[-1]  # type: ignore
   blob = bucket.blob(f'{latest_dir}linux/jacoco.xml')


### PR DESCRIPTION
This PR fixes the handling of missing JVM coverage report. The new logic returns an empty Textcov object instead of throwing a RuntimeError. The new setting allows processing of new OSS-Fuzz integration which does not have existing coverage reports.