### PR TITLE
JVM: Fix bug in exceptions list handling

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -819,7 +819,8 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
       constructor_sig = ctr.get('function_signature', '')
       if constructor_sig:
         constructors.append(f'<signature>{constructor_sig}</signature>')
-        exceptions = introspector.query_introspector_function_props(ctr.get('project', ''), constructor_sig).get('exceptions', [])
+        exceptions = introspector.query_introspector_function_props(
+            ctr.get('project', ''), constructor_sig).get('exceptions', [])
         self.exceptions.extend(exceptions)
 
     if constructors:
@@ -834,7 +835,8 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
       function_sig = func.get('function_signature', '')
       if not function_sig:
         continue
-      exceptions = introspector.query_introspector_function_props(func.get('project', ''), function_sig).get('exceptions', [])
+      exceptions = introspector.query_introspector_function_props(
+          func.get('project', ''), function_sig).get('exceptions', [])
       self.exceptions.extend(exceptions)
       if is_static:
         functions.append(f'<item><signature>{function_sig}</signature></item>')

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -819,9 +819,8 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
       constructor_sig = ctr.get('function_signature', '')
       if constructor_sig:
         constructors.append(f'<signature>{constructor_sig}</signature>')
-        self.exceptions.update(
-            introspector.query_introspector_function_props(
-                ctr.get('project', ''), constructor_sig)[0])
+        exceptions = introspector.query_introspector_function_props(ctr.get('project', ''), constructor_sig).get('exceptions', [])
+        self.exceptions.extend(exceptions)
 
     if constructors:
       ctr_str = '\n'.join(constructors)
@@ -835,9 +834,8 @@ class DefaultJvmTemplateBuilder(PromptBuilder):
       function_sig = func.get('function_signature', '')
       if not function_sig:
         continue
-      self.exceptions.update(
-          introspector.query_introspector_function_props(
-              func.get('project', ''), function_sig)[0])
+      exceptions = introspector.query_introspector_function_props(func.get('project', ''), function_sig).get('exceptions', [])
+      self.exceptions.extend(exceptions)
       if is_static:
         functions.append(f'<item><signature>{function_sig}</signature></item>')
       else:


### PR DESCRIPTION
This PR fixes a bug in exception handling for JVM prompt generation. The return value of `introspector.query_introspector_function_props()` could be an empty dictionary, causing a `KeyError` when attempting to access the first items. The fix adds fail-safe logic for when the dictionary is empty and directly provides a default empty list for processing.