### PR TITLE
introspector: do not extract functions from test-migration

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -613,7 +613,7 @@ def _select_top_functions_from_oracle(project: str, limit: int,
                                       target_oracle: str,
                                       target_oracles: list[str]) -> OrderedDict:
   """Selects the top |limit| functions from |target_oracle|."""
-  if target_oracle not in target_oracles:
+  if target_oracle not in target_oracles or target_oracle == 'test-migration':
     return OrderedDict()
 
   logger.info('Extracting functions using oracle %s.', target_oracle)


### PR DESCRIPTION
There's no functions to extract.