### PR TITLE
test-to-harness: Fix missing return statement

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -779,11 +779,10 @@ def populate_benchmarks_using_introspector(project: str, language: str,
   # TODO(David): clean up benchmark code to make it more flexible for varying
   # forms of target selectors, and potential mixing both types of target
   # selectors.
+  if any('test-migration' in oracle for oracle in target_oracles):
+    return populate_benchmarks_using_test_migration(project, language, limit)
+
   potential_benchmarks = []
-  for target_oracle in target_oracles:
-    if 'test-migration' in target_oracle:
-      potential_benchmarks.extend(
-          populate_benchmarks_using_test_migration(project, language, limit))
 
   if language == 'jvm':
     functions = _select_functions_from_jvm_oracles(project, limit,


### PR DESCRIPTION
For benchmark generation process, if there is any oracle with test-migration then the process should only generate benchmarks from the test-migration oracle and ignoring the others because the benchmarks will have different .yaml structure. But the current logic missing a return statement and the logic will continue to handle other oracles after processing the test-migration oracle. This PR fixes that.