### PR TITLE
JVM: Fix missing coverage for constructors

### DIFF
--- a/experiment/textcov.py
+++ b/experiment/textcov.py
@@ -42,8 +42,7 @@ JVM_CLASS_MAPPING = {
 }
 
 JVM_SKIPPED_METHOD = [
-    '<init>', '<cinit>', 'fuzzerTestOneInput', 'fuzzerInitialize',
-    'fuzzerTearDown'
+    'fuzzerTestOneInput', 'fuzzerInitialize', 'fuzzerTearDown'
 ]
 
 


### PR DESCRIPTION
This PR fixes a bug in JVM coverage caluclation which skip the coverage calculations for constructors.