### PR TITLE
Fix bug of wrong fuzzing language for Java and python projects

### DIFF
--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -160,7 +160,8 @@ def _build_project_local_docker(project: str):
 
 def _copy_project_src(project: str,
                       out: str,
-                      cloud_experiment_bucket: str = ''):
+                      cloud_experiment_bucket: str = '',
+                      language: str = 'c++'):
   """Copies /|src| from cloud if bucket is available or from local image."""
   if cloud_experiment_bucket:
     logger.info(
@@ -173,7 +174,7 @@ def _copy_project_src(project: str,
         f'Retrieving human-written fuzz targets of {project} from local '
         'Docker build.')
     _build_project_local_docker(project)
-    _copy_project_src_from_local(project, out)
+    _copy_project_src_from_local(project, out, language)
 
 
 def _build_project_on_cloud(project: str, cloud_experiment_bucket: str) -> str:
@@ -235,7 +236,7 @@ def _copy_project_src_from_cloud(bucket_dirname: str, out: str,
     logger.info(f"Deleted {blob.name} from the bucket.")
 
 
-def _copy_project_src_from_local(project: str, out: str):
+def _copy_project_src_from_local(project: str, out: str, language: str):
   """Runs the project's OSS-Fuzz image to copy /|src| to /|out|."""
   run_container = [
       'docker',
@@ -256,7 +257,7 @@ def _copy_project_src_from_local(project: str, out: str):
       '-e',
       'HELPER=True',
       '-e',
-      'FUZZING_LANGUAGE=c++',
+      f'FUZZING_LANGUAGE={language}',
       '--name',
       f'{project}-container',
       f'gcr.io/oss-fuzz/{project}',
@@ -398,7 +399,7 @@ def search_source(
     out = os.path.join(temp_dir, 'out')
     os.makedirs(out)
 
-    _copy_project_src(project, out, cloud_experiment_bucket)
+    _copy_project_src(project, out, cloud_experiment_bucket, language)
 
     potential_harnesses, interesting_filepaths = _identify_fuzz_targets(
         out, interesting_filenames, language)


### PR DESCRIPTION
This PR fixes a bug in local project building of Java and python projects for benchmark generation, where the fuzzing language is wrongly fixed to `c++`.