### PR TITLE
introspector: Fix bug in introspector response data retrieval

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -209,8 +209,10 @@ def _get_data(resp: Optional[requests.Response], key: str,
         resp.content.decode('utf-8').strip())
     return default_value
 
+  # To handle the case that some FI query could return empty list,
+  # empty dict or boolean value False
   content = data.get(key)
-  if content:
+  if content or key in data.keys():
     return content
 
   logger.error('Failed to get %s from FI:\n'


### PR DESCRIPTION
This PR fixes a bug in the `_get_data` function used for retrieving the necessary data from an introspector response. It was found that some introspector queries could return an empty list, empty dictionary, or boolean False as data. This causes the current check to be unable to distinguish between a missing field in the response, an empty list, or a boolean False value. This PR addresses the issue.