### PR TITLE
Fix package missing bug

### DIFF
--- a/experimental/jvm/generate_projects.py
+++ b/experimental/jvm/generate_projects.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Manager for running auto-gen from scratch."""
 
+import sys
+sys.path.append('../../')
+
 import argparse
 import logging
 import os

--- a/experimental/jvm/generate_projects.py
+++ b/experimental/jvm/generate_projects.py
@@ -15,6 +15,7 @@
 """Manager for running auto-gen from scratch."""
 
 import sys
+
 sys.path.append('../../')
 
 import argparse

--- a/experimental/jvm/utils.py
+++ b/experimental/jvm/utils.py
@@ -16,15 +16,17 @@
 """Provides a set of utils for oss-fuzz-gen on new Java projects integration"""
 
 import sys
-sys.path.append('../..')
+
+sys.path.append('../../')
 
 import logging
 import os
 import subprocess
 from typing import Optional
 
-from experimental.jvm import constants, oss_fuzz_templates
 from urllib3.util import parse_url
+
+from experimental.jvm import constants, oss_fuzz_templates
 
 logger = logging.getLogger(__name__)
 

--- a/experimental/jvm/utils.py
+++ b/experimental/jvm/utils.py
@@ -15,13 +15,15 @@
 ###############################################################################
 """Provides a set of utils for oss-fuzz-gen on new Java projects integration"""
 
+import sys
+sys.path.append('../..')
+
 import logging
 import os
 import subprocess
 from typing import Optional
 
-import constants
-import oss_fuzz_templates
+from experimental.jvm import constants, oss_fuzz_templates
 from urllib3.util import parse_url
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The Python script in the `experimental.jvm` package is not intended to be invoked by the core OFG logic. Instead, it is meant to be executed by the `run_e2e.sh` script located in the same directory. Therefore, if the package name `experimental.jvm` needs to be changed as done in #604, the `sys.path` must be set to the core OFG base path. This PR implements that change.