### PR TITLE
Don't quote `$AGENT_ARG` in docker_run.sh

### DIFF
--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -161,7 +161,7 @@ $PYTHON run_all_experiments.py \
   --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
   --temperature-list "${VARY_TEMPERATURE[@]}" \
   --model "$MODEL" \
-  "$AGENT_ARG"
+  $AGENT_ARG
 
 export ret_val=$?
 


### PR DESCRIPTION
Otherwise we can pass an empty string which breaks the argument passing.