### PR TITLE
Support large PR experiments.

### DIFF
--- a/ci/k8s/large-pr-exp.yaml
+++ b/ci/k8s/large-pr-exp.yaml
@@ -1,0 +1,76 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ofg-pr-${GKE_EXP_NAME}
+  labels:
+    customLabel: "myCustomValue"
+spec:
+  activeDeadlineSeconds: 108000  # 30 hours. We don't want large experiments to run indefinitely and eat up resources.
+  template:
+    spec:
+      containers:
+      - name: experiment
+        image:  us-central1-docker.pkg.dev/oss-fuzz-base/testing/oss-fuzz-gen-pull-request:pr-${PR_ID}
+        imagePullPolicy: Always
+        # To guarantee uniqueness we use the node name in the experiment path.
+        # Modify the follow command to customize one-off experiments.
+        # For benchmark sets that need more disk, increase the results volume
+        # size too.
+        command: ["/bin/bash", "report/docker_run.sh", "${GKE_EXP_BENCHMARK}", "${GKE_EXP_NAME}", "${GKE_EXP_FUZZING_TIMEOUT}", "ofg-pr", "${GKE_EXP_LLM}", "${GKE_EXP_DELAY}", "${GKE_EXP_LOCAL_INTROSPECTOR}", "${GKE_EXP_NUM_SAMPLES}", "${GKE_EXP_LLM_FIX_LIMIT}", "${GKE_EXP_VARY_TEMPERATURE}", "${GKE_EXP_AGENT}"]
+        resources:
+          requests:
+            cpu: ${GKE_EXP_REQ_CPU}
+            ephemeral-storage: 10Gi
+            memory: ${GKE_EXP_REQ_MEM}
+        volumeMounts:
+        - mountPath: "/experiment/results"
+          name: results-volume
+        env:
+        - name: LLM_NUM_EXP
+          value: '450'
+        - name: LLM_NUM_EVA
+          value: '10'
+        - name: VERTEX_AI_LOCATIONS
+          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,northamerica-northeast1,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
+      # imagePullSecrets:
+      # - name: oss-fuzz-base-artifect
+      volumes:
+      - name: results-volume
+        ephemeral:
+          volumeClaimTemplate:
+            metadata:
+              labels:
+                type: ephemeral
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "ephemeral-ssd"
+              resources:
+                requests:
+                  storage: 1000Gi
+      restartPolicy: Never
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 432000  # 7 days.
+  podFailurePolicy:
+    rules:
+      - action: FailJob
+        onExitCodes:
+          containerName: experiment  # Optional
+          operator: NotIn            # One of: In, NotIn
+          values: [0]
+      - action: Ignore             # One of: Ignore, FailJob, Count
+        onPodConditions:
+        - type: DisruptionTarget   # Indicates Pod disruption

--- a/ci/request_pr_exp.py
+++ b/ci/request_pr_exp.py
@@ -33,15 +33,21 @@ from string import Template
 logging.basicConfig(level=logging.INFO)
 
 DEFAULT_CLUSTER = 'llm-experiment'
+LARGE_CLUSTER = 'llm-experiment-large'
 DEFAULT_LOCATION = 'us-central1-c'
+LARGE_LOCATION = 'us-central1'
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'k8s', 'pr-exp.yaml')
+LARGE_TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'k8s',
+                                   'large-pr-exp.yaml')
 BENCHMARK_SET = 'comparison'
 LLM_NAME = 'vertex_ai_gemini-1-5'
 LLM_CHAT_NAME = 'vertex_ai_gemini-1-5-chat'
 EXP_DELAY = 0
 FUZZING_TIMEOUT = 300
 REQUEST_CPU = 6
+LARGE_REQUEST_CPU = 356
 REQUEST_MEM = 30
+LARGE_REQUEST_MEM = 1000
 NUM_SAMPLES = 2
 NUM_FIXES = 2
 VARY_TEMPERATURE = True
@@ -158,6 +164,12 @@ def _parse_args(cmd) -> argparse.Namespace:
                       action='store_true',
                       default=False,
                       help='Enables agent enhancement.')
+  parser.add_argument('-lg',
+                      '--large',
+                      action='store_true',
+                      default=False,
+                      help=('(Use sparingly) Do a large experiment with '
+                            'many more cores available.'))
   args = parser.parse_args(cmd)
 
   assert os.path.isfile(
@@ -171,6 +183,13 @@ def _parse_args(cmd) -> argparse.Namespace:
   # Use Chat model by default in agent-enhance experiments.
   if args.agent and args.llm == LLM_NAME:
     args.llm = LLM_CHAT_NAME
+
+  if args.large:
+    args.location = LARGE_LOCATION
+    args.cluster = LARGE_CLUSTER
+    args.request_cpus = LARGE_REQUEST_CPU
+    args.request_memory = LARGE_REQUEST_MEM
+    args.gke_template = LARGE_TEMPLATE_PATH
 
   return args
 


### PR DESCRIPTION
This can be triggered by passing `--large`, which changes the cluster and CPU/memory requests and parallelism.