### PR TITLE
builder_runner: store summary.json in workdir in cloud runs

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -960,7 +960,17 @@ class CloudBuilderRunner(BuilderRunner):
 
     blob = bucket.blob(f'{coverage_name}/report/linux/summary.json')
     if blob.exists():
-      with blob.open() as f:
+      # Download summary.json to our workdir.
+      cov_summary_folder = os.path.join(
+          self.work_dirs.code_coverage_report(generated_target_name),
+          'report/linux/')
+      os.makedirs(cov_summary_folder)
+      coverage_summary_file = os.path.join(cov_summary_folder, 'summary.json')
+      with open(coverage_summary_file, 'w') as f:
+        blob.download_to_file(f)
+
+      # Load the coverage summary
+      with open(coverage_summary_file, 'r') as f:
         run_result.coverage_summary = json.load(f)
 
     target_basename = os.path.basename(self.benchmark.target_path)

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -959,7 +959,16 @@ class CloudBuilderRunner(BuilderRunner):
                            log_path=run_log_path)
     blob = bucket.blob(f'{coverage_name}/report/linux/summary.json')
     if blob.exists():
-      with blob.open() as f:
+
+      # Download summary.json to our workdir.
+      cov_summary_folder = os.path.join(self.work_dirs.code_coverage_report(generated_target_name), 'report/linux/')
+      os.makedirs(cov_summary_folder)
+      coverage_summary_file = os.path.join(cov_summary_folder, 'summary.json')
+      with open(coverage_summary_file, 'w') as f:
+        blob.download_to_file(f)
+
+      # Load the coverage summary
+      with open(coverage_summary_file) as f:
         run_result.coverage_summary = json.load(f)
 
     target_basename = os.path.basename(self.benchmark.target_path)

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -969,8 +969,8 @@ class CloudBuilderRunner(BuilderRunner):
       with open(coverage_summary_file, 'w') as f:
         blob.download_to_file(f)
 
-      # Load the coverage summary
-      with open(coverage_summary_file) as f:
+    blob = bucket.blob(f'{coverage_name}/report/linux/summary.json')
+    if blob.exists():
         run_result.coverage_summary = json.load(f)
 
     target_basename = os.path.basename(self.benchmark.target_path)

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -957,17 +957,6 @@ class CloudBuilderRunner(BuilderRunner):
                            coverage_report_path=coverage_path,
                            reproducer_path=reproducer_path,
                            log_path=run_log_path)
-    blob = bucket.blob(f'{coverage_name}/report/linux/summary.json')
-    if blob.exists():
-
-      # Download summary.json to our workdir.
-      cov_summary_folder = os.path.join(
-          self.work_dirs.code_coverage_report(generated_target_name),
-          'report/linux/')
-      os.makedirs(cov_summary_folder)
-      coverage_summary_file = os.path.join(cov_summary_folder, 'summary.json')
-      with open(coverage_summary_file, 'w') as f:
-        blob.download_to_file(f)
 
     blob = bucket.blob(f'{coverage_name}/report/linux/summary.json')
     if blob.exists():

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -966,7 +966,7 @@ class CloudBuilderRunner(BuilderRunner):
           'report/linux/')
       os.makedirs(cov_summary_folder)
       coverage_summary_file = os.path.join(cov_summary_folder, 'summary.json')
-      with open(coverage_summary_file, 'w') as f:
+      with open(coverage_summary_file, 'wb') as f:
         blob.download_to_file(f)
 
       # Load the coverage summary

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -971,6 +971,7 @@ class CloudBuilderRunner(BuilderRunner):
 
     blob = bucket.blob(f'{coverage_name}/report/linux/summary.json')
     if blob.exists():
+      with blob.open() as f:
         run_result.coverage_summary = json.load(f)
 
     target_basename = os.path.basename(self.benchmark.target_path)

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -961,7 +961,9 @@ class CloudBuilderRunner(BuilderRunner):
     if blob.exists():
 
       # Download summary.json to our workdir.
-      cov_summary_folder = os.path.join(self.work_dirs.code_coverage_report(generated_target_name), 'report/linux/')
+      cov_summary_folder = os.path.join(
+          self.work_dirs.code_coverage_report(generated_target_name),
+          'report/linux/')
       os.makedirs(cov_summary_folder)
       coverage_summary_file = os.path.join(cov_summary_folder, 'summary.json')
       with open(coverage_summary_file, 'w') as f:

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -161,7 +161,7 @@ $PYTHON run_all_experiments.py \
   --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
   --temperature-list "${VARY_TEMPERATURE[@]}" \
   --model "$MODEL" \
-  $AGENT_ARG >> $LOCAL_RESULTS_DIR/logs-from-run.txt 2>&1
+  $AGENT_ARG
 
 export ret_val=$?
 

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -161,7 +161,7 @@ $PYTHON run_all_experiments.py \
   --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
   --temperature-list "${VARY_TEMPERATURE[@]}" \
   --model "$MODEL" \
-  $AGENT_ARG
+  $AGENT_ARG >> $LOCAL_RESULTS_DIR/logs-from-run.txt 2>&1
 
 export ret_val=$?
 

--- a/report/web.py
+++ b/report/web.py
@@ -120,7 +120,7 @@ class GenerateReport:
     for l in os.listdir(coverage_path):
       if l.split('.')[0] == sample.id:
         coverage_report = os.path.join(coverage_path, l)
-    if coverage_report:
+    if coverage_report and os.path.isdir(coverage_report) and len(os.listdir(coverage_report)) > 1:
       # Copy coverage to reports out
       dst = os.path.join(self._output_dir, 'sample', benchmark.id, 'coverage')
       os.makedirs(dst, exist_ok=True)

--- a/report/web.py
+++ b/report/web.py
@@ -120,7 +120,8 @@ class GenerateReport:
     for l in os.listdir(coverage_path):
       if l.split('.')[0] == sample.id:
         coverage_report = os.path.join(coverage_path, l)
-    if coverage_report and os.path.isdir(coverage_report) and len(os.listdir(coverage_report)) > 1:
+    if coverage_report and os.path.isdir(coverage_report) and len(
+        os.listdir(coverage_report)) > 1:
       # Copy coverage to reports out
       dst = os.path.join(self._output_dir, 'sample', benchmark.id, 'coverage')
       os.makedirs(dst, exist_ok=True)


### PR DESCRIPTION
This will make post processing of results easier, also when downloading the reports locally.