### PR TITLE
builder-runner: store textcov in workdir

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -762,10 +762,10 @@ class BuilderRunner:
         benchmark_target_name)
     shutil.copytree(coverage_report, destination_coverage, dirs_exist_ok=True)
 
-    textcov_dir = os.path.join(get_build_artifact_dir(generated_project,
-                                               'out'), 'textcov_reports')
-    dst_textcov = os.path.join(self.work_dirs.code_coverage_report(
-        benchmark_target_name), 'textcov')
+    textcov_dir = os.path.join(get_build_artifact_dir(generated_project, 'out'),
+                               'textcov_reports')
+    dst_textcov = os.path.join(
+        self.work_dirs.code_coverage_report(benchmark_target_name), 'textcov')
     shutil.copytree(textcov_dir, dst_textcov, dirs_exist_ok=True)
 
     coverage_summary = os.path.join(
@@ -773,9 +773,6 @@ class BuilderRunner:
         'summary.json')
     with open(coverage_summary) as f:
       coverage_summary = json.load(f)
-
-
-
 
     return local_textcov, coverage_summary
 
@@ -985,19 +982,21 @@ class CloudBuilderRunner(BuilderRunner):
     target_basename = os.path.basename(self.benchmark.target_path)
 
     # Load coverage reports.
-    textcov_blob_path = self._get_cloud_textcov_path(bucket, coverage_name)
+    textcov_blob_path = self._get_cloud_textcov_path(coverage_name)
     if self.benchmark.language == 'jvm':
       blob = bucket.blob(textcov_blob_path)
       if blob.exists():
         with blob.open() as f:
           run_result.coverage = textcov.Textcov.from_jvm_file(f)
-        self._copy_textcov_to_workdir(bucket, textcov_blob_path, generated_target_name)
+        self._copy_textcov_to_workdir(bucket, textcov_blob_path,
+                                      generated_target_name)
     elif self.benchmark.language == 'python':
       blob = bucket.blob(textcov_blob_path)
       if blob.exists():
         with blob.open() as f:
           run_result.coverage = textcov.Textcov.from_python_file(f)
-        self._copy_textcov_to_workdir(bucket, textcov_blob_path, generated_target_name)
+        self._copy_textcov_to_workdir(bucket, textcov_blob_path,
+                                      generated_target_name)
     else:
       # C/C++
       blob = bucket.blob(textcov_blob_path)
@@ -1009,7 +1008,8 @@ class CloudBuilderRunner(BuilderRunner):
                   # Don't include other functions defined in the target code.
                   re.compile(r'^' + re.escape(target_basename) + ':')
               ])
-        self._copy_textcov_to_workdir(bucket, textcov_blob_path, generated_target_name)
+        self._copy_textcov_to_workdir(bucket, textcov_blob_path,
+                                      generated_target_name)
 
     # Parse libfuzzer logs to get fuzz target runtime details.
     with open(self.work_dirs.run_logs_target(generated_target_name, iteration),
@@ -1022,27 +1022,26 @@ class CloudBuilderRunner(BuilderRunner):
 
     return build_result, run_result
 
-
-  def _copy_textcov_to_workdir(self, bucket: storage.bucket.Bucket, textcov_blob_path: str, generated_target_name: str) -> None:
+  def _copy_textcov_to_workdir(self, bucket, textcov_blob_path: str,
+                               generated_target_name: str) -> None:
     """Stores a given textcov blob into the workdir."""
     blob = bucket.blob(textcov_blob_path)
     textcov_dir = os.path.join(
-          self.work_dirs.code_coverage_report(generated_target_name), 'textcov')
-    os.makedirs(textcov_dir, exists_ok=True)
+        self.work_dirs.code_coverage_report(generated_target_name), 'textcov')
+    os.makedirs(textcov_dir, exist_ok=True)
     textcov_dst = os.path.join(textcov_dir, os.path.basename(textcov_blob_path))
     with open(textcov_dst, 'wb') as f:
       blob.download_to_file(f)
-    
 
   def _get_cloud_textcov_path(self, coverage_name: str) -> str:
     """Extracts textcov blob path for this benchmark."""
     if self.benchmark.language == 'jvm':
       return f'{coverage_name}/textcov_reports/jacoco.xml'
-    elif self.benchmark.language == 'python':
+    if self.benchmark.language == 'python':
       return f'{coverage_name}/textcov_reports/all_cov.json'
-    else:
-      return (f'{coverage_name}/textcov_reports/{self.benchmark.target_name}'
-          '.covreport')
+
+    return (f'{coverage_name}/textcov_reports/{self.benchmark.target_name}'
+            '.covreport')
 
 
 def get_build_artifact_dir(generated_project: str, build_artifact: str) -> str:

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -161,7 +161,7 @@ $PYTHON run_all_experiments.py \
   --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
   --temperature-list "${VARY_TEMPERATURE[@]}" \
   --model "$MODEL" \
-  $AGENT_ARG
+  $AGENT_ARG >> $LOCAL_RESULTS_DIR/logs-from-run.txt 2>&1
 
 export ret_val=$?
 


### PR DESCRIPTION
This is useful to easily process textcov improvements for a benchmark, without doing it in sync with the experiments running