### PR TITLE
run_all_experiments: fix coverage sync and wrong aggregate coverage gains measure

### DIFF
--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -132,8 +132,7 @@ def prepare_experiment_targets(
   return experiment_configs
 
 
-def run_experiments(benchmark: benchmarklib.Benchmark,
-                    args: argparse.Namespace) -> Result:
+def run_experiments(benchmark: benchmarklib.Benchmark, args) -> Result:
   """Runs an experiment based on the |benchmark| config."""
   try:
     work_dirs = WorkDirs(os.path.join(args.work_dir, f'output-{benchmark.id}'))
@@ -314,7 +313,7 @@ def _print_and_dump_experiment_result(result: Result):
   # Process total gain from all generated harnesses for each projects and
   # update summary report. This makes it possible to view per-project stats
   # as experiments complete rather than only after all experiments run.
-  coverage_gain_dict = _process_total_coverage_gain(EXPERIMENT_RESULTS)
+  coverage_gain_dict = _process_total_coverage_gain()
   add_to_json_report(WORK_DIR, 'project_summary', coverage_gain_dict)
 
 
@@ -363,23 +362,42 @@ def add_to_json_report(outdir: str, key: str, value: Any) -> None:
     f.write(json.dumps(json_report))
 
 
-def _process_total_coverage_gain(
-    results: list[Result]) -> dict[str, dict[str, Any]]:
+def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
   """Processes and calculates the total coverage gain for each project."""
   textcov_dict: dict[str, list[textcov.Textcov]] = {}
-  if not results:
+
+  # Load all the textcov dirs
+  for benchmark_dir in os.listdir(WORK_DIR):
+    try:
+      project = benchmark_dir.split('-')[1]
+      benchmark = '-'.join(benchmark_dir.split('-')[2:])
+    except:
+      continue
+
+    coverage_reports = os.path.join('results', benchmark_dir, 'code-coverage-reports')
+    if not os.path.isdir(coverage_reports):
+        continue
+
+    if project not in textcov_dict:
+      textcov_dict[project] = []
+    for sample in os.listdir(coverage_reports):
+        summary = os.path.join(coverage_reports, sample, 'textcov')
+        if not os.path.isdir(summary):
+          continue
+
+        for textcov_file in os.listdir(summary):
+          if textcov_file.endswith('.covreport'):
+            with open(os.path.join(summary, textcov_file), 'rb') as f:
+              textcov_dict[project].append(textcov.Textcov.from_file(f))
+          elif textcov_file == 'all_cov.json':
+            with open(os.path.join(summary, textcov_file)) as f:
+              textcov_dict[project].append(textcov.Textcov.from_python_file(f))
+          elif textcov_file == 'jacoco.xml':
+            with open(os.path.join(summary, textcov_file)) as f:
+              textcov_dict[project].append(textcov.Textcov.from_jvm_file(f))
+
+  if not textcov_dict:
     return {}
-  for result in results:
-    # TODO(dongge): Do not use a hacky string for result.result when an
-    # exception happened during experiments?
-    if not isinstance(result.result, run_one_experiment.AggregatedResult):
-      continue
-    cov = result.result.full_textcov_diff
-    if not cov:
-      continue
-    if result.benchmark.project not in textcov_dict:
-      textcov_dict[result.benchmark.project] = []
-    textcov_dict[result.benchmark.project].append(cov)
 
   coverage_gain: dict[str, dict[str, Any]] = {}
   for project, cov_list in textcov_dict.items():
@@ -458,7 +476,7 @@ def main():
       p.join()
 
   # Process total gain from all generated harnesses for each projects
-  coverage_gain_dict = _process_total_coverage_gain(EXPERIMENT_RESULTS)
+  coverage_gain_dict = _process_total_coverage_gain()
   add_to_json_report(args.work_dir, 'project_summary', coverage_gain_dict)
 
   # Capture time at end

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -374,7 +374,7 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
     except:
       continue
 
-    coverage_reports = os.path.join('results', benchmark_dir, 'code-coverage-reports')
+    coverage_reports = os.path.join(WORK_DIR, benchmark_dir, 'code-coverage-reports')
     if not os.path.isdir(coverage_reports):
         continue
 
@@ -404,7 +404,6 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
     total_cov = textcov.Textcov()
     for cov in cov_list:
       total_cov.merge(cov)
-    total_cov.to_file(os.path.join('results', '%s-textcov_merged'%(project)))
     existing_textcov = evaluator.load_existing_textcov(project)
     coverage_summary = evaluator.load_existing_coverage_summary(project)
 
@@ -415,13 +414,7 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
       lines = []
 
     total_existing_lines = sum(lines)
-    print('Project: %s'%(project))
-    print('- total assembled: %d'%(total_cov.covered_lines))
-    print('- Total summary: %d'%(total_existing_lines))
-    print('- Existing textcov: %d'%(existing_textcov.covered_lines))
     total_cov.subtract_covered_lines(existing_textcov)
-    print("- Subtracted: %d"%(total_cov.covered_lines))
-
 
     total_lines = max(total_cov.total_lines, sum(lines))
 

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -370,31 +370,31 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
   for benchmark_dir in os.listdir(WORK_DIR):
     try:
       project = benchmark_dir.split('-')[1]
-      benchmark = '-'.join(benchmark_dir.split('-')[2:])
     except:
       continue
 
-    coverage_reports = os.path.join(WORK_DIR, benchmark_dir, 'code-coverage-reports')
+    coverage_reports = os.path.join(WORK_DIR, benchmark_dir,
+                                    'code-coverage-reports')
     if not os.path.isdir(coverage_reports):
-        continue
+      continue
 
     if project not in textcov_dict:
       textcov_dict[project] = []
     for sample in os.listdir(coverage_reports):
-        summary = os.path.join(coverage_reports, sample, 'textcov')
-        if not os.path.isdir(summary):
-          continue
+      summary = os.path.join(coverage_reports, sample, 'textcov')
+      if not os.path.isdir(summary):
+        continue
 
-        for textcov_file in os.listdir(summary):
-          if textcov_file.endswith('.covreport'):
-            with open(os.path.join(summary, textcov_file), 'rb') as f:
-              textcov_dict[project].append(textcov.Textcov.from_file(f))
-          elif textcov_file == 'all_cov.json':
-            with open(os.path.join(summary, textcov_file)) as f:
-              textcov_dict[project].append(textcov.Textcov.from_python_file(f))
-          elif textcov_file == 'jacoco.xml':
-            with open(os.path.join(summary, textcov_file)) as f:
-              textcov_dict[project].append(textcov.Textcov.from_jvm_file(f))
+      for textcov_file in os.listdir(summary):
+        if textcov_file.endswith('.covreport'):
+          with open(os.path.join(summary, textcov_file), 'rb') as f:
+            textcov_dict[project].append(textcov.Textcov.from_file(f))
+        elif textcov_file == 'all_cov.json':
+          with open(os.path.join(summary, textcov_file)) as f:
+            textcov_dict[project].append(textcov.Textcov.from_python_file(f))
+        elif textcov_file == 'jacoco.xml':
+          with open(os.path.join(summary, textcov_file)) as f:
+            textcov_dict[project].append(textcov.Textcov.from_jvm_file(f))
 
   if not textcov_dict:
     return {}
@@ -416,7 +416,7 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
     total_existing_lines = sum(lines)
     total_cov.subtract_covered_lines(existing_textcov)
 
-    total_lines = max(total_cov.total_lines, sum(lines))
+    total_lines = max(total_cov.total_lines, total_existing_lines)
 
     if total_lines:
       coverage_gain[project] = {

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -404,7 +404,8 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
     total_cov = textcov.Textcov()
     for cov in cov_list:
       total_cov.merge(cov)
-
+    total_cov.to_file(os.path.join('results', '%s-textcov_merged'%(project)))
+    existing_textcov = evaluator.load_existing_textcov(project)
     coverage_summary = evaluator.load_existing_coverage_summary(project)
 
     try:
@@ -412,6 +413,15 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
       lines = [f['summary']['lines']['count'] for f in coverage_summary_files]
     except (KeyError, TypeError):
       lines = []
+
+    total_existing_lines = sum(lines)
+    print('Project: %s'%(project))
+    print('- total assembled: %d'%(total_cov.covered_lines))
+    print('- Total summary: %d'%(total_existing_lines))
+    print('- Existing textcov: %d'%(existing_textcov.covered_lines))
+    total_cov.subtract_covered_lines(existing_textcov)
+    print("- Subtracted: %d"%(total_cov.covered_lines))
+
 
     total_lines = max(total_cov.total_lines, sum(lines))
 

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -369,7 +369,7 @@ def _process_total_coverage_gain() -> dict[str, dict[str, Any]]:
   # Load all the textcov dirs
   for benchmark_dir in os.listdir(WORK_DIR):
     try:
-      project = benchmark_dir.split('-')[1]
+      project = '-'.join(benchmark_dir.split('-')[1:-1])
     except:
       continue
 


### PR DESCRIPTION
- Adjusts coverage gain to show the actual coverage gain with respect to the existing coverage report. Previously the aggregated data simply showed the total coverage achieved.
- Makes the reading independent of the results array. The goal here is to make it asynchronously since we experienced issues where some benchmark runs would finish but not show up in the aggregate table.