### PR TITLE
benchmark-sets: add buggy benchmark

### DIFF
--- a/benchmark-sets/bug-fdp-consume-buffers/htslib.yaml
+++ b/benchmark-sets/bug-fdp-consume-buffers/htslib.yaml
@@ -1,0 +1,12 @@
+"functions":
+# https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-09-18-618-ochang-extra-large-all-oracles-many/sample/output-htslib-fai_path/03.html
+- "name": "fai_path"
+  "params":
+  - "name": "fa"
+    "type": "bool "
+  "return_type": "void"
+  "signature": "char * fai_path(const char *)"
+"language": "c++"
+"project": "htslib"
+"target_name": "hts_open_fuzzer"
+"target_path": "/src/htslib/test/fuzz/hts_open_fuzzer.c"

--- a/benchmark-sets/bug-fdp-consume-buffers/libxml2.yaml
+++ b/benchmark-sets/bug-fdp-consume-buffers/libxml2.yaml
@@ -1,0 +1,14 @@
+"functions":
+# https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-09-18-618-ochang-extra-large-all-oracles-many/sample/output-libxml2-htmlcreatefileparserctxt/02.html
+- "name": "htmlCreateFileParserCtxt"
+  "params":
+  - "name": "filename"
+    "type": "bool "
+  - "name": "encoding"
+    "type": "bool "
+  "return_type": "void"
+  "signature": "htmlParserCtxtPtr htmlCreateFileParserCtxt(const char *, const char *)"
+"language": "c++"
+"project": "libxml2"
+"target_name": "uri"
+"target_path": "/src/libxml2/fuzz/uri.c"

--- a/benchmark-sets/bug-fdp-consume-buffers/lodepng.yaml
+++ b/benchmark-sets/bug-fdp-consume-buffers/lodepng.yaml
@@ -1,0 +1,22 @@
+"functions":
+# https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-09-18-620-david-quick1234-lpng/sample/output-lodepng-_zn7lodepng6encodeernst3__16vectorihns0_9allocatoriheeeepkhjj16lodepngcolortypej/01.html
+- "name": "_ZN7lodepng6encodeERNSt3__16vectorIhNS0_9allocatorIhEEEEPKhjj16LodePNGColorTypej"
+  "params":
+  - "name": "out"
+    "type": "bool "
+  - "name": "in"
+    "type": "bool "
+  - "name": "w"
+    "type": "int"
+  - "name": "h"
+    "type": "int"
+  - "name": "colortype"
+    "type": "int"
+  - "name": "bitdepth"
+    "type": "int"
+  "return_type": "int"
+  "signature": "unsigned int lodepng::encode(vector<unsigned char, std::__1::allocator<unsigned char> > &, const unsigned char *, unsigned int, unsigned int, LodePNGColorType, unsigned int)"
+"language": "c++"
+"project": "lodepng"
+"target_name": "lodepng_fuzzer"
+"target_path": "/src/lodepng/lodepng_fuzzer.cpp"

--- a/benchmark-sets/bug-fdp-consume-buffers/opus.yaml
+++ b/benchmark-sets/bug-fdp-consume-buffers/opus.yaml
@@ -1,0 +1,25 @@
+"functions":
+# https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-09-18-618-ochang-extra-large-all-oracles-many/sample/output-opus-opus_decoder_get_nb_samples/02.html
+- "name": "opus_decoder_get_nb_samples"
+  "params":
+  - "name": "dec"
+    "type": "bool "
+  - "name": "packet"
+    "type": "bool "
+  - "name": "len"
+    "type": "int"
+  "return_type": "int"
+  "signature": "int opus_decoder_get_nb_samples(const OpusDecoder *, const unsigned char *, opus_int32)"
+# https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-09-09-589-ochang-large-exp-fuzz-keyword-and-easy-params/sample/output-opus-opus_packet_unpad/01.html
+- "name": "opus_packet_unpad"
+  "params":
+  - "name": "data"
+    "type": "bool "
+  - "name": "len"
+    "type": "int"
+  "return_type": "int"
+  "signature": "opus_int32 opus_packet_unpad(unsigned char *, opus_int32)"
+"language": "c++"
+"project": "opus"
+"target_name": "opus_repacketizer_fuzzer_floating"
+"target_path": "/src/opus/tests/opus_repacketizer_fuzzer.cc"

--- a/benchmark-sets/bug-fdp-consume-buffers/snappy.yaml
+++ b/benchmark-sets/bug-fdp-consume-buffers/snappy.yaml
@@ -1,0 +1,18 @@
+"functions":
+# https://llm-exp.oss-fuzz.com/Result-reports/ofg-pr/2024-09-18-618-ochang-extra-large-all-oracles-many/sample/output-snappy-_zn6snappy11rawcompressepkcmpcpm/02.html
+- "name": "_ZN6snappy11RawCompressEPKcmPcPm"
+  "params":
+  - "name": "input"
+    "type": "bool "
+  - "name": "input_length"
+    "type": "size_t"
+  - "name": "compressed"
+    "type": "bool "
+  - "name": "compressed_length"
+    "type": "bool "
+  "return_type": "void"
+  "signature": "void snappy::RawCompress(const char *, size_t, char *, size_t *)"
+"language": "c++"
+"project": "snappy"
+"target_name": "snappy_uncompress_fuzzer"
+"target_path": "/src/snappy/snappy_uncompress_fuzzer.cc"


### PR DESCRIPTION
This is useful for testing mititgations and also regressions. The benchmark has been annotated with links to the bugs.