### PR TITLE
Fix bug in triaging stack func

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -415,11 +415,10 @@ class BuilderRunner:
             SemanticCheckResult(SemanticCheckResult.FP_NEAR_INIT_CRASH, symptom,
                                 crash_stacks, crash_func))
 
-      # FP case 3: 1st func of the 1st thread stack is in fuzz target.
+      # FP case 3: no func in 1st thread stack belongs to testing proj.
       if len(crash_stacks) > 0:
         first_stack = crash_stacks[0]
-        # Check the first stack frame of the first stack only.
-        for stack_frame in first_stack[:1]:
+        for stack_frame in first_stack:
           if self._stack_func_is_of_testing_project(stack_frame):
             if 'LLVMFuzzerTestOneInput' in stack_frame:
               return ParseResult(


### PR DESCRIPTION
This PR fixes the bug in using heuristic methods to determine whether the fuzz driver has a problem. This sub-rule was originally intended to traverse each stack frame in the first crash stack until it finds a stack frame containing the "LLVMFuzzerTestOneInput" function, and other stack frames before this stack frame do not contain functions of testing proj. For the task of determining whether the function in the stack frame belongs to testing proj (i.e. function "_stack_func_is_of_testing_project"), we originally planned to let LLM make the judgment. Since adding this part of logic to the original framework makes the code redundant and complicated, we will implement this logic in the agent framework. The agent code will be submitted in the next few days.