### PR TITLE
cache: align names with oss-fuzz and specify entrypoint explicitly

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -632,6 +632,7 @@ class BuilderRunner:
     os.makedirs(workspacedir, exist_ok=True)
     if self.benchmark.cppify_headers:
       command.extend(['-e', 'JCC_CPPIFY_PROJECT_HEADERS=1'])
+    command.extend(['--entrypoint', '/bin/bash'])
     command.append(f'gcr.io/oss-fuzz/{generated_project}')
 
     pre_build_command = []
@@ -652,7 +653,7 @@ class BuilderRunner:
       post_build_command.extend(['&&', 'chmod', '777', '-R', '/out/*'])
 
     build_command = pre_build_command + ['compile'] + post_build_command
-    build_bash_command = ['/bin/bash', '-c', ' '.join(build_command)]
+    build_bash_command = ['-c', ' '.join(build_command)]
     command.extend(build_bash_command)
     with open(log_path, 'w+') as log_file:
       try:

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -189,13 +189,11 @@ def _get_project_cache_name(project: str) -> str:
 def _get_project_cache_image_name(project: str, sanitizer: str) -> str:
   """Gets name of cached Docker image for a project and a respective
   sanitizer."""
-  sanitizer_mapping = {
-    'address': 'asan',
-    'coverage': 'cov'
-  }
-  san_lookup  = sanitizer_mapping[sanitizer]
+  sanitizer_mapping = {'address': 'asan', 'coverage': 'cov'}
+  san_lookup = sanitizer_mapping[sanitizer]
   return ('us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/'
           f'{project}-ofg-cached-{san_lookup}')
+
 
 def _has_cache_build_script(project: str) -> bool:
   """Checks if a project has cached fuzzer build script."""

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -189,8 +189,13 @@ def _get_project_cache_name(project: str) -> str:
 def _get_project_cache_image_name(project: str, sanitizer: str) -> str:
   """Gets name of cached Docker image for a project and a respective
   sanitizer."""
-  return f'gcr.io/oss-fuzz/{project}_{sanitizer}_cache'
-
+  sanitizer_mapping = {
+    'address': 'asan',
+    'coverage': 'cov'
+  }
+  san_lookup  = sanitizer_mapping[sanitizer]
+  return ('us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/'
+          f'{project}-ofg-cached-{san_lookup}')
 
 def _has_cache_build_script(project: str) -> bool:
   """Checks if a project has cached fuzzer build script."""


### PR DESCRIPTION
Changes the of cached images to align with changes from https://github.com/google/oss-fuzz/pull/12549

These images were causing issues unless we specify the explicit entrypoint when running the harnesses, so adjusted that as well.