### PR TITLE
prompts: extend test-to-harness prompting

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1243,10 +1243,7 @@ class TestToHarnessConverter(PromptBuilder):
     self.benchmark = benchmark
 
     self.harness_source_code = introspector.query_introspector_source_code(
-      self.benchmark.project,
-      self.benchmark.target_path,
-      0, 10000
-    )
+        self.benchmark.project, self.benchmark.target_path, 0, 10000)
 
     # Load templates.
     self.priming_template_file = self._find_template(
@@ -1339,39 +1336,43 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
     else:
       included_header_files = self.extract_header_files(test_source_code)
       if included_header_files:
-        harness_included_header_files = ('The following header files are used in the '
+        harness_included_header_files = (
+            'The following header files are used in the '
             'test source code. Please make sure to include the same ones: '
-              f'{included_header_files}')
+            f'{included_header_files}')
       else:
         harness_included_header_files = ''
-      prompt_text = prompt_text.replace('{HARNESS_HEADERS}', harness_included_header_files)
+      prompt_text = prompt_text.replace('{HARNESS_HEADERS}',
+                                        harness_included_header_files)
 
       headers_to_include = \
         introspector.query_introspector_header_files(
         self.benchmark.project)
       if headers_to_include:
         header_inclusion_string = '<headers>\n'
-        for header in headers_to_include:
-          header_inclusion_string += f'<elem>{header}</elem>\n'
+        header_inclusion_string += ''.join(
+            f'<elem>{h}</elem>\n' for h in headers_to_include)
+        #for header in headers_to_include:
+        #  header_inclusion_string += f'<elem>{header}</elem>\n'
         header_inclusion_string += '</headers>\n'
-        header_inclusion_string = ('The following header files exist in the project source code. '
-          'If the harness you create needs any header files make sure they are in the list:\n'
-              f'{header_inclusion_string}')
+        header_inclusion_string = (
+            'The following header files exist in the project source code. '
+            'If the harness you create needs any header files make sure '
+            'they are in the list:\n'
+            f'{header_inclusion_string}')
       else:
         header_inclusion_string = ''
       prompt_text = prompt_text.replace('{HEADER_FILE_LANG}',
-                                      header_inclusion_string)
-
+                                        header_inclusion_string)
 
       prompt_text = prompt_text.replace('{PROG_LANG}', self.benchmark.language)
       #prompt_text = prompt_text.replace('{HEADER_FILE_LANG}', language_text)
 
-      harness_sample_text = """There are already harnesses targeting this project, and an example of
-this is:
-<code>
-%s
-</code>"""%(self.harness_source_code)
-      prompt_text = prompt_text.replace('{TARGET_SAMPLE_HARNESS}', harness_sample_text)
+      harness_sample_text = ('There are already harnesses targeting this '
+                             'project, and an example of this is:\n'
+                             f'<code>{self.harness_source_code}</code>')
+      prompt_text = prompt_text.replace('{TARGET_SAMPLE_HARNESS}',
+                                        harness_sample_text)
 
     self._prompt.add_priming(prompt_text)
     return self._prompt

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1352,8 +1352,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
         header_inclusion_string = '<headers>\n'
         header_inclusion_string += ''.join(
             f'<elem>{h}</elem>\n' for h in headers_to_include)
-        #for header in headers_to_include:
-        #  header_inclusion_string += f'<elem>{header}</elem>\n'
+
         header_inclusion_string += '</headers>\n'
         header_inclusion_string = (
             'The following header files exist in the project source code. '
@@ -1364,9 +1363,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
         header_inclusion_string = ''
       prompt_text = prompt_text.replace('{HEADER_FILE_LANG}',
                                         header_inclusion_string)
-
       prompt_text = prompt_text.replace('{PROG_LANG}', self.benchmark.language)
-      #prompt_text = prompt_text.replace('{HEADER_FILE_LANG}', language_text)
 
       harness_sample_text = ('There are already harnesses targeting this '
                              'project, and an example of this is:\n'

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1242,6 +1242,12 @@ class TestToHarnessConverter(PromptBuilder):
     self._template_dir = template_dir
     self.benchmark = benchmark
 
+    self.harness_source_code = introspector.query_introspector_source_code(
+      self.benchmark.project,
+      self.benchmark.target_path,
+      0, 10000
+    )
+
     # Load templates.
     self.priming_template_file = self._find_template(
         template_dir, 'test_to_harness_priming.txt')
@@ -1329,13 +1335,43 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
       classes = introspector.query_introspector_public_classes(
           self.benchmark.project)
       prompt_text = prompt_text.replace('{PUBLIC_CLASSES}', ','.join(classes))
+      prompt_text = prompt_text.replace('{TARGET_SAMPLE_HARNESS}', '')
     else:
       included_header_files = self.extract_header_files(test_source_code)
-      self.language_text = ('The following header files are used in the '
-                            'test. Please make sure to include the same ones: '
-                            f'{included_header_files}')
+      if included_header_files:
+        harness_included_header_files = ('The following header files are used in the '
+            'test source code. Please make sure to include the same ones: '
+              f'{included_header_files}')
+      else:
+        harness_included_header_files = ''
+      prompt_text = prompt_text.replace('{HARNESS_HEADERS}', harness_included_header_files)
+
+      headers_to_include = \
+        introspector.query_introspector_header_files(
+        self.benchmark.project)
+      if headers_to_include:
+        header_inclusion_string = '<headers>\n'
+        for header in headers_to_include:
+          header_inclusion_string += f'<elem>{header}</elem>\n'
+        header_inclusion_string += '</headers>\n'
+        header_inclusion_string = ('The following header files exist in the project source code. '
+          'If the harness you create needs any header files make sure they are in the list:\n'
+              f'{header_inclusion_string}')
+      else:
+        header_inclusion_string = ''
+      prompt_text = prompt_text.replace('{HEADER_FILE_LANG}',
+                                      header_inclusion_string)
+
+
       prompt_text = prompt_text.replace('{PROG_LANG}', self.benchmark.language)
-      prompt_text = prompt_text.replace('{HEADER_FILE_LANG}', language_text)
+      #prompt_text = prompt_text.replace('{HEADER_FILE_LANG}', language_text)
+
+      harness_sample_text = """There are already harnesses targeting this project, and an example of
+this is:
+<code>
+%s
+</code>"""%(self.harness_source_code)
+      prompt_text = prompt_text.replace('{TARGET_SAMPLE_HARNESS}', harness_sample_text)
 
     self._prompt.add_priming(prompt_text)
     return self._prompt

--- a/prompts/template_xml/test_to_harness_priming.txt
+++ b/prompts/template_xml/test_to_harness_priming.txt
@@ -17,4 +17,8 @@ Please write a fuzzing harness that is inspired by this unittest.
 
 {HEADER_FILE_LANG}
 
+{HARNESS_HEADERS}
+
+{TARGET_SAMPLE_HARNESS}
+
 In your response, include *only* the code for the harness, nothing more. You should wrap the code in <code></code> tags.


### PR DESCRIPTION
- Fixes some issues there were with header file inclusion in the prompt (it used the wrong variable, so the string was wrong)
- adds a sample harness from the actual repository
- adds a list of all headers
