### PR TITLE
fuzzer-build-scirpts: add duckdb and assimp

### DIFF
--- a/fuzzer_build_script/assimp
+++ b/fuzzer_build_script/assimp
@@ -1,0 +1,3 @@
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -std=c++11 -I$SRC/assimp/include \ 
+  fuzz/assimp_fuzzer.cc -o $OUT/assimp_fuzzer  \
+  ./lib/libassimp.a ./contrib/zlib/libzlibstatic.a

--- a/fuzzer_build_script/duckdb
+++ b/fuzzer_build_script/duckdb
@@ -1,0 +1,6 @@
+EXTENSION_LIBS=$(find ./build/relassert/extension/ -name "*.a")
+THIRD_PARTY_LIBS=$(find ./build/relassert/third_party/ -name "*.a")
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./test/ossfuzz/parse_fuzz_test.cpp \
+    -o $OUT/parse_fuzz_test -I./ -I./src/include \
+    ./build/relassert/src/libduckdb_static.a \
+    ${EXTENSION_LIBS} ${THIRD_PARTY_LIBS}


### PR DESCRIPTION
Duckdb takes a very long time (30 min or so), which makes it tricky to work with locally. This solves it.