### PR TITLE
Better format agent chat history in reports.

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -5,7 +5,7 @@ import re
 import subprocess as sp
 import time
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import logger
 import utils
@@ -41,6 +41,13 @@ class BaseAgent(ABC):
       if tool.name == tool_name:
         return tool
     return None
+
+  def chat_llm(self, round: int, client: Any, prompt: Prompt) -> str:
+    """Chat with LLM."""
+    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %2d>', round, prompt.get())
+    response = self.llm.chat_llm(client=client, prompt=prompt)
+    logger.info('<CHAT RESPONSE:ROUND %02d>%s</CHAT RESPONSE:ROUND %02d>', round, response)
+    return response
 
   def _parse_tag(self, response: str, tag: str) -> str:
     """Parses the XML-style tags from LLM response."""

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -44,9 +44,11 @@ class BaseAgent(ABC):
 
   def chat_llm(self, round: int, client: Any, prompt: Prompt) -> str:
     """Chat with LLM."""
-    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %2d>', round, prompt.get())
+    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %2d>', round,
+                prompt.get())
     response = self.llm.chat_llm(client=client, prompt=prompt)
-    logger.info('<CHAT RESPONSE:ROUND %02d>%s</CHAT RESPONSE:ROUND %02d>', round, response)
+    logger.info('<CHAT RESPONSE:ROUND %02d>%s</CHAT RESPONSE:ROUND %02d>',
+                round, response)
     return response
 
   def _parse_tag(self, response: str, tag: str) -> str:

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -42,13 +42,13 @@ class BaseAgent(ABC):
         return tool
     return None
 
-  def chat_llm(self, round: int, client: Any, prompt: Prompt) -> str:
+  def chat_llm(self, cur_round: int, client: Any, prompt: Prompt) -> str:
     """Chat with LLM."""
-    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %2d>', round,
-                prompt.get())
+    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %2d>', cur_round,
+                prompt.get(), cur_round)
     response = self.llm.chat_llm(client=client, prompt=prompt)
     logger.info('<CHAT RESPONSE:ROUND %02d>%s</CHAT RESPONSE:ROUND %02d>',
-                round, response)
+                cur_round, response, cur_round)
     return response
 
   def _parse_tag(self, response: str, tag: str) -> str:

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -44,8 +44,8 @@ class BaseAgent(ABC):
 
   def chat_llm(self, cur_round: int, client: Any, prompt: Prompt) -> str:
     """Chat with LLM."""
-    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %2d>', cur_round,
-                prompt.get(), cur_round)
+    logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %02d>',
+                cur_round, prompt.get(), cur_round)
     response = self.llm.chat_llm(client=client, prompt=prompt)
     logger.info('<CHAT RESPONSE:ROUND %02d>%s</CHAT RESPONSE:ROUND %02d>',
                 cur_round, response, cur_round)

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -213,9 +213,7 @@ class Prototyper(BaseAgent):
     try:
       client = self.llm.get_chat_client(model=self.llm.get_model())
       while prompt and cur_round < MAX_ROUND:
-        logger.info('ROUND %02d agent prompt: %s', cur_round, prompt.get())
-        response = self.llm.chat_llm(client=client, prompt=prompt)
-        logger.debug('ROUND %02d LLM response: %s', cur_round, response)
+        response = self.chat_llm(round, client=client, prompt=prompt)
         prompt = self._container_tool_reaction(cur_round, response,
                                                build_result)
         cur_round += 1

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -213,7 +213,7 @@ class Prototyper(BaseAgent):
     try:
       client = self.llm.get_chat_client(model=self.llm.get_model())
       while prompt and cur_round < MAX_ROUND:
-        response = self.chat_llm(round, client=client, prompt=prompt)
+        response = self.chat_llm(cur_round, client=client, prompt=prompt)
         prompt = self._container_tool_reaction(cur_round, response,
                                                build_result)
         cur_round += 1

--- a/common/cloud_builder.py
+++ b/common/cloud_builder.py
@@ -27,6 +27,7 @@ REGION = os.getenv('CLOUD_BUILD_LOCATION', 'us-west2')
 REGIONAL_CLIENT_OPTIONS = google.api_core.client_options.ClientOptions(
     api_endpoint=f'https://{REGION}-cloudbuild.googleapis.com/')
 _CHAT_HISTORY_PREFIX_PATTERN = r'^Step\s+#(\d+)\s+-\s+"agent-step":\s+'
+_CHAT_HISTORY_START_MARKER = '<CHAT PROMPT:ROUND 01>'
 
 
 class CloudBuilder:
@@ -226,7 +227,7 @@ class CloudBuilder:
     for log_line in full_log.splitlines():
       if not re.match(_CHAT_HISTORY_PREFIX_PATTERN, log_line):
         continue
-      if 'ROUND 01 agent prompt:' in log_line:
+      if _CHAT_HISTORY_START_MARKER in log_line:
         in_chat = True
       if in_chat:
         stripped_line = re.sub(_CHAT_HISTORY_PREFIX_PATTERN, '', log_line)

--- a/logger.py
+++ b/logger.py
@@ -141,6 +141,7 @@ def get_trial_logger(name: str = __name__,
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(level)
+    logger.propagate = False
 
   _trial_logger = CustomLoggerAdapter(logger, {'trial': trial})
   return _trial_logger

--- a/report/common.py
+++ b/report/common.py
@@ -129,6 +129,13 @@ class Triage:
   triager_prompt: str
 
 
+@dataclasses.dataclass
+class LogPart:
+  chat_prompt: bool = False
+  chat_response: bool = False
+  content: str = ''
+
+
 class FileSystem:
   """
   FileSystem provides a wrapper over standard library and GCS client and
@@ -267,6 +274,9 @@ class Results:
   def get_final_target_code(self, benchmark: str, sample: str) -> str:
     """Gets the targets of benchmark |benchmark| with sample ID |sample|."""
     targets_dir = os.path.join(self._results_dir, benchmark, 'fixed_targets')
+    # TODO(donggeliu): Make this consistent with agent output.
+    if not os.path.exists(targets_dir):
+      return ''
 
     for name in sorted(FileSystem(targets_dir).listdir()):
       path = os.path.join(targets_dir, name)
@@ -277,14 +287,14 @@ class Results:
         return code
     return ''
 
-  def get_logs(self, benchmark: str, sample: str) -> str:
+  def get_logs(self, benchmark: str, sample: str) -> list[LogPart]:
     status_dir = os.path.join(self._results_dir, benchmark, 'status')
     results_path = os.path.join(status_dir, sample, 'log.txt')
     if not FileSystem(results_path).exists():
-      return ''
+      return []
 
     with FileSystem(results_path).open() as f:
-      return f.read()
+      return _parse_log_parts(f.read())
 
   def get_run_logs(self, benchmark: str, sample: str) -> str:
     """Returns the content of the last run log."""
@@ -353,6 +363,10 @@ class Results:
     """Gets the targets of benchmark |benchmark| with sample ID |sample| from
     the OFG version 1 (single prompt)."""
     targets_dir = os.path.join(self._results_dir, benchmark, 'fixed_targets')
+    # TODO(donggeliu): Make this consistent with agent output.
+    if not os.path.exists(targets_dir):
+      return []
+
     targets = []
 
     for name in sorted(FileSystem(targets_dir).listdir()):
@@ -533,7 +547,11 @@ class Results:
       return True
 
     # Check sub-directories.
-    expected_dirs = ['raw_targets', 'status', 'fixed_targets']
+    # TODO(donggeliu): Make this consistent with agent output.
+    # We used to expect 'fixed_targets' and 'raw_targets' here, but the agent
+    # workflow doesn't populate them. As a result, these directories don't get
+    # uploaded to GCS.
+    expected_dirs = ['status']
     return all(
         FileSystem(os.path.join(self._results_dir, cur_dir,
                                 expected_dir)).isdir()
@@ -545,6 +563,10 @@ class Results:
     prompt)."""
     targets = []
     raw_targets_dir = os.path.join(self._results_dir, benchmark, 'raw_targets')
+    # TODO(donggeliu): Make this consistent with agent output.
+    if not os.path.exists(raw_targets_dir):
+      return []
+
     for filename in sorted(FileSystem(raw_targets_dir).listdir()):
       if os.path.splitext(filename)[1] in TARGET_EXTS:
         targets.append(os.path.join(raw_targets_dir, filename))
@@ -623,3 +645,53 @@ class Results:
           matched_prefix_signature = function_signature
 
     return matched_prefix_signature
+
+
+def _parse_log_parts(log: str) -> list[LogPart]:
+  """Parse log into parts."""
+  _CHAT_PROMPT_START_MARKER = re.compile(r'<CHAT PROMPT:ROUND\s+\d+>')
+  _CHAT_PROMPT_END_MARKER = re.compile(r'</CHAT PROMPT:ROUND\s+\d+>')
+  _CHAT_RESPONSE_START_MARKER = re.compile(r'<CHAT RESPONSE:ROUND\s+\d+>')
+  _CHAT_RESPONSE_END_MARKER = re.compile(r'</CHAT RESPONSE:ROUND\s+\d+>')
+  parts = []
+  idx = 0
+  next_marker = _CHAT_PROMPT_START_MARKER
+
+  while idx < len(log):
+    match = next_marker.search(log, idx)
+    if not match:
+      parts.append(LogPart(content=log[idx:]))
+      break
+
+    if match.start() > idx:
+      # Log content in between chat logs.
+      parts.append(LogPart(content=log[idx:match.start()]))
+
+    # Read up to the start of the corresponding end marker.
+    end_idx = len(log)
+
+    chat_prompt = False
+    chat_response = False
+    if next_marker == _CHAT_PROMPT_START_MARKER:
+      end = _CHAT_PROMPT_END_MARKER.search(log, match.end())
+      chat_prompt = True
+      next_marker = _CHAT_RESPONSE_START_MARKER
+    else:
+      assert next_marker == _CHAT_RESPONSE_START_MARKER
+      end = _CHAT_RESPONSE_END_MARKER.search(log, match.end())
+      chat_response = True
+      next_marker = _CHAT_PROMPT_START_MARKER
+
+    if end:
+      end_idx = end.start()
+      # Skip past the end tag.
+      idx = end.end()
+    else:
+      # No corresponding end tag, just read till the end of the log.
+      end_idx = len(log)
+      idx = end_idx
+
+    parts.append(LogPart(chat_prompt=chat_prompt, chat_response=chat_response, content=log[match.end():end_idx]))
+
+
+  return parts

--- a/report/common.py
+++ b/report/common.py
@@ -34,6 +34,11 @@ MAX_RUN_LOGS_LEN = 16 * 1024
 
 TARGET_EXTS = project_src.SEARCH_EXTS + ['.java', '.py'] + ['.fuzz_target']
 
+_CHAT_PROMPT_START_MARKER = re.compile(r'<CHAT PROMPT:ROUND\s+\d+>')
+_CHAT_PROMPT_END_MARKER = re.compile(r'</CHAT PROMPT:ROUND\s+\d+>')
+_CHAT_RESPONSE_START_MARKER = re.compile(r'<CHAT RESPONSE:ROUND\s+\d+>')
+_CHAT_RESPONSE_END_MARKER = re.compile(r'</CHAT RESPONSE:ROUND\s+\d+>')
+
 
 @dataclasses.dataclass
 class AccumulatedResult:
@@ -649,10 +654,6 @@ class Results:
 
 def _parse_log_parts(log: str) -> list[LogPart]:
   """Parse log into parts."""
-  _CHAT_PROMPT_START_MARKER = re.compile(r'<CHAT PROMPT:ROUND\s+\d+>')
-  _CHAT_PROMPT_END_MARKER = re.compile(r'</CHAT PROMPT:ROUND\s+\d+>')
-  _CHAT_RESPONSE_START_MARKER = re.compile(r'<CHAT RESPONSE:ROUND\s+\d+>')
-  _CHAT_RESPONSE_END_MARKER = re.compile(r'</CHAT RESPONSE:ROUND\s+\d+>')
   parts = []
   idx = 0
   next_marker = _CHAT_PROMPT_START_MARKER
@@ -691,7 +692,9 @@ def _parse_log_parts(log: str) -> list[LogPart]:
       end_idx = len(log)
       idx = end_idx
 
-    parts.append(LogPart(chat_prompt=chat_prompt, chat_response=chat_response, content=log[match.end():end_idx]))
-
+    parts.append(
+        LogPart(chat_prompt=chat_prompt,
+                chat_response=chat_response,
+                content=log[match.end():end_idx]))
 
   return parts

--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -53,6 +53,19 @@ th {
 tbody tr:nth-child(odd) {
     background-color: #f4f5ff;
 }
+
+.chat_prompt {
+    background-color: #fff7f2;
+    max-width: 50%;
+    overflow: scroll;
+}
+
+.chat_response {
+    background-color: #fcfff2;
+    max-width: 50%;
+    overflow: scroll;
+    margin-left: auto;
+}
 </style>
 <body>
     LLM: {{ model }}

--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -58,9 +58,11 @@ Crash reason: {{ sample.result.semantic_error }}
 {% endfor %}
 
 <h2>Logs</h2>
-<pre>
-{{ logs }}
+{% for part in logs %}
+<pre {% if part.chat_prompt %}class="chat_prompt"{% elif part.chat_response %}class="chat_response"{% endif %}>
+{{ part.content }}
 </pre>
+{% endfor %}
 
 <h2>Run logs</h2>
 <pre>


### PR DESCRIPTION
To make the LLM interactions clearer. Prompts are coloured with a slight pink background, and responses are moved to the right side with a slight green background. 

Part of #676.

Also stop propagating chat logging to the root logger (to avoid duplicate output). 

This PR also adds some workarounds for when `fixed_targets`, `raw_targets` don't exist in the results dir for agent runs. This can happen when we download a results dir from GCS, because empty dirs are not uploaded. 

Example: 

![image](https://github.com/user-attachments/assets/6c04e037-5275-4ff3-90a9-ebbf99098fe9)