### PR TITLE
Update ofg cached image name.

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -189,10 +189,8 @@ def _get_project_cache_name(project: str) -> str:
 def _get_project_cache_image_name(project: str, sanitizer: str) -> str:
   """Gets name of cached Docker image for a project and a respective
   sanitizer."""
-  sanitizer_mapping = {'address': 'asan', 'coverage': 'cov'}
-  san_lookup = sanitizer_mapping[sanitizer]
   return ('us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/'
-          f'{project}-ofg-cached-{san_lookup}')
+          f'{project}-ofg-cached-{sanitizer}')
 
 
 def _has_cache_build_script(project: str) -> bool:


### PR DESCRIPTION
To match https://github.com/google/oss-fuzz/pull/12676.

This gets rid of an unnecessary inconsistency.