### PR TITLE
fix: consider fuzzing successful if semantic check passes

### DIFF
--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -516,7 +516,7 @@ class BuilderRunner:
         run_result.crashes, run_result.crash_info, \
           run_result.semantic_check = \
             self._parse_libfuzzer_logs(f, project_name, flag)
-      run_result.succeeded = not run_result.semantic_check.has_err
+      run_result.succeeded = run_result.semantic_check.has_err
 
     return build_result, run_result
 


### PR DESCRIPTION
**Desc**

A fuzzing result should be considered successful if the semantic check yields an error type other than SemanticCheckResult.NOT_APPLICABLE or SemanticCheckResult.NO_SEMANTIC_ERR (see [fuzz_target_error.py#L163](https://github.com/google/oss-fuzz-gen/blob/main/experiment/fuzz_target_error.py#L163)).

Currently, in [builder_runner.py#L519](https://github.com/google/oss-fuzz-gen/blob/main/experiment/builder_runner.py#L519), the code incorrectly marks the run as failed when the semantic result has the desired error type, preventing an early stop on successful fuzzing - [evaluator.py#L391](https://github.com/google/oss-fuzz-gen/blob/main/experiment/evaluator.py#L391)