### PR TITLE
Fix Dockerfile rewrite for using cached builds.

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -68,7 +68,7 @@ def _set_temp_oss_fuzz_repo():
 def _clone_oss_fuzz_repo():
   """Clones OSS-Fuzz to |OSS_FUZZ_DIR|."""
   clone_command = [
-      'git', 'clone', '-b', 'add-arg-cloud-build', 'https://github.com/google/oss-fuzz', '--depth', '1',
+      'git', 'clone', 'https://github.com/google/oss-fuzz', '--depth', '1',
       OSS_FUZZ_DIR
   ]
   proc = sp.Popen(clone_command,

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -68,7 +68,7 @@ def _set_temp_oss_fuzz_repo():
 def _clone_oss_fuzz_repo():
   """Clones OSS-Fuzz to |OSS_FUZZ_DIR|."""
   clone_command = [
-      'git', 'clone', 'https://github.com/google/oss-fuzz', '--depth', '1',
+      'git', 'clone', '-b', 'add-arg-cloud-build', 'https://github.com/google/oss-fuzz', '--depth', '1',
       OSS_FUZZ_DIR
   ]
   proc = sp.Popen(clone_command,
@@ -315,16 +315,23 @@ def rewrite_project_to_cached_project_chronos(generated_project) -> None:
 
   # Now comment out everything except the first FROM and the last COPY that
   # was added earlier in the OFG process.
+  arg_line = -1
+  workdir_line = -1
   from_line = -1
   copy_fuzzer_line = -1
 
   for line_idx, line in enumerate(docker_content.split('\n')):
+    if line.startswith('WORKDIR') and workdir_line == -1:
+      # OSS-Fuzz infra relies on parsing WORKDIR.
+      workdir_line = line_idx
+    if line.startswith('ARG') and arg_line == -1:
+      arg_line = line_idx
     if line.startswith('FROM') and from_line == -1:
       from_line = line_idx
     if line.startswith('COPY'):
       copy_fuzzer_line = line_idx
 
-  lines_to_keep = {from_line, copy_fuzzer_line}
+  lines_to_keep = {arg_line, from_line, copy_fuzzer_line, workdir_line}
   new_content = ''
   for line_idx, line in enumerate(docker_content.split('\n')):
     if line_idx not in lines_to_keep:


### PR DESCRIPTION
We weren't keeping the ARG, WORKDIR lines.

ARG is necessary for obvious reasons since we are relying on injecting
the base image at runtime.

WORKDIR is required for: https://github.com/google/oss-fuzz/blob/edfa6730fa9f1dca77dd27c0b3a643171e082950/infra/build/functions/build_project.py#L229