### PR TITLE
Update large-pr-exp.yaml

### DIFF
--- a/ci/k8s/large-pr-exp.yaml
+++ b/ci/k8s/large-pr-exp.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     customLabel: "myCustomValue"
 spec:
-  activeDeadlineSeconds: 108000  # 30 hours. We don't want large experiments to run indefinitely and eat up resources.
+  activeDeadlineSeconds: 604800  # 7 days. We don't want large experiments to run indefinitely and eat up resources.
   template:
     spec:
       containers:
@@ -31,6 +31,8 @@ spec:
         # For benchmark sets that need more disk, increase the results volume
         # size too.
         command: ["/bin/bash", "report/docker_run.sh", "${GKE_EXP_BENCHMARK}", "${GKE_EXP_NAME}", "${GKE_EXP_FUZZING_TIMEOUT}", "ofg-pr", "${GKE_EXP_LLM}", "${GKE_EXP_DELAY}", "${GKE_EXP_LOCAL_INTROSPECTOR}", "${GKE_EXP_NUM_SAMPLES}", "${GKE_EXP_LLM_FIX_LIMIT}", "${GKE_EXP_VARY_TEMPERATURE}", "${GKE_EXP_AGENT}"]
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: ${GKE_EXP_REQ_CPU}


### PR DESCRIPTION
- Increase deadline
- Set `privileged: true` so we can gdb on live instances to debug issues.