### PR TITLE
Agent prioritize bash

### DIFF
--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -3,6 +3,7 @@ Use it as a usual module locally, or as script in cloud builds.
 """
 import subprocess as sp
 import time
+from datetime import timedelta
 from typing import Optional
 
 import logger
@@ -136,7 +137,8 @@ class Prototyper(BaseAgent):
     start_time = time.time()
     compile_process = compilation_tool.compile()
     end_time = time.time()
-    logger.debug('ROUND %02d compilation time: %s', end_time - start_time)
+    logger.debug('ROUND %02d compilation time: %s', cur_round,
+                 timedelta(seconds=end_time - start_time))
     compile_succeed = compile_process.returncode == 0
     logger.debug('ROUND %02d Fuzz target compiles: %s', cur_round,
                  compile_succeed)

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -2,6 +2,7 @@
 Use it as a usual module locally, or as script in cloud builds.
 """
 import subprocess as sp
+import time
 from typing import Optional
 
 import logger
@@ -132,9 +133,12 @@ class Prototyper(BaseAgent):
 
     # Recompile.
     logger.info('===== ROUND %02d Recompile =====', cur_round)
+    start_time = time.time()
     compile_process = compilation_tool.compile()
+    end_time = time.time()
+    logger.debug('ROUND %02d compilation time: %s', end_time - start_time)
     compile_succeed = compile_process.returncode == 0
-    logger.debug('ROUND %02d Fuzz target compile Succeessfully: %s', cur_round,
+    logger.debug('ROUND %02d Fuzz target compiles: %s', cur_round,
                  compile_succeed)
 
     # Double-check binary.

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -84,14 +84,14 @@ class Prototyper(BaseAgent):
 
     logger.info('First compile fuzz target without modifying build script.')
     build_result.build_script_source = ''
-    self._validate_fuzz_target_and_build_script_via_recompile(
+    self._validate_fuzz_target_and_build_script_via_compile(
         cur_round, build_result)
 
     if not build_result.success and build_script_source:
       logger.info('Then compile fuzz target with modified build script.')
       build_result.build_script_source = build_script_source
-      self._validate_fuzz_target_and_build_script_via_recompile(
-          cur_round, build_result, use_recompile=False)
+      self._validate_fuzz_target_and_build_script_via_compile(
+          cur_round, build_result)
 
   def _validate_fuzz_target_references_function(
       self, compilation_tool: ProjectContainerTool, benchmark: Benchmark,
@@ -110,11 +110,8 @@ class Prototyper(BaseAgent):
                    cur_round)
     return function_referenced
 
-  def _validate_fuzz_target_and_build_script_via_recompile(
-      self,
-      cur_round: int,
-      build_result: BuildResult,
-      use_recompile: bool = True) -> None:
+  def _validate_fuzz_target_and_build_script_via_compile(
+      self, cur_round: int, build_result: BuildResult) -> None:
     """Validates the new fuzz target and build script by recompiling them."""
     benchmark = build_result.benchmark
     compilation_tool = ProjectContainerTool(benchmark=benchmark)
@@ -135,7 +132,7 @@ class Prototyper(BaseAgent):
 
     # Recompile.
     logger.info('===== ROUND %02d Recompile =====', cur_round)
-    compile_process = compilation_tool.compile(use_recompile=use_recompile)
+    compile_process = compilation_tool.compile()
     compile_succeed = compile_process.returncode == 0
     logger.debug('ROUND %02d Fuzz target compile Succeessfully: %s', cur_round,
                  compile_succeed)

--- a/tool/container_tool.py
+++ b/tool/container_tool.py
@@ -96,18 +96,8 @@ class ProjectContainerTool(BaseTool):
     process.args = command
     return process
 
-  def compile(self,
-              use_recompile: bool = True,
-              extra_commands: str = '') -> sp.CompletedProcess:
-    """Compiles or recompiles the fuzz target."""
-    if use_recompile:
-      logger.info('Will attempt to use recompile')
-      self.execute(
-          '[ -f /usr/local/bin/recompile ] && echo "Will use recompile" '
-          '&& mv /usr/local/bin/recompile /usr/local/bin/compile')
-    else:
-      logger.info('Will use the original compile')
-
+  def compile(self, extra_commands: str = '') -> sp.CompletedProcess:
+    """Compiles the fuzz target."""
     command = 'compile > /dev/null' + extra_commands
     return self.execute(command)
 


### PR DESCRIPTION
Previously, when the LLM response included both bash commands and a conclusion, we ignored the bash command and compiled the fuzz target in the conclusion alone. This approach is suboptimal, as conclusions may be premature, and the bash command often provides useful context to refine them.

To improve accuracy, we should prioritize the bash command when both are present in a response.

A more robust solution would involve structuring tasks to prevent mixed responses (e.g., using task-focused agents). But until then, prioritizing bash commands in mixed responses provides a fallback/default solution.