### PR TITLE
Remove `northamerica-northeast1` from `Vertex AI` regions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -44,7 +44,7 @@ gcloud auth application-default set-quota-project <your-project>
 You'll also need to specify the GCP projects and locations where you have Vertex AI quota (comma delimited):
 ```bash
 export CLOUD_ML_PROJECT_ID=<gcp-project-id>
-export VERTEX_AI_LOCATIONS=us-west1,us-west4,us-east4,us-central1,northamerica-northeast1
+export VERTEX_AI_LOCATIONS=us-west1,us-west4,us-east4,us-central1
 ```
 
 #### OpenAI

--- a/ci/k8s/large-pr-exp.yaml
+++ b/ci/k8s/large-pr-exp.yaml
@@ -47,7 +47,7 @@ spec:
         - name: LLM_NUM_EVA
           value: '10'
         - name: VERTEX_AI_LOCATIONS
-          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,northamerica-northeast1,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
+          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
         - name: CLOUD_BUILD_LOCATION
           value: 'us-west1'
         - name: GCB_BUILDPOOL_NAME

--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -48,7 +48,7 @@ spec:
         - name: LLM_NUM_EVA
           value: '10'
         - name: VERTEX_AI_LOCATIONS
-          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,northamerica-northeast1,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
+          value: 'asia-east1,asia-east2,asia-northeast1,asia-northeast3,asia-south1,asia-southeast1,australia-southeast1,europe-central2,europe-north1,europe-southwest1,europe-west1,europe-west2,europe-west3,europe-west4,europe-west6,europe-west8,europe-west9,southamerica-east1,us-central1,us-east1,us-east4,us-east5,us-south1,us-west1,us-west4'
         - name: CLOUD_BUILD_LOCATION
           value: 'us-west2'
         - name: GCB_BUILDPOOL_NAME


### PR DESCRIPTION
... because it does not support long context (> 32K). https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#canada_1