### PR TITLE
Build agent image in cloud build

### DIFF
--- a/common/cloud_builder.py
+++ b/common/cloud_builder.py
@@ -132,7 +132,7 @@ class CloudBuilder:
                 'dir': '/workspace',
                 'args': ['clone', '--depth=1', OF_REPO, 'ofg/oss-fuzz']
             },
-            # Step 3: Run the Python script with the dill files
+            # Step 3: Run the Python script with the dill files.
             {
                 'name': 'gcr.io/cloud-builders/docker',
                 'args': [

--- a/common/cloud_builder.py
+++ b/common/cloud_builder.py
@@ -134,6 +134,15 @@ class CloudBuilder:
             },
             # Step 3: Run the Python script with the dill files
             {
+                'name': 'gcr.io/cloud-builders/docker',
+                'args': [
+                    'build', '.', '-t',
+                    ('us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/'
+                     'agent-image'), '-f', 'Dockerfile.cloudbuild-agent'
+                ],
+                'dir': '/workspace/ofg/',
+            },
+            {
                 'id':
                     'agent-step',
                 'name':


### PR DESCRIPTION
Previously, cloud build pulls an agent image that I manually uploaded to artifact registry.
However, this will fail when we update dependencies (e.g., upgrade python packages) in PRs.

This PR builds the image with the PR source code so that its agent image is always up-to-date.