### PR TITLE
[JVM] Fix mismatch langauge for jvm projects

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -463,7 +463,12 @@ def query_introspector_language_stats() -> dict:
   """Queries introspector for language stats"""
 
   resp = _query_introspector(INTROSPECTOR_LANGUAGE_STATS, {})
-  return _get_data(resp, 'stats', {})
+  result = _get_data(resp, 'stats', {})
+  if result:
+    # FI returns java as the key for jvm projects
+    result = {'jvm' if key == 'java' else key: value for key, value in result.items()}
+
+  return result
 
 
 def query_introspector_type_info(project: str, type_name: str) -> list[dict]:

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -466,7 +466,9 @@ def query_introspector_language_stats() -> dict:
   result = _get_data(resp, 'stats', {})
   if result:
     # FI returns java as the key for jvm projects
-    result = {'jvm' if key == 'java' else key: value for key, value in result.items()}
+    result = {
+        'jvm' if key == 'java' else key: value for key, value in result.items()
+    }
 
   return result
 


### PR DESCRIPTION
This PR fixes a bug in an introspector call to /api/database-language-stats. The introspector use the key java instead of jvm for java projects.