### PR TITLE
[jvm] Include other import statements for test to harness approach

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1334,7 +1334,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
     with open(template_file) as file:
       return file.read()
 
-  def _extract_jvm_imports(self, src: str, cls: list[str]) -> tuple[list[str], list[str]]:
+  def _extract_jvm_imports(self, src: str,
+                           cls: list[str]) -> tuple[list[str], list[str]]:
     """Extract and interpret import statements from java source."""
 
     # Extract import statements
@@ -1359,7 +1360,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
 
     results = set()
     others = set()
-    for full_import, is_static, cls_name in imports:
+    for full_import, _, cls_name in imports:
       found = False
       if '*' in cls_name:
         # Resolve generic import
@@ -1371,7 +1372,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
               found = True
 
         if not found:
-            others.add(full_import)
+          others.add(full_import)
       else:
         if cls_name in cls:
           results.add(full_import)
@@ -1434,7 +1435,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
                                         harness_sample_text)
 
       # Extract import list
-      import_list, other_import_list = self._extract_jvm_imports(test_source_code, classes)
+      import_list, other_import_list = self._extract_jvm_imports(
+          test_source_code, classes)
       prompt_text = prompt_text.replace('{IMPORT_STATEMENTS}',
                                         '\n'.join(import_list))
       prompt_text = prompt_text.replace('{OTHER_IMPORT_STATEMENTS}',

--- a/prompts/template_xml/jvm_requirement_test_to_harness.txt
+++ b/prompts/template_xml/jvm_requirement_test_to_harness.txt
@@ -48,8 +48,12 @@ Here is a comma-separated list of all publicly accessible classes in this projec
 {PUBLIC_CLASSES}
 </item>
 <item>
-Here is a list of import statements that you many needed for create the harness. If use use any classes that is not from java.lang package, you must import it by referencing these import statements below.
+Here is a list of import statements that you many needed for create the harness. If use use any classes that is not from java.lang package, you must import it by referencing these import statements below. You may need to add other import stataments from other classes that does not covered by these import statements here.
 {IMPORT_STATEMENTS}
+</item>
+<item>
+Here is a list of other import statements that you may need to make the generated harness compiles. Please only add them if necessary.
+{OTHER_IMPORT_STATEMENTS}
 </item>
 <item>
 You MUST ONLY use any of the following methods from the FuzzedDataProvider of the Jazzer framework for generating random data for fuzzing.


### PR DESCRIPTION
This PR fixes the prompts for jvm test-to-harness approach to add in other import statement in the prompts for reference. This help LLM to include more necessary import statements to the generated harness.