### PR TITLE
[JVM] Add logic to add suggested targets

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1372,6 +1372,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
 
     return list(sorted(results))
 
+  def _get_jvm_public_candidates(self, proj: str) -> list[str]:
+    """Helper function to retrieve list of public candidates for jvm."""
+    method_set = set()
+    methods = introspector.query_introspector_jvm_all_public_candidates(proj)
+    for method in methods:
+      if "<init>" not in method['function_name']:
+        method_set.add(method['function_name'])
+    return list(method_set)
+
   def extract_header_files(self, text):
     # Include any weird macros defined that does not have any values. This
     # was found empirically to be valuable.
@@ -1424,6 +1433,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {}
                              f'<code>\n{self.harness_source_code}\n</code>')
       prompt_text = prompt_text.replace('{TARGET_SAMPLE_HARNESS}',
                                         harness_sample_text)
+
+      # Extract must included methods
+      methods = self._get_jvm_public_candidates(self.benchmark.project)
+      prompt_text = prompt_text.replace('{PUBLIC_METHODS}', ','.join(methods))
 
       # Extract import list
       import_list = self._extract_jvm_imports(test_source_code, classes)

--- a/prompts/template_xml/jvm_requirement_test_to_harness.txt
+++ b/prompts/template_xml/jvm_requirement_test_to_harness.txt
@@ -15,6 +15,11 @@ Here is a list of requirements that you MUST follow.
 <item>Please use {HARNESS_NAME} as the Java class name.</item>
 <item>You MUST invoke the close method of any resource class objects that implements the java.lang.AutoCloseable interface in the finally block after the target method is invoked.</item>
 <item>You MUST use similar approach as the examples and tests to catch exceptions.</item>
+<item>
+Here is a comma separated list of public project methods. You must include the invocation of at least one of them in the generated harness. Each of the method signature follows the format of <code>[Full qualified name of the class].method_name(method_arguments)</code>.
+{PUBLIC_METHODS}
+</item>
+<item>
 <item>Do not create new variables with the same names as existing variables.
 WRONG:
 <code>


### PR DESCRIPTION
This PR fixes the logic for jvm test-to-harness to provide references of some methods suggestions for LLM.