### PR TITLE
[JVM] Add retry logic for no coverage gain

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -343,8 +343,9 @@ def query_introspector_public_classes(project: str) -> list[str]:
   return _get_data(resp, 'classes', [])
 
 
-def query_introspector_source_code(project: str, filepath: str, begin_line: int,
-                                   end_line: int) -> str:
+def query_introspector_source_code(project: str, filepath: str,
+                                   begin_line: int = 0,
+                                   end_line: int = 10000) -> str:
   """Queries FuzzIntrospector API for source code of a
     file |filepath| between |begin_line| and |end_line|."""
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -343,7 +343,8 @@ def query_introspector_public_classes(project: str) -> list[str]:
   return _get_data(resp, 'classes', [])
 
 
-def query_introspector_source_code(project: str, filepath: str,
+def query_introspector_source_code(project: str,
+                                   filepath: str,
                                    begin_line: int = 0,
                                    end_line: int = 10000) -> str:
   """Queries FuzzIntrospector API for source code of a

--- a/llm_toolkit/code_fixer.py
+++ b/llm_toolkit/code_fixer.py
@@ -368,7 +368,7 @@ def group_error_messages(error_lines: list[str]) -> list[str]:
 
 def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
             llm_fix_id: int, error_desc: Optional[str], errors: list[str],
-            fixer_model_name: str, language: str) -> None:
+            fixer_model_name: str, language: str, jvm_cov_fix: bool) -> None:
   """Reads and fixes |target_path| in place with LLM based on |error_log|."""
   fuzz_target_source_code = parser.parse_code(target_path)
 
@@ -385,6 +385,7 @@ def llm_fix(ai_binary: str, target_path: str, benchmark: benchmarklib.Benchmark,
                 prompt_path,
                 response_dir,
                 language,
+                jvm_cov_fix,
                 fixer_model_name,
                 temperature=0.5 - llm_fix_id * 0.04)
 
@@ -427,6 +428,7 @@ def apply_llm_fix(ai_binary: str,
                   prompt_path: str,
                   response_dir: str,
                   language: str,
+                  jvm_cov_fix: bool,
                   fixer_model_name: str = models.DefaultModel.name,
                   temperature: float = 0.4):
   """Queries LLM to fix the code."""
@@ -440,7 +442,7 @@ def apply_llm_fix(ai_binary: str,
   if language == 'jvm':
     builder = prompt_builder.JvmErrorFixingBuilder(fixer_model, benchmark,
                                                    fuzz_target_source_code,
-                                                   errors)
+                                                   errors, jvm_cov_fix)
     prompt = builder.build([], None, None)
     prompt.save(prompt_path)
   else:

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -1073,11 +1073,11 @@ class JvmErrorFixingBuilder(PromptBuilder):
 
     # Load templates.
     if self.jvm_cov_fix:
-        self.template_file = self._find_template(
-            template_dir, 'jvm_requirement_coverage_fixing.txt')
+      self.template_file = self._find_template(
+          template_dir, 'jvm_requirement_coverage_fixing.txt')
     else:
-        self.template_file = self._find_template(
-            template_dir, 'jvm_requirement_error_fixing.txt')
+      self.template_file = self._find_template(
+          template_dir, 'jvm_requirement_error_fixing.txt')
 
   def _find_template(self, template_dir: str, template_name: str) -> str:
     """Finds template file based on |template_dir|."""
@@ -1105,6 +1105,8 @@ class JvmErrorFixingBuilder(PromptBuilder):
     with open(self.template_file, 'r') as f:
       prompt_text = f.read()
 
+    proj = self.benchmark.project
+
     # Format the repository
     target_repository = oss_fuzz_checkout.get_project_repository(
         self.benchmark.project)
@@ -1122,13 +1124,13 @@ class JvmErrorFixingBuilder(PromptBuilder):
       harnesses = introspector.query_introspector_for_harness_intrinsics(proj)
       for pair in harnesses:
         path = pair.get('source', '')
-        if source_path:
+        if path:
           source = introspector.query_introspector_source_code(proj, path)
           if source:
             source_list.append(source)
 
       prompt_text = prompt_text.replace('{EXISTING_HARNESS}',
-                                          '\n---\n'.join(source_list))
+                                        '\n---\n'.join(source_list))
 
       # Add all public candidates to prompt
       methods = introspector.query_introspector_jvm_all_public_candidates(proj)

--- a/prompts/template_xml/jvm_requirement_coverage_fixing.txt
+++ b/prompts/template_xml/jvm_requirement_coverage_fixing.txt
@@ -1,23 +1,24 @@
-I'm a security engineer looking to write a good fuzzing harnesses. I got some compilation errors and want you to help fix them.
+I'm a security engineer looking to write good fuzzing harnesses. I want you help me improve my fuzzing harness so it could covers more part of the code.
 
 The target library is {TARGET_REPO}.
 
-The target project is written in the Java programming language.
+The target project is implemented in the Java programming language; therefore, the harness should also be written in Java.  
+The fuzzing harness must be executable within the Jazzer fuzzing framework.  
 
-This is a Java programming language so the harness should be written in Java.
-The fuzzing harness should be executable under the Jazzer fuzzing framework.
+Below is the source code of the target fuzzing harness that I would like to improve:  
+<code>  
+{GENERATED_HARNESS}  
+</code>  
 
-I have already done the conversion and here is my harness code.
-<code>
-{GENERATED_HARNESS}
-</code>
+For reference, the source code for all existing harnesses of the project is provided below, separated by `---`:
+<code>  
+{EXISTING_HARNESS}  
+</code>  
 
-And I got the following errors from the compiler. Please help me fix them while keeping all the format and other logics unchanged.
-<error>
-{ERRORS}
-</error>
+Additionally, a list of all public methods and constructors of the project is included for your reference, you should try to expand the fuzzing harness that calls these targets to improve the overall fuzzing coverage:
+{PUBLIC_METHODS}
 
-If missing imports for classes used are found but failed to locate the correct import statements, try removing the use of that class.
+Your task is to improve the target fuzzing harness provided above to increase code coverage for additional parts of the project that are not covered by the existing fuzzing harnesses. Please ensure that the changes made are minimal.
 In your response, include ONLY the code for the harness, nothing more. You should wrap the code in <code></code> tags.
 
 Here is an additional list of requirements that you MUST follow.

--- a/prompts/template_xml/jvm_requirement_coverage_fixing.txt
+++ b/prompts/template_xml/jvm_requirement_coverage_fixing.txt
@@ -2,18 +2,18 @@ I'm a security engineer looking to write good fuzzing harnesses. I want you help
 
 The target library is {TARGET_REPO}.
 
-The target project is implemented in the Java programming language; therefore, the harness should also be written in Java.  
-The fuzzing harness must be executable within the Jazzer fuzzing framework.  
+The target project is implemented in the Java programming language; therefore, the harness should also be written in Java.
+The fuzzing harness must be executable within the Jazzer fuzzing framework.
 
-Below is the source code of the target fuzzing harness that I would like to improve:  
-<code>  
-{GENERATED_HARNESS}  
-</code>  
+Below is the source code of the target fuzzing harness that I would like to improve:
+<code>
+{GENERATED_HARNESS}
+</code>
 
 For reference, the source code for all existing harnesses of the project is provided below, separated by `---`:
-<code>  
-{EXISTING_HARNESS}  
-</code>  
+<code>
+{EXISTING_HARNESS}
+</code>
 
 Additionally, a list of all public methods and constructors of the project is included for your reference, you should try to expand the fuzzing harness that calls these targets to improve the overall fuzzing coverage:
 {PUBLIC_METHODS}


### PR DESCRIPTION
This PR relocate the calculation of coverage total and coverage diff into the checking and retry loop. This fixes can then use the lively caluclated coverage diff to determine if the successfully build and run harness increase the project coverage or not. If it does not increase the project coverage, use the new retry logic prompts to ask LLM to help fixing the harness. The fixing of errors in generated harness as well as harness with no coverage increase are count together. After this fix, it increase the rate of successfully build and run for generated harness and make sure more of them could have help improveing  project coverage.

*Remark, this coverage feedback approach is currently only work exclusively for JVM projects.*
