### PR TITLE
Fix fuzz target source path and binary name in gnutls.yaml

### DIFF
--- a/benchmark-sets/all/gnutls.yaml
+++ b/benchmark-sets/all/gnutls.yaml
@@ -49,5 +49,5 @@
   "signature": "ssize_t gnutls_record_recv_seq(gnutls_session_t, void *, size_t, unsigned char *)"
 "language": "c++"
 "project": "gnutls"
-"target_name": "libtasn1_gnutls_der_fuzzer"
-"target_path": "/src/libtasn1/fuzz/libtasn1_gnutls_der_fuzzer.c"
+"target_name": "gnutls_private_key_parser_fuzzer"
+"target_path": "/src/gnutls/fuzz/gnutls_private_key_parser_fuzzer.c"


### PR DESCRIPTION
This is a tricky case because the old target path (`/src/libtasn1/fuzz/libtasn1_gnutls_der_fuzzer.c`) is indeed a fuzz target, but it was not used.

I found the new one and its corresponding binary with @jonathanmetzman's trick:
1. Add a magic string (`const volatile char* build_id = "BUILD_TRACKER_my_unique_identifier_123";`) to the fuzz target before compilation.
2. Find the binary with the string (`find /out -type f -executable -print0 | xargs -0 sh -c 'for file do if strings "$file" | grep "BUILD_TRACKER_" >/dev/null; then basename "$file"; fi; done'`) after compilation.

I reckon we can do this systematically and automatically:
1. Inject unique magic strings (e.g., `BUILD_TRACKER_my_unique_identifier_1`, `BUILD_TRACKER_my_unique_identifier_2`) to all c/c++ files containing `LLVMFuzzerTestOneInput`.
2. Match binaries in /out against fuzz target source files based on the string.