### PR TITLE
Fix fuzz target source path and binary name in hostap.yaml

### DIFF
--- a/benchmark-sets/all/hostap.yaml
+++ b/benchmark-sets/all/hostap.yaml
@@ -35,5 +35,5 @@
   "signature": "int wpa_supplicant_run(struct wpa_global *)"
 "language": "c++"
 "project": "hostap"
-"target_name": "fuzzer-common"
-"target_path": "/src/hostap/tests/fuzzing/fuzzer-common.c"
+"target_name": "json"
+"target_path": "/src/hostap/tests/fuzzing/json/json.c"


### PR DESCRIPTION
Similar to #750, this is another tricky case where the old target path is indeed a fuzz target and seems to be compiled with all actual fuzz targets.

Found the correct fuzz target source path and binary name using the same trick as in #750.