### PR TITLE
Update fuzz target source file path and binary name of librawspeed.yaml

### DIFF
--- a/benchmark-sets/all/librawspeed.yaml
+++ b/benchmark-sets/all/librawspeed.yaml
@@ -47,5 +47,5 @@
   "signature": "RawImage rawspeed::DngDecoder::decodeRawInternal()"
 "language": "c++"
 "project": "librawspeed"
-"target_name": "/src/librawspeed/fuzz/librawspeed/codes/PrefixCodeDecoder/Solo.cpp"
-"target_path": "/src/librawspeed/fuzz/librawspeed/codes/PrefixCodeDecoder/Solo.cpp"
+"target_name": "BitVacuumerRoundtripFuzzer"
+"target_path": "/src/librawspeed/fuzz/librawspeed/bitstreams/BitVacuumerRoundtrip.cpp"


### PR DESCRIPTION
This is another strange case:
1. The project is [compatible](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#librawspeed) with FI.
2. FI API [did not report](https://introspector.oss-fuzz.com/api/harness-source-and-executable?project=librawspeed) any pair.
3. The trick from #750 works:
```bash
#!/usr/bin/env bash

# First, find all matching files
FILES=$(find /src \
    -type f \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' \) \
    -not -path '*/aflplusplus/*' \
    -not -path '*/fuzztest/*' \
    -not -path '*/honggfuzz/*' \
    -not -path '*/libfuzzer/*' \
    -exec grep -l 'LLVMFuzzerTestOneInput' {} \;)

# For each file, insert a build_id line at the top of the file
for file in $FILES; do
    # Escape any slashes so the file path can be safely inserted by sed
    file_escaped=$(echo "$file" | sed 's/\//\\\//g')

    # Insert the build_id line at the top of the file
    # Adjust the insertion point as needed (e.g., after includes) if desired
    sed -i "1i const volatile char* build_id = \"$file_escaped\";" "$file"
done

echo "build_id line inserted in all matched files."
```

