### PR TITLE
Ignore comment-only build script

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -75,6 +75,9 @@ class BaseAgent(ABC):
         line for line in raw_code_block.splitlines()
         if not line.strip().startswith('```')
     ]
+    # Sometimes LLM returns a build script containing only comments.
+    if all(line.strip().startswith('#') for line in filtered_lines):
+      return ''
     filtered_code_block = '\n'.join(filtered_lines)
     return filtered_code_block
 


### PR DESCRIPTION
Sometimes LLM suggests a build script with comments-only when it wants to reuse the existing build script, e.g.,
```
<build script>
# Reuse the existing build.sh
</build script>
```

This avoids confusing LLM to 'think' the build script works.
Returning `''` will make OFG use the existing build script.