### PR TITLE
Replace build script content using a HereDoc with a unique EOF

### DIFF
--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -132,7 +132,7 @@ class Prototyper(BaseAgent):
 
     # Replace fuzz target and build script in the container.
     replace_file_content_command = (
-        'cat << "EOF" > {file_path}\n{file_content}\nEOF')
+        'cat << "OFG_EOF" > {file_path}\n{file_content}\nOFG_EOF')
     compilation_tool.execute(
         replace_file_content_command.format(
             file_path=benchmark.target_path,


### PR DESCRIPTION
Because sometimes build script content uses HereDoc too, which often uses the most common EOF as end-of-file delimiter.