### PR TITLE
Fix "Couldn't find any package by regex 'python3.11-venv'"

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,8 +31,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install venv
-        run: sudo apt-get update && sudo apt-get install python3.11-venv
       - name: Set up venv
         run: python3.11 -m venv .venv
       - name: Active venv dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install venv
-        run: sudo apt-get update && apt-get install python3.11-venv
+        run: sudo apt-get update && sudo apt-get install python3.11-venv
       - name: Set up venv
         run: python3.11 -m venv .venv
       - name: Active venv dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install venv
-        run: sudo apt-get install python3.11-venv
+        run: sudo apt-get update && apt-get install python3.11-venv
       - name: Set up venv
         run: python3.11 -m venv .venv
       - name: Active venv dependencies


### PR DESCRIPTION
To address recent failures from linter CI:
```bash
E: Unable to locate package python3.11-venv
E: Couldn't find any package by glob 'python3.11-venv'
E: Couldn't find any package by regex 'python3.11-venv'
```

This is likely due to the new Ubuntu version (noble) does not have `python3.11-venv`, but we don't have to install it anyway.