### PR TITLE
from_scratch: fix enumeration bug

### DIFF
--- a/experimental/from_scratch/generate.py
+++ b/experimental/from_scratch/generate.py
@@ -82,7 +82,7 @@ def get_target_benchmark(
   for function in project.all_functions:
     if function.name == target_function_name:
       param_list = []
-      for idx, arg_name in function.arg_names:
+      for idx, arg_name in enumerate(function.arg_names):
         param_list.append({'name': arg_name, 'type': function.arg_types[idx]})
 
       # Build a context.


### PR DESCRIPTION
`function.arg_names` is a python list. Looping it to get both the items and the index requires the enumeration function which is missing from the code. The original code works because the testing is only done on empty arg_names which does not trigger the loop. This PR fixes the bug.