### PR TITLE
from-scratch: simplify installation

### DIFF
--- a/experimental/from_scratch/README.md
+++ b/experimental/from_scratch/README.md
@@ -15,10 +15,7 @@ python3.11 -m virtualenv .venv
 git clone https://github.com/ossf/fuzz-introspector
 cd fuzz-introspector/src
 python3 -m pip install -e .
-cd ../
-python3 -m pip install -r ./requirements.txt
-cd ../
-
+cd ../../
 
 # Prepare a target
 git clone https://github.com/dvhar/dateparse


### PR DESCRIPTION
The `requirements.txt` step is no longer needed since https://github.com/ossf/fuzz-introspector/pull/2060