### PR TITLE
Add timestamp suffix to avoid conflict

### DIFF
--- a/data_prep/project_src.py
+++ b/data_prep/project_src.py
@@ -269,10 +269,11 @@ def _copy_project_src_from_local(project: str, out: str, language: str):
     logger.info('Done copying %s /src to %s.', project, out)
   finally:
     # Shut down the container that was just started.
-    result = sp.run(['docker', 'container', 'stop', f'{project}-container-{timestamp}'],
-                    capture_output=True,
-                    stdin=sp.DEVNULL,
-                    check=False)
+    result = sp.run(
+        ['docker', 'container', 'stop', f'{project}-container-{timestamp}'],
+        capture_output=True,
+        stdin=sp.DEVNULL,
+        check=False)
     if result.returncode:
       logger.error('Failed to stop container image: %s-container', project)
       logger.error('STDOUT: %s', result.stdout)


### PR DESCRIPTION
The docker container created during local source copy from local is only used within the function. But it will result in docker container collision when it is running across multiple pipelines. This PR fixes the naming of the one-use docker container to add a timestamp suffix (and retry with random sleep when collision occur) to avoid docker container collision.