### PR TITLE
Disable JCC and the reliance of its err.log

### DIFF
--- a/experiment/workdir.py
+++ b/experiment/workdir.py
@@ -100,11 +100,6 @@ class WorkDirs:
     return os.path.join(self.build_logs,
                         f'{generated_target_name}-F{iteration}.log')
 
-  def error_logs_target(self, generated_target_name: str,
-                        iteration: int) -> str:
-    return os.path.join(self.build_logs,
-                        f'{generated_target_name}-F{iteration}.err.log')
-
   def run_logs_target(self, generated_target_name: str, iteration: int):
     return os.path.join(self.run_logs,
                         f'{generated_target_name}-F{iteration}.log')


### PR DESCRIPTION
Reasons:
1. We don't need `JCC` to parse and pass fuzz target build error messages (into `err.log`), because agents can capture and fix build errors in project's containers natively, without relying on `target_experiment.py`. Some err.log were empty anyway.
2. Agents can modify build script, hence we don't need JCC to add flags, add header files, or switch compiler (C/C++).
3. `JCC`'s heuristics cause build errors in some projects (e.g., `brpc`).