### PR TITLE
Fix Agent prompt and infra

### DIFF
--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -251,8 +251,8 @@ class Prototyper(BaseAgent):
       # binary to expected path, but does not reference function-under-test.
       prompt_text.replace(
           '{BUILD_TEXT}',
-          'Althoug `/src/build.sh` compiles and saves the binary to the correct'
-          ' path:')
+          'Althoug `/src/build.bk.sh` compiles and saves the binary to the '
+          'correct path:')
       # NOTE: Unsafe to say the following, because /src/build.sh may miss a
       # library required by the function-under-test, and the fuzz target did not
       # invoke the function-under-test either.
@@ -310,8 +310,8 @@ class Prototyper(BaseAgent):
           build_result.benchmark.target_name,
           trial=build_result.trial)
       prompt_text = (
-          'The fuzz target compiles successfully with /src/build.sh, but the '
-          'final fuzz target binary was not saved to the expected path at '
+          'The fuzz target compiles successfully with /src/build.bk.sh, but the'
+          ' final fuzz target binary was not saved to the expected path at '
           f'`{binary_path}`.\n'
           f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
           f'<compilation log>\n{compile_log}\n</compilation log>\n'

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -238,18 +238,18 @@ class Prototyper(BaseAgent):
                                            extra_text=prompt.get()).strip()
     prompt_text = (
         "The fuzz target's `LLVMFuzzerTestOneInput` did not invoke the "
-        f'function-under-test `{function_signature}`:'
+        f'function-under-test `{function_signature}`:\n'
         f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
         '{BUILD_TEXT}\n'
         f'<compilation log>\n{compile_log}\n</compilation log>\n'
         'That is NOT enough. YOU MUST MODIFY THE FUZZ TARGET to CALL '
         f'FUNCTION `{function_signature}` **EXPLICITLY OR IMPLICITLY** in '
-        '`LLVMFuzzerTestOneInput` to generate a valid fuzz target. Study the '
+        '`LLVMFuzzerTestOneInput` to generate a valid fuzz target.\nStudy the '
         'source code for function usages to know how.\n')
     if build_result_alt and build_result_alt.binary_exists:
       # Preference 3: New fuzz target + default build.sh can compile and save
       # binary to expected path, but does not reference function-under-test.
-      prompt_text.replace(
+      prompt_text = prompt_text.replace(
           '{BUILD_TEXT}',
           'Althoug `/src/build.bk.sh` compiles and saves the binary to the '
           'correct path:')
@@ -262,14 +262,14 @@ class Prototyper(BaseAgent):
       #     '<build script></build script> empty.')
       prompt_text += (
           'When you have a solution later, make sure you output the FULL fuzz '
-          'target. YOU MUST NOT OMIT ANY '
-          'CODE even if it is the same as before.\n')
+          'target. YOU MUST NOT OMIT ANY CODE even if it is the same as before.'
+          '\n')
       prompt.append(prompt_text)
       return build_result_alt, prompt
     if build_result_ori and build_result_ori.binary_exists:
       # Preference 4: New fuzz target + New build.sh can compile and save
       # binary to expected path, but does not reference function-under-test.
-      prompt_text.replace(
+      prompt_text = prompt_text.replace(
           '{BUILD_TEXT}',
           'Althoug your build script compiles and saves the binary to the '
           'correct path:\n'

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -50,7 +50,8 @@ class Prototyper(BaseAgent):
         benchmark.language, []),
                            project_example_content=project_examples,
                            project_context_content=context_info,
-                           tool_guides=self.inspect_tool.tutorial())
+                           tool_guides=self.inspect_tool.tutorial(),
+                           project_dir=self.inspect_tool.project_dir)
     return prompt
 
   def _update_fuzz_target_and_build_script(self, cur_round: int, response: str,
@@ -371,7 +372,8 @@ class Prototyper(BaseAgent):
         build_result=build_result,
         compile_log=compile_log,
         initial=prompt.get())
-    prompt = builder.build(example_pair=[])
+    prompt = builder.build(example_pair=[],
+                           project_dir=self.inspect_tool.project_dir)
     return build_result, prompt
 
   def _container_handle_conclusion(self, cur_round: int, response: str,

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -331,7 +331,8 @@ class Prototyper(BaseAgent):
         model=self.llm,
         benchmark=build_result.benchmark,
         build_result=build_result,
-        compile_log=compile_log)
+        compile_log=compile_log,
+        initial=prompt.get())
     prompt = builder.build(example_pair=[])
     return build_result, prompt
 

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -1,6 +1,7 @@
 """An LLM agent to generate a simple fuzz target prototype that can build.
 Use it as a usual module locally, or as script in cloud builds.
 """
+import copy
 import os
 import subprocess as sp
 import time
@@ -97,26 +98,34 @@ class Prototyper(BaseAgent):
     build_result.binary_exists = binary_exists
     build_result.is_function_referenced = referenced
 
-  def _validate_fuzz_target_and_build_script(self, cur_round: int,
-                                             build_result: BuildResult) -> None:
+  def _validate_fuzz_target_and_build_script(
+      self, cur_round: int, build_result: BuildResult
+  ) -> tuple[Optional[BuildResult], Optional[BuildResult]]:
     """Validates the new fuzz target and build script."""
     # Steps:
     #   1. Recompile without modifying the build script, in case LLM is wrong.
     #   2. Recompile with the modified build script, if any.
-    build_script_source = build_result.build_script_source
+    build_result_alt = None
+    if build_result.build_script_source:
+      build_result_alt = copy.deepcopy(build_result)
+      logger.info('First compile fuzz target without modifying build script.',
+                  trial=build_result_alt.trial)
+      build_result_alt.build_script_source = ''
+      self._validate_fuzz_target_and_build_script_via_compile(
+          cur_round, build_result_alt)
 
-    logger.info('First compile fuzz target without modifying build script.',
+    # No need to run expensive build_result, when *_alt is perfect.
+    if build_result_alt and build_result_alt.success:
+      return build_result_alt, None
+
+    # New fuzz target + has new build.sh.
+    logger.info('Compile fuzz target with modified build script.',
                 trial=build_result.trial)
-    build_result.build_script_source = ''
     self._validate_fuzz_target_and_build_script_via_compile(
         cur_round, build_result)
 
-    if not build_result.success and build_script_source:
-      logger.info('Then compile fuzz target with modified build script.',
-                  trial=build_result.trial)
-      build_result.build_script_source = build_script_source
-      self._validate_fuzz_target_and_build_script_via_compile(
-          cur_round, build_result)
+    # Although build_result_alt is not perfect, LLM may still learn from it.
+    return build_result_alt, build_result
 
   def _validate_fuzz_target_references_function(
       self, compilation_tool: ProjectContainerTool, benchmark: Benchmark,
@@ -194,6 +203,138 @@ class Prototyper(BaseAgent):
                               binary_exists=binary_exists,
                               referenced=function_referenced)
 
+  def _generate_prompt_from_build_result(
+      self, build_result_alt: Optional[BuildResult],
+      build_result_ori: Optional[BuildResult], build_result: BuildResult,
+      prompt: Prompt, cur_round: int) -> tuple[BuildResult, Optional[Prompt]]:
+    """Selects which build result to use and generates a prompt accordingly."""
+
+    # Case 1: Successful.
+    if build_result_alt and build_result_alt.success:
+      # Preference 1: New fuzz target + default build.sh can compile, save
+      # binary to expected path, and reference function-under-test.
+      logger.info(
+          'Default /src/build.sh works perfectly, no need for a new '
+          'buid script',
+          trial=build_result.trial)
+      logger.info('***** Prototyper succeded in %02d rounds *****',
+                  cur_round,
+                  trial=build_result.trial)
+      return build_result_alt, None
+
+    if build_result_ori and build_result_ori.success:
+      # Preference 2: New fuzz target + new build.sh can compile, save
+      # binary to expected path, and reference function-under-test.
+      logger.info('***** Prototyper succeded in %02d rounds *****',
+                  cur_round,
+                  trial=build_result.trial)
+      return build_result_ori, None
+
+    # Case 2: Binary exits, meaning not referencing function-under-test.
+    function_signature = build_result.benchmark.function_signature
+    fuzz_target_source = build_result.fuzz_target_source
+    build_script_source = build_result.build_script_source
+    compile_log = self.llm.truncate_prompt(build_result.compile_log,
+                                           extra_text=prompt.get()).strip()
+    prompt_text = (
+        "The fuzz target's `LLVMFuzzerTestOneInput` did not invoke the "
+        f'function-under-test `{function_signature}`:'
+        f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
+        '{BUILD_TEXT}\n'
+        f'<compilation log>\n{compile_log}\n</compilation log>\n'
+        'That is NOT enough. YOU MUST MODIFY THE FUZZ TARGET to CALL '
+        f'FUNCTION `{function_signature}` **EXPLICITLY OR IMPLICITLY** in '
+        '`LLVMFuzzerTestOneInput` to generate a valid fuzz target. Study the '
+        'source code for function usages to know how.\n')
+    if build_result_alt and build_result_alt.binary_exists:
+      # Preference 3: New fuzz target + default build.sh can compile and save
+      # binary to expected path, but does not reference function-under-test.
+      prompt_text.replace(
+          '{BUILD_TEXT}',
+          'Althoug `/src/build.sh` compiles and saves the binary to the correct'
+          ' path:')
+      # NOTE: Unsafe to say the following, because /src/build.sh may miss a
+      # library required by the function-under-test, and the fuzz target did not
+      # invoke the function-under-test either.
+      # prompt_text += (
+      #     'In addition, given the default /src/build.sh works perfectly, you '
+      #     'do not have to generate a new build script and can leave '
+      #     '<build script></build script> empty.')
+      prompt_text += (
+          'When you have a solution later, make sure you output the FULL fuzz '
+          'target. YOU MUST NOT OMIT ANY '
+          'CODE even if it is the same as before.\n')
+      prompt.append(prompt_text)
+      return build_result_alt, prompt
+    if build_result_ori and build_result_ori.binary_exists:
+      # Preference 4: New fuzz target + New build.sh can compile and save
+      # binary to expected path, but does not reference function-under-test.
+      prompt_text.replace(
+          '{BUILD_TEXT}',
+          'Althoug your build script compiles and saves the binary to the '
+          'correct path:\n'
+          f'<build script>\n{build_script_source}\n</build script>\n')
+      prompt_text += (
+          'When you have a solution later, make sure you output the FULL fuzz '
+          'target (and the FULL build script, if any). YOU MUST NOT OMIT ANY '
+          'CODE even if it is the same as before.\n')
+      prompt.append(prompt_text)
+      return build_result_ori, prompt
+
+    # Case 3: Compiles, meaning the binary is not saved.
+    binary_path = os.path.join('/out', build_result.benchmark.target_name)
+    if build_result_ori and build_result_ori.compiles:
+      # Preference 6: New fuzz target + new build.sh can compile, but does
+      # not save binary to expected path.
+      prompt_text = (
+          'The fuzz target and build script compiles successfully, but the '
+          'final fuzz target binary was not saved to the expected path at '
+          f'`{binary_path}`.\n'
+          f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
+          f'<build script>\n{build_script_source}\n</build script>\n'
+          f'<compilation log>\n{compile_log}\n</compilation log>\n'
+          'YOU MUST MODIFY THE BUILD SCRIPT to ensure the binary is saved to '
+          f'{binary_path}.\n')
+      prompt_text += (
+          'When you have a solution later, make sure you output the FULL fuzz '
+          'target (and the FULL build script, if any). YOU MUST NOT OMIT ANY '
+          'CODE even if it is the same as before.\n')
+      prompt.append(prompt_text)
+      return build_result_ori, prompt
+    if build_result_alt and build_result_alt.compiles:
+      # Preference 5: New fuzz target + default build.sh can compile, but does
+      # not save binary to expected path, indicating benchmark data error.
+      logger.error(
+          'The human-written build.sh does not save the fuzz target binary to '
+          'expected path /out/%s, indicating incorrect info in benchmark YAML.',
+          build_result.benchmark.target_name,
+          trial=build_result.trial)
+      prompt_text = (
+          'The fuzz target compiles successfully with /src/build.sh, but the '
+          'final fuzz target binary was not saved to the expected path at '
+          f'`{binary_path}`.\n'
+          f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
+          f'<compilation log>\n{compile_log}\n</compilation log>\n'
+          'YOU MUST MODIFY THE BUILD SCRIPT to ensure the binary is saved to '
+          f'{binary_path}.\n')
+      prompt_text += (
+          'When you have a solution later, make sure you output the FULL fuzz '
+          'target (and the FULL build script, if any). YOU MUST NOT OMIT ANY '
+          'CODE even if it is the same as before.\n')
+      prompt.append(prompt_text)
+      return build_result_alt, prompt
+
+    # Preference 7: New fuzz target + both `build.sh`s cannot compile. No need
+    # to mention the default build.sh.
+    # return build_result
+    builder = prompt_builder.PrototyperFixerTemplateBuilder(
+        model=self.llm,
+        benchmark=build_result.benchmark,
+        build_result=build_result,
+        compile_log=compile_log)
+    prompt = builder.build(example_pair=[])
+    return build_result, prompt
+
   def _container_handle_conclusion(self, cur_round: int, response: str,
                                    build_result: BuildResult,
                                    prompt: Prompt) -> Optional[Prompt]:
@@ -206,104 +347,15 @@ class Prototyper(BaseAgent):
                 trial=build_result.trial)
 
     self._update_fuzz_target_and_build_script(cur_round, response, build_result)
-    build_script_source = build_result.build_script_source
 
-    self._validate_fuzz_target_and_build_script(cur_round, build_result)
-    if build_result.success:
-      logger.info('***** Prototyper succeded in %02d rounds *****',
-                  cur_round,
-                  trial=build_result.trial)
-      return None
+    build_result_alt, build_result_ori = (
+        self._validate_fuzz_target_and_build_script(cur_round, build_result))
 
-    fuzz_target_source = build_result.fuzz_target_source
-    default_build_script_works = (build_script_source
-                                  != build_result.build_script_source)
-    build_script_source = build_result.build_script_source
-    compile_log = self.llm.truncate_prompt(build_result.compile_log,
-                                           extra_text=prompt.get()).strip()
-    prompt_text = ''
-    if not build_result.compiles:
-      # Build script here must be from LLM, as it will be attempted last.
-      compile_log = self.llm.truncate_prompt(build_result.compile_log,
-                                             extra_text=prompt.get()).strip()
-      logger.info('***** Failed to recompile in %02d rounds *****',
-                  cur_round,
-                  trial=build_result.trial)
-      prompt_text = (
-          'Failed to build fuzz target. Here is the fuzz target, build script, '
-          'compliation command, and other compilation runtime output. Analyze '
-          'the error messages, the fuzz target, and the build script carefully '
-          'to identify the root cause. Avoid making random changes to the fuzz '
-          'target or build script without a clear understanding of the error. '
-          'If necessary, #include necessary headers and #define required macros'
-          'or constants in the fuzz target, or adjust compiler flags to link '
-          'required libraries in the build script. After collecting information'
-          ', analyzing and understanding the error root cause, YOU MUST take at'
-          ' least one step to validate your theory with source code evidence. '
-          'Only if your theory is verified, respond the revised fuzz target and'
-          'build script in FULL.\n'
-          'Always try to learn from the source code about how to fix errors, '
-          'for example, search for the key words (e.g., function name, type '
-          'name, constant name) in the source code to learn how they are used. '
-          'Similarly, learn from the other fuzz targets and the build script to'
-          'understand how to include the correct headers.\n'
-          'Focus on writing a minimum buildable fuzz target that calls the '
-          'target function. We can increase its complexity later, but first try'
-          'to make it compile successfully.'
-          'If an error happens repeatedly and cannot be fixed, try to '
-          'mitigate it. For example, replace or remove the line.'
-          f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
-          f'<build script>\n{build_script_source}\n</build script>'
-          f'\n<compilation log>\n{compile_log}\n</compilation log>\n')
-    elif not build_result.binary_exists:
-      # Build script here must be from LLM, as default script won't miss binary.
-      binary_path = os.path.join('/out', build_result.benchmark.target_name)
-      logger.info(
-          '***** Fuzz target binary does not exist at %s in %02d rounds *****',
-          binary_path,
-          cur_round,
-          trial=build_result.trial)
-      prompt_text = (
-          'The following fuzz target and build script compiles successfully, '
-          'but the fuzz target binary was not saved to the expected path '
-          f'`{binary_path}`.\n'
-          f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
-          f'<build script>\n{build_script_source}\n</build script>\n'
-          f'<compilation log>\n{compile_log}\n</compilation log>\n'
-          'YOU MUST MODIFY THE BUILD SCRIPT to ensure the binary is saved to '
-          f'{binary_path}.\n')
-    elif not build_result.is_function_referenced:
-      logger.info(
-          '***** Fuzz target does not reference function-under-test in %02d '
-          'rounds *****',
-          cur_round,
-          trial=build_result.trial)
-      function_signature = build_result.benchmark.function_signature
-      prompt_text = (
-          'The fuzz target builds successfully, but the target function '
-          f'`{function_signature}` was not used by `LLVMFuzzerTestOneInput` in '
-          'fuzz target.\n'
-          f'<fuzz target>\n{fuzz_target_source}\n</fuzz target>\n'
-          f'<build script>\n{build_script_source}\n</build script>\n'
-          f'<compilation log>\n{compile_log}\n</compilation log>\n'
-          'YOU MUST MODIFY THE FUZZ TARGET to CALL FUNCTION '
-          f'`{function_signature}` in `LLVMFuzzerTestOneInput`.\n')
-      # Build script here may be default.
-      if default_build_script_works:
-        prompt_text += (
-            'The build_script is empty, because the default build script at '
-            '/src/build.sh works perfectly. Considering using that instead.')
+    # Updates build_result with _alt or _ori, depending on their status.
+    build_result, prompt_final = self._generate_prompt_from_build_result(
+        build_result_alt, build_result_ori, build_result, prompt, cur_round)
 
-    prompt_text += (
-        'When you have a solution later, make sure you output the FULL fuzz '
-        'target')
-    if build_result.build_script_source:
-      prompt_text += ' and the FULL build script'
-    prompt_text += (
-        '. YOU MUST NOT OMIT ANY CODE even if it is the same as before.')
-
-    prompt.append(prompt_text)
-    return prompt
+    return prompt_final
 
   def _container_tool_reaction(self, cur_round: int, response: str,
                                build_result: BuildResult) -> Optional[Prompt]:

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -54,39 +54,19 @@ class Prototyper(BaseAgent):
                            project_dir=self.inspect_tool.project_dir)
     return prompt
 
-  def _update_fuzz_target_and_build_script(self, cur_round: int, response: str,
+  def _update_fuzz_target_and_build_script(self, response: str,
                                            build_result: BuildResult) -> None:
     """Updates fuzz target and build script in build_result with LLM response.
     """
     fuzz_target_source = self._filter_code(
         self._parse_tag(response, 'fuzz target'))
     build_result.fuzz_target_source = fuzz_target_source
-    if fuzz_target_source:
-      logger.debug('ROUND %02d Parsed fuzz target from LLM: %s',
-                   cur_round,
-                   fuzz_target_source,
-                   trial=build_result.trial)
-    else:
-      logger.error('ROUND %02d No fuzz target source code in conclusion: %s',
-                   cur_round,
-                   response,
-                   trial=build_result.trial)
 
     build_script_source = self._filter_code(
         self._parse_tag(response, 'build script'))
     # Sometimes LLM adds chronos, which makes no sense for new build scripts.
     build_result.build_script_source = build_script_source.replace(
         'source /src/chronos.sh', '')
-    if build_script_source:
-      logger.debug('ROUND %02d Parsed build script from LLM: %s',
-                   cur_round,
-                   build_script_source,
-                   trial=build_result.trial)
-    else:
-      logger.debug('ROUND %02d No build script in conclusion: %s',
-                   cur_round,
-                   response,
-                   trial=build_result.trial)
 
   def _update_build_result(self, build_result: BuildResult,
                            compile_process: sp.CompletedProcess, compiles: bool,
@@ -387,7 +367,7 @@ class Prototyper(BaseAgent):
                 cur_round,
                 trial=build_result.trial)
 
-    self._update_fuzz_target_and_build_script(cur_round, response, build_result)
+    self._update_fuzz_target_and_build_script(response, build_result)
 
     build_result_alt, build_result_ori = (
         self._validate_fuzz_target_and_build_script(cur_round, build_result))

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -47,7 +47,7 @@ class Prototyper(BaseAgent):
         benchmark=benchmark,
     )
     prompt = builder.build(example_pair=prompt_builder.EXAMPLES.get(
-        benchmark.language, []),
+        benchmark.file_type.value.lower(), []),
                            project_example_content=project_examples,
                            project_context_content=context_info,
                            tool_guides=self.inspect_tool.tutorial(),

--- a/experiment/builder_runner.py
+++ b/experiment/builder_runner.py
@@ -951,17 +951,15 @@ class CloudBuilderRunner(BuilderRunner):
         f'--real_project={project_name}',
     ]
 
-    # Temporarily comment out due to error in cached images.
-    # TODO(dongge): Add this back when the cached image works again.
-    # if oss_fuzz_checkout.ENABLE_CACHING and (
-    #     oss_fuzz_checkout.is_image_cached(project_name, 'address') and
-    #     oss_fuzz_checkout.is_image_cached(project_name, 'coverage')):
-    #   logger.info('Using cached image for %s', project_name)
-    #   command.append('--use_cached_image')
+    if oss_fuzz_checkout.ENABLE_CACHING and (
+        oss_fuzz_checkout.is_image_cached(project_name, 'address') and
+        oss_fuzz_checkout.is_image_cached(project_name, 'coverage')):
+      logger.info('Using cached image for %s', project_name)
+      command.append('--use_cached_image')
 
-    #   # Overwrite the Dockerfile to be caching friendly
-    #   oss_fuzz_checkout.rewrite_project_to_cached_project_chronos(
-    #       generated_project)
+      # Overwrite the Dockerfile to be caching friendly
+      oss_fuzz_checkout.rewrite_project_to_cached_project_chronos(
+          generated_project)
 
     if cloud_build_tags:
       command += ['--tags'] + cloud_build_tags

--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -307,6 +307,8 @@ class Evaluator:
 
     # Add additional statement in dockerfile to overwrite with generated fuzzer
     with open(os.path.join(generated_project_path, 'Dockerfile'), 'a') as f:
+      f.write('\nRUN cp /src/build.sh /src/build.bk.sh\n')
+    with open(os.path.join(generated_project_path, 'Dockerfile'), 'a') as f:
       f.write('\nCOPY agent-build.sh /src/build.sh\n')
 
     return name

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -70,7 +70,7 @@ def _clone_oss_fuzz_repo():
   """Clones OSS-Fuzz to |OSS_FUZZ_DIR|."""
   clone_command = [
       'git', 'clone', 'https://github.com/google/oss-fuzz', '--depth', '1',
-      '--branch', 'target-exp-log-account', OSS_FUZZ_DIR
+      OSS_FUZZ_DIR
   ]
   proc = sp.Popen(clone_command,
                   stdout=sp.PIPE,

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -616,7 +616,7 @@ class PrototyperFixerTemplateBuilder(PrototyperTemplateBuilder):
       build_text = (f'<build script>\n{self.build_result.build_script_source}\n'
                     '</build script>')
     else:
-      build_text = 'Build script reuses `/src/build.sh`.'
+      build_text = 'Build script reuses `/src/build.bk.sh`.'
     prompt = self._get_template(self.priming_template_file)
     prompt = prompt.replace('{FUZZ_TARGET_SOURCE}',
                             self.build_result.fuzz_target_source)

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -547,11 +547,10 @@ class PrototyperTemplateBuilder(DefaultTemplateBuilder):
   def __init__(self,
                model: models.LLM,
                benchmark: Benchmark,
-               template_dir: str = DEFAULT_TEMPLATE_DIR):
-    super().__init__(model)
-    self._template_dir = template_dir
+               template_dir: str = DEFAULT_TEMPLATE_DIR,
+               initial: Any = None):
+    super().__init__(model, benchmark, template_dir, initial)
     self.agent_templare_dir = AGENT_TEMPLATE_DIR
-    self.benchmark = benchmark
 
     # Load templates.
     self.priming_template_file = self._find_template(self.agent_templare_dir,
@@ -594,8 +593,9 @@ class PrototyperFixerTemplateBuilder(PrototyperTemplateBuilder):
                benchmark: Benchmark,
                build_result: BuildResult,
                compile_log: str,
-               template_dir: str = DEFAULT_TEMPLATE_DIR):
-    super().__init__(model, benchmark, template_dir)
+               template_dir: str = DEFAULT_TEMPLATE_DIR,
+               initial: Any = None):
+    super().__init__(model, benchmark, template_dir, initial)
     # Load templates.
     self.priming_template_file = self._find_template(self.agent_templare_dir,
                                                      'prototyper-fixing.txt')
@@ -612,11 +612,13 @@ class PrototyperFixerTemplateBuilder(PrototyperTemplateBuilder):
          tool_guides)
     if not self.benchmark:
       return self._prompt
+
     if self.build_result.build_script_source:
       build_text = (f'<build script>\n{self.build_result.build_script_source}\n'
                     '</build script>')
     else:
       build_text = 'Build script reuses `/src/build.bk.sh`.'
+
     prompt = self._get_template(self.priming_template_file)
     prompt = prompt.replace('{FUZZ_TARGET_SOURCE}',
                             self.build_result.fuzz_target_source)

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -617,9 +617,9 @@ class PrototyperFixerTemplateBuilder(PrototyperTemplateBuilder):
                     '</build script>')
     else:
       build_text = 'Build script reuses `/src/build.sh`.'
-
-    prompt = self.priming_template_file.replace(
-        '{FUZZ_TARGET_SOURCE}', self.build_result.fuzz_target_source)
+    prompt = self._get_template(self.priming_template_file)
+    prompt = prompt.replace('{FUZZ_TARGET_SOURCE}',
+                            self.build_result.fuzz_target_source)
     prompt = prompt.replace('{BUILD_TEXT}', build_text)
     prompt = prompt.replace('{COMPILE_LOG}', self.compile_log)
     prompt = prompt.replace('{FUNCTION_SIGNATURE}',

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -553,8 +553,16 @@ class PrototyperTemplateBuilder(DefaultTemplateBuilder):
     self.agent_templare_dir = AGENT_TEMPLATE_DIR
 
     # Load templates.
-    self.priming_template_file = self._find_template(self.agent_templare_dir,
-                                                     'prototyper-priming.txt')
+    if benchmark.is_c_target:
+      self.priming_template_file = self._find_template(
+          self.agent_templare_dir, 'prototyper-priming.c.txt')
+    elif benchmark.is_cpp_target:
+      self.priming_template_file = self._find_template(
+          self.agent_templare_dir, 'prototyper-priming.cpp.txt')
+    else:
+      self.problem_template_file = self._find_template(
+          self.agent_templare_dir, 'prototyper-priming.txt')
+
     self.cpp_priming_filler_file = self._find_template(
         template_dir, 'cpp-specific-priming-filler.txt')
     self.problem_template_file = self._find_template(template_dir,

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -568,11 +568,13 @@ class PrototyperTemplateBuilder(DefaultTemplateBuilder):
             example_pair: list[list[str]],
             project_example_content: Optional[list[list[str]]] = None,
             project_context_content: Optional[dict] = None,
-            tool_guides: str = '') -> prompts.Prompt:
+            tool_guides: str = '',
+            project_dir: str = '') -> prompts.Prompt:
     """Constructs a prompt using the templates in |self| and saves it."""
     if not self.benchmark:
       return self._prompt
     priming = self._format_priming(self.benchmark)
+    priming = priming.replace('{PROJECT_DIR}', project_dir)
     final_problem = self.format_problem(self.benchmark.function_signature)
     final_problem += (f'You MUST call <code>\n'
                       f'{self.benchmark.function_signature}\n'
@@ -606,7 +608,8 @@ class PrototyperFixerTemplateBuilder(PrototyperTemplateBuilder):
             example_pair: list[list[str]],
             project_example_content: Optional[list[list[str]]] = None,
             project_context_content: Optional[dict] = None,
-            tool_guides: str = '') -> prompts.Prompt:
+            tool_guides: str = '',
+            project_dir: str = '') -> prompts.Prompt:
     """Constructs a prompt using the templates in |self| and saves it."""
     del (example_pair, project_example_content, project_context_content,
          tool_guides)
@@ -626,6 +629,7 @@ class PrototyperFixerTemplateBuilder(PrototyperTemplateBuilder):
     prompt = prompt.replace('{COMPILE_LOG}', self.compile_log)
     prompt = prompt.replace('{FUNCTION_SIGNATURE}',
                             self.benchmark.function_signature)
+    prompt = prompt.replace('{PROJECT_DIR}', project_dir)
     self._prompt.append(prompt)
 
     return self._prompt

--- a/prompts/agent/prototyper-fixing.txt
+++ b/prompts/agent/prototyper-fixing.txt
@@ -9,7 +9,7 @@ TIPS:
 1. If necessary, #include necessary headers and #define required macros or constants in the fuzz target.
 2. Adjust compiler flags to link required libraries in the build script.
 3. After collecting information, analyzing and understanding the error root cause. YOU MUST take at least one step to validate your theory with source code evidence.
-4. Always use the source code to understand errors and how to fix them. For example, search for the key words (e.g., function name, type name, constant name) in the source code to learn how they are used. Similarly, learn from the other fuzz targets and the build script to understand how to include the correct headers.
+4. Always use the source code from project source code directory `{PROJECT_DIR}/` to understand errors and how to fix them. For example, search for the key words (e.g., function name, type name, constant name) in the source code to learn how they are used. Similarly, learn from the other fuzz targets and the build script to understand how to include the correct headers.
 5. Once you have verified the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.bk.sh is insufficient).
 6. Focus on writing a compilable fuzz target that calls the function-under-test {FUNCTION_SIGNATURE}, don't worry about coverage or finding bugs. We can improve that later, but first try to ensure it calls the function-under-test {FUNCTION_SIGNATURE} and can compile successfully.
 7. If an error happens repeatedly and cannot be fixed, try to mitigate it. For example, replace or remove the line.

--- a/prompts/agent/prototyper-fixing.txt
+++ b/prompts/agent/prototyper-fixing.txt
@@ -4,13 +4,13 @@ Failed to build fuzz target. Here is the fuzz target, build script, compilation 
 <compilation log>\n{COMPILE_LOG}\n</compilation log>
 YOU MUST first analyze the error messages with the fuzz target and the build script carefully to identify the root cause.
 YOU MUST NOT make any assumptions of the source code or build environment. Always confirm assumptions with source code evidence, obtain them via Bash commands.
-Once you are absolutely certain of the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.sh is insufficient).
+Once you are absolutely certain of the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.bk.sh is insufficient).
 TIPS:
 1. If necessary, #include necessary headers and #define required macros or constants in the fuzz target.
 2. Adjust compiler flags to link required libraries in the build script.
 3. After collecting information, analyzing and understanding the error root cause. YOU MUST take at least one step to validate your theory with source code evidence.
 4. Always use the source code to understand errors and how to fix them. For example, search for the key words (e.g., function name, type name, constant name) in the source code to learn how they are used. Similarly, learn from the other fuzz targets and the build script to understand how to include the correct headers.
-5. Once you have verified the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.sh is insufficient).
+5. Once you have verified the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.bk.sh is insufficient).
 6. Focus on writing a compilable fuzz target that calls the function-under-test {FUNCTION_SIGNATURE}, don't worry about coverage or finding bugs. We can improve that later, but first try to ensure it calls the function-under-test {FUNCTION_SIGNATURE} and can compile successfully.
 7. If an error happens repeatedly and cannot be fixed, try to mitigate it. For example, replace or remove the line.
 

--- a/prompts/agent/prototyper-fixing.txt
+++ b/prompts/agent/prototyper-fixing.txt
@@ -1,0 +1,16 @@
+Failed to build fuzz target. Here is the fuzz target, build script, compilation command, and compilation output:
+<fuzz target>\n{FUZZ_TARGET_SOURCE}\n</fuzz target>
+{BUILD_TEXT}
+<compilation log>\n{COMPILE_LOG}\n</compilation log>
+YOU MUST first analyze the error messages with the fuzz target and the build script carefully to identify the root cause.
+YOU MUST NOT make any assumptions of the source code or build environment. Always confirm assumptions with source code evidence, obtain them via Bash commands.
+Once you are absolutely certain of the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.sh is insufficient).
+TIPS:
+1. If necessary, #include necessary headers and #define required macros or constants in the fuzz target.
+2. Adjust compiler flags to link required libraries in the build script.
+3. After collecting information, analyzing and understanding the error root cause. YOU MUST take at least one step to validate your theory with source code evidence.
+4. Always use the source code to understand errors and how to fix them. For example, search for the key words (e.g., function name, type name, constant name) in the source code to learn how they are used. Similarly, learn from the other fuzz targets and the build script to understand how to include the correct headers.
+5. Once you have verified the error root cause, output the FULL SOURCE CODE of the fuzz target (and FULL SOURCE CODE of build script, if /src/build.sh is insufficient).
+6. Focus on writing a compilable fuzz target that calls the function-under-test {FUNCTION_SIGNATURE}, don't worry about coverage or finding bugs. We can improve that later, but first try to ensure it calls the function-under-test {FUNCTION_SIGNATURE} and can compile successfully.
+7. If an error happens repeatedly and cannot be fixed, try to mitigate it. For example, replace or remove the line.
+

--- a/prompts/agent/prototyper-priming.c.txt
+++ b/prompts/agent/prototyper-priming.c.txt
@@ -1,0 +1,141 @@
+<system>
+As a security testing engineer, you must write an `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)` fuzz target in {LANGUAGE}.
+Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a minimum fuzz target of a given function-under-test that can build successfully.
+</system>
+
+<steps>
+Follow these steps to write a minimum fuzz target:
+
+Step 1. Determine the information you need to write an effective fuzz target.
+This includes:
+    * **Source code** of the function under test.
+    * **Custom Types and Dependencies** definitions and implementations.
+    * **Initialization and setup** requirements and steps.
+    * **Build details** and integration steps.
+    * Valid and edge-case input values.
+    * Environmental and runtime dependencies.
+
+Step 2. Collect information using the Bash tool.
+Use the bash tool (see <tool> section) and follow its rules to gather the necessary information. You can collect information from:
+    * The existing human written fuzz target at `{FUZZ_TARGET_PATH}`.
+    * The existing human written build script `/src/build.bk.sh`.
+    * The project source code directory `{PROJECT_DIR}/` cloned from the project repository.
+    * Documentation about the project, the function, and the variables/constants involved.
+    * Environment variables.
+    * Knowledge about OSS-Fuzz's build infrastructure: It will compile your fuzz target in the same way as the exiting human written fuzz target with the build script.
+
+Step 3. Analyze the function and its parameters.
+Understand the function under test by analyzing its source code and documentation:
+    * **Purpose and functionality** of the function.
+    * **Input processing** and internal logic.
+    * **Dependencies** on other functions or global variables.
+    * **Error handling** and edge cases.
+
+Step 4. Understand initialization requirements.
+Identify what is needed to properly initialize the function:
+    * **Header files** and their relative paths used by include statements in the fuzz target.
+    * **Complex input parameters or objects** initialization.
+    * **Constructor functions** or initialization routines.
+    * **Global state** or configuration needs to be set up.
+    * **Mocking** external dependencies if necessary.
+
+Step 5. Understand Constraints and edge cases.
+For each input parameter, understand:
+    * Valid ranges and data types.
+    * Invalid or edge-case values (e.g., zero, NULL, predefined constants, maximum values).
+    * Special values that trigger different code paths.
+
+Step 6: Plan Fuzz Target Implementation.
+Decide how to implement the fuzz target:
+    * **Extract parameters** from the `data` and `size` variable of `LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)`.
+    * Handle fixed-size versus variable-size data.
+    * **Initialize function's parameters** by appropriately mapping the raw input bytes.
+    * Ensure that the fuzz target remains deterministic and avoids side effects.
+    * Avoid `goto` statements.
+
+Step 7: **Write** the fuzz target code.
+Implement the `LLVMFuzzerTestOneInput` function:
+    * Header files:
+        * Investigate how existing fuzz targets include headers.
+        * Investigate where they are located in the project
+        * Collect all headers required by your fuzz target and their locations.
+        * Include their relative path in the same way as the existing fuzz targets.
+    * Macros or Constants:
+        * Include or define necessary macros or constants.
+    * Input Handling:
+        * Check that the input size is sufficient.
+        * Extract parameters from the input data.
+        * Handle any necessary conversions or validations.
+    * Function Invocation:
+        * Initialize required objects or state.
+        * Modify the existing fuzz target at `{FUZZ_TARGET_PATH}` to fuzz the function under test with the fuzzed parameters.
+        * Ensure proper error handling.
+    *
+    * Cleanup:
+        * Free any allocated resources.
+        * Reset any global state if necessary.
+
+Step 8 (Optional): **Modify** the Build Script.
+Write a new build script only if the existing one (`/src/build.bk.sh`) is insufficient:
+    * Decide if you need to modify the build script at `/src/build.bk.sh` to successfully build the new fuzz target.
+    * Include compilation steps for the project under test.
+    * Include compilation steps for the new fuzz target.
+    * Specify necessary compiler and linker flags.
+    * Ensure all dependencies are correctly linked.
+
+Step 9: Providing Your Conclusion:
+    * Provide your conclusion on the FULL new fuzz target and build script **ONLY AFTER** you have gathered all necessary information.
+    * **DO NOT SEND** any other content (e.g., bash tool commands) in the conclusion message. ALWAYS send other commands individually and ONLY SEND conclusion after collecting all information.
+    * Conclusion Format:
+        * Overall Description:
+            * Summarize your findings and describe your fuzz target design.
+            * Wrap this summary within <conclusion> and </conclusion> tags.
+    * Modified Fuzz Target:
+        * Provide the full code of the modified fuzz target.
+        * Wrap the code within <fuzz target> and </fuzz target> tags.
+    * Modified Build Script (if applicable):
+        * If you need to modify the build script, provide the full code.
+        * Wrap it within <build script> and </build script> tags.
+    * Format Example:
+        <conclusion>
+        I determined that the fuzz target needs to include specific header files and adjust the `LLVMFuzzerTestOneInput` function to call the new function-under-test. Additionally, the build script requires modification to link against the necessary libraries.
+        </conclusion>
+        <fuzz target>
+        [Your FULL fuzz target code here.]
+        </fuzz target>
+        <build script>
+        [Your FULL build script code here, if applicable.]
+        </build script>
+
+</steps>
+
+{TYPE_SPECIFIC_PRIMING}
+
+<instructions>
+3. Methodical Approach:
+    * Be systematic to cover all necessary aspects, such as:
+        * Understanding the function's parameters and dependencies.
+        * Identifying required header files and libraries.
+        * Recognizing any special initialization or environmental requirements.
+1. Utilizing Existing Examples:
+    * Use the existing fuzz target at `{FUZZ_TARGET_PATH}` and other fuzz targets with `LLVMFuzzerTestOneInput` in its parent directory as references.
+    * Pay special attention to:
+        * How header files are included.
+        * The structure and content of the `LLVMFuzzerTestOneInput` function.
+    * Typically, you only need to modify the content of `LLVMFuzzerTestOneInput`.
+2. Investigating Header Inclusions:
+    * Use bash tool to find required headers and libraries.
+    * Examine library files built by `/src/build.bk.sh` to understand available functions and symbols.
+3. Modifying the Build Script (if necessary):
+    * Modifying `/src/build.bk.sh` to build the necessary components or include required libraries if function-under-test is not included.
+    * The project's directory may contain a `README.md` with build instructions (e.g., at `/src/<project-name>/README.md`
+4. Do Not Compile:
+    * **Do not compile** the fuzz target during your investigation.
+    * Provide your conclusions based on the information gathered after you have a solution.
+5. Formatting Code Snippets:
+    * Do not wrap code snippets with triple backticks (```).
+    * Use the specified XML-style tags for wrapping code and other content.
+6. DO NOT send the <conclusion> early: Provide conclusions **only after** gathering all necessary information.
+7. Focus on Final Goals:
+    * Ensure that your fuzz target and build script aim to successfully build the fuzz target and fuzz the function-under-test.
+</instructions>

--- a/prompts/agent/prototyper-priming.cpp.txt
+++ b/prompts/agent/prototyper-priming.cpp.txt
@@ -1,0 +1,143 @@
+<system>
+As a security testing engineer, you must write an `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)` fuzz target in {LANGUAGE}.
+Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a minimum fuzz target of a given function-under-test that can build successfully.
+</system>
+
+<steps>
+Follow these steps to write a minimum fuzz target:
+
+Step 1. Determine the information you need to write an effective fuzz target.
+This includes:
+    * **Source code** of the function under test.
+    * **Custom Types and Dependencies** definitions and implementations.
+    * **Initialization and setup** requirements and steps.
+    * **Build details** and integration steps.
+    * Valid and edge-case input values.
+    * Environmental and runtime dependencies.
+
+Step 2. Collect information using the Bash tool.
+Use the bash tool (see <tool> section) and follow its rules to gather the necessary information. You can collect information from:
+    * The existing human written fuzz target at `{FUZZ_TARGET_PATH}`.
+    * The existing human written build script `/src/build.bk.sh`.
+    * The project source code directory `{PROJECT_DIR}/` cloned from the project repository.
+    * Documentation about the project, the function, and the variables/constants involved.
+    * Environment variables.
+    * Knowledge about OSS-Fuzz's build infrastructure: It will compile your fuzz target in the same way as the exiting human written fuzz target with the build script.
+
+Step 3. Analyze the function and its parameters.
+Understand the function under test by analyzing its source code and documentation:
+    * **Purpose and functionality** of the function.
+    * **Input processing** and internal logic.
+    * **Dependencies** on other functions or global variables.
+    * **Error handling** and edge cases.
+
+Step 4. Understand initialization requirements.
+Identify what is needed to properly initialize the function:
+    * **Header files** and their relative paths used by include statements in the fuzz target.
+    * **Complex input parameters or objects** initialization.
+    * **Constructor functions** or initialization routines.
+    * **Global state** or configuration needs to be set up.
+    * **Mocking** external dependencies if necessary.
+
+Step 5. Understand Constraints and edge cases.
+For each input parameter, understand:
+    * Valid ranges and data types.
+    * Invalid or edge-case values (e.g., zero, NULL, predefined constants, maximum values).
+    * Special values that trigger different code paths.
+
+Step 6: Plan Fuzz Target Implementation.
+Decide how to implement the fuzz target:
+    * **Extract parameters** from the `data` and `size` variable of `LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)`.
+    * Handle fixed-size versus variable-size data.
+    * **Initialize function's parameters** by appropriately mapping the raw input bytes.
+    * Ensure that the fuzz target remains deterministic and avoids side effects.
+    * Avoid `goto` statements.
+
+Step 7: **Write** the fuzz target code.
+Implement the `LLVMFuzzerTestOneInput` function:
+    * Header files:
+        * Investigate how existing fuzz targets include headers.
+        * Investigate where they are located in the project
+        * Collect all headers required by your fuzz target and their locations.
+        * Include their relative path in the same way as the existing fuzz targets.
+    * Macros or Constants:
+        * Include or define necessary macros or constants.
+    * Input Handling:
+        * Use `FuzzedDataProvider` if and only if the fuzz target at `{FUZZ_TARGET_PATH}` is a C++ file.
+        * Use `extern "C"` if and only if the fuzz target at `{FUZZ_TARGET_PATH}` is a C++ file.
+        * Check that the input size is sufficient.
+        * Extract parameters from the input data.
+        * Handle any necessary conversions or validations.
+    * Function Invocation:
+        * Initialize required objects or state.
+        * Modify the existing fuzz target at `{FUZZ_TARGET_PATH}` to fuzz the function under test with the fuzzed parameters.
+        * Ensure proper error handling.
+    *
+    * Cleanup:
+        * Free any allocated resources.
+        * Reset any global state if necessary.
+
+Step 8 (Optional): **Modify** the Build Script.
+Write a new build script only if the existing one (`/src/build.bk.sh`) is insufficient:
+    * Decide if you need to modify the build script at `/src/build.bk.sh` to successfully build the new fuzz target.
+    * Include compilation steps for the project under test.
+    * Include compilation steps for the new fuzz target.
+    * Specify necessary compiler and linker flags.
+    * Ensure all dependencies are correctly linked.
+
+Step 9: Providing Your Conclusion:
+    * Provide your conclusion on the FULL new fuzz target and build script **ONLY AFTER** you have gathered all necessary information.
+    * **DO NOT SEND** any other content (e.g., bash tool commands) in the conclusion message. ALWAYS send other commands individually and ONLY SEND conclusion after collecting all information.
+    * Conclusion Format:
+        * Overall Description:
+            * Summarize your findings and describe your fuzz target design.
+            * Wrap this summary within <conclusion> and </conclusion> tags.
+    * Modified Fuzz Target:
+        * Provide the full code of the modified fuzz target.
+        * Wrap the code within <fuzz target> and </fuzz target> tags.
+    * Modified Build Script (if applicable):
+        * If you need to modify the build script, provide the full code.
+        * Wrap it within <build script> and </build script> tags.
+    * Format Example:
+        <conclusion>
+        I determined that the fuzz target needs to include specific header files and adjust the `LLVMFuzzerTestOneInput` function to call the new function-under-test. Additionally, the build script requires modification to link against the necessary libraries.
+        </conclusion>
+        <fuzz target>
+        [Your FULL fuzz target code here.]
+        </fuzz target>
+        <build script>
+        [Your FULL build script code here, if applicable.]
+        </build script>
+
+</steps>
+
+{TYPE_SPECIFIC_PRIMING}
+
+<instructions>
+3. Methodical Approach:
+    * Be systematic to cover all necessary aspects, such as:
+        * Understanding the function's parameters and dependencies.
+        * Identifying required header files and libraries.
+        * Recognizing any special initialization or environmental requirements.
+1. Utilizing Existing Examples:
+    * Use the existing fuzz target at `{FUZZ_TARGET_PATH}` and other fuzz targets with `LLVMFuzzerTestOneInput` in its parent directory as references.
+    * Pay special attention to:
+        * How header files are included.
+        * The structure and content of the `LLVMFuzzerTestOneInput` function.
+    * Typically, you only need to modify the content of `LLVMFuzzerTestOneInput`.
+2. Investigating Header Inclusions:
+    * Use bash tool to find required headers and libraries.
+    * Examine library files built by `/src/build.bk.sh` to understand available functions and symbols.
+3. Modifying the Build Script (if necessary):
+    * Modifying `/src/build.bk.sh` to build the necessary components or include required libraries if function-under-test is not included.
+    * The project's directory may contain a `README.md` with build instructions (e.g., at `/src/<project-name>/README.md`
+4. Do Not Compile:
+    * **Do not compile** the fuzz target during your investigation.
+    * Provide your conclusions based on the information gathered after you have a solution.
+5. Formatting Code Snippets:
+    * Do not wrap code snippets with triple backticks (```).
+    * Use the specified XML-style tags for wrapping code and other content.
+6. DO NOT send the <conclusion> early: Provide conclusions **only after** gathering all necessary information.
+7. Focus on Final Goals:
+    * Ensure that your fuzz target and build script aim to successfully build the fuzz target and fuzz the function-under-test.
+</instructions>

--- a/prompts/agent/prototyper-priming.txt
+++ b/prompts/agent/prototyper-priming.txt
@@ -18,7 +18,7 @@ This includes:
 Step 2. Collect information using the Bash tool.
 Use the bash tool (see <tool> section) and follow its rules to gather the necessary information. You can collect information from:
     * The existing human written fuzz target at `{FUZZ_TARGET_PATH}`.
-    * The existing human written build script `/src/build.sh`.
+    * The existing human written build script `/src/build.bk.sh`.
     * The project source code (in `.`, or `/src/<project-under-test>/`) clone from the project repository.
     * Documentation about the project, the function, and the variables/constants involved.
     * Environment variables.
@@ -78,8 +78,8 @@ Implement the `LLVMFuzzerTestOneInput` function:
         * Reset any global state if necessary.
 
 Step 8 (Optional): **Modify** the Build Script.
-Write a new build script only if the existing one (`/src/build.sh`) is insufficient:
-    * Decide if you need to modify the build script at `/src/build.sh` to successfully build the new fuzz target.
+Write a new build script only if the existing one (`/src/build.bk.sh`) is insufficient:
+    * Decide if you need to modify the build script at `/src/build.bk.sh` to successfully build the new fuzz target.
     * Include compilation steps for the project under test.
     * Include compilation steps for the new fuzz target.
     * Specify necessary compiler and linker flags.
@@ -127,9 +127,9 @@ Step 9: Providing Your Conclusion:
     * Typically, you only need to modify the content of `LLVMFuzzerTestOneInput`.
 2. Investigating Header Inclusions:
     * Use bash tool to find required headers and libraries.
-    * Examine library files built by `/src/build.sh` to understand available functions and symbols.
+    * Examine library files built by `/src/build.bk.sh` to understand available functions and symbols.
 3. Modifying the Build Script (if necessary):
-    * Modifying `/src/build.sh` to build the necessary components or include required libraries if function-under-test is not included.
+    * Modifying `/src/build.bk.sh` to build the necessary components or include required libraries if function-under-test is not included.
     * The project's directory may contain a `README.md` with build instructions (e.g., at `/src/<project-name>/README.md`
 4. Do Not Compile:
     * **Do not compile** the fuzz target during your investigation.

--- a/prompts/agent/prototyper-priming.txt
+++ b/prompts/agent/prototyper-priming.txt
@@ -19,7 +19,7 @@ Step 2. Collect information using the Bash tool.
 Use the bash tool (see <tool> section) and follow its rules to gather the necessary information. You can collect information from:
     * The existing human written fuzz target at `{FUZZ_TARGET_PATH}`.
     * The existing human written build script `/src/build.bk.sh`.
-    * The project source code (in `.`, or `/src/<project-under-test>/`) clone from the project repository.
+    * The project source code directory `{PROJECT_DIR}/` cloned from the project repository.
     * Documentation about the project, the function, and the variables/constants involved.
     * Environment variables.
     * Knowledge about OSS-Fuzz's build infrastructure: It will compile your fuzz target in the same way as the exiting human written fuzz target with the build script.

--- a/prompts/tool/container_tool.txt
+++ b/prompts/tool/container_tool.txt
@@ -92,7 +92,7 @@ Command 5. Check Build Script for Compilation Flags and Libraries:
     To check which compiler flags and libraries are used in the build script.
     </reason>
     <bash>
-    cat /src/build.sh
+    cat /src/build.bk.sh
     </bash>
 Command 6. Verify Available Libraries:
     <reason>

--- a/prompts/tool/container_tool.txt
+++ b/prompts/tool/container_tool.txt
@@ -111,8 +111,7 @@ Command 7. Understand Environment Variables:
 </example usages>
 
 <final reminder>
-1. STRICTLY ONE Bash Command in each message: Do NOT send multiple bash commands in one message.
-3. Do Not Compile or Run Code:
+1. Do Not Compile or Run Code:
     * Your investigation is limited to reading and interpreting information using bash commands.
 </final reminder>
 </tool>

--- a/results.py
+++ b/results.py
@@ -72,6 +72,7 @@ class BuildResult(Result):
   compiles: bool  # Build success/failure.
   compile_error: str  # Build error message.
   compile_log: str  # Build full output.
+  binary_exists: bool  # Fuzz target binary generated successfully.
   is_function_referenced: bool  # Fuzz target references function-under-test.
 
   def __init__(self,
@@ -81,6 +82,7 @@ class BuildResult(Result):
                compiles: bool = False,
                compile_error: str = '',
                compile_log: str = '',
+               binary_exists: bool = False,
                is_function_referenced: bool = False,
                fuzz_target_source: str = '',
                build_script_source: str = '',
@@ -91,6 +93,7 @@ class BuildResult(Result):
     self.compiles = compiles
     self.compile_error = compile_error
     self.compile_log = compile_log
+    self.binary_exists = binary_exists
     self.is_function_referenced = is_function_referenced
 
   def to_dict(self) -> dict:
@@ -98,12 +101,13 @@ class BuildResult(Result):
         'compiles': self.success,
         'compile_error': self.compile_error,
         'compile_log': self.compile_log,
+        'binary_exists': self.binary_exists,
         'is_function_referenced': self.is_function_referenced,
     }
 
   @property
   def success(self):
-    return self.compiles and self.is_function_referenced
+    return self.compiles and self.binary_exists and self.is_function_referenced
 
 
 # TODO: Make this class an attribute of Result, avoid too many attributes in one
@@ -132,6 +136,7 @@ class RunResult(BuildResult):
       compiles: bool = False,
       compile_error: str = '',
       compile_log: str = '',
+      binary_exists: bool = False,
       is_function_referenced: bool = False,
       crashes: bool = False,  # Runtime crash.
       run_error: str = '',  # Runtime crash error message.
@@ -151,8 +156,9 @@ class RunResult(BuildResult):
       author: Any = None,
       chat_history: Optional[dict] = None) -> None:
     super().__init__(benchmark, trial, work_dirs, compiles, compile_error,
-                     compile_log, is_function_referenced, fuzz_target_source,
-                     build_script_source, author, chat_history)
+                     compile_log, binary_exists, is_function_referenced,
+                     fuzz_target_source, build_script_source, author,
+                     chat_history)
     self.crashes = crashes
     self.run_error = run_error
     self.run_log = run_log

--- a/stage/execution_stage.py
+++ b/stage/execution_stage.py
@@ -120,6 +120,7 @@ class ExecutionStage(BaseStage):
           compiles=last_result.compiles,
           compile_error=last_result.compile_error,
           compile_log=last_result.compile_log,
+          binary_exists=last_result.binary_exists,
           is_function_referenced=last_result.is_function_referenced,
           crashes=run_result.crashes,
           run_error=run_result.crash_info,
@@ -148,6 +149,7 @@ class ExecutionStage(BaseStage):
           compiles=last_result.compiles,
           compile_error=last_result.compile_error,
           compile_log=last_result.compile_log,
+          binary_exists=last_result.binary_exists,
           is_function_referenced=last_result.is_function_referenced)
 
     return runresult

--- a/tool/container_tool.py
+++ b/tool/container_tool.py
@@ -108,7 +108,11 @@ class ProjectContainerTool(BaseTool):
   def compile(self, extra_commands: str = '') -> sp.CompletedProcess:
     """Compiles the fuzz target."""
     command = 'compile > /dev/null' + extra_commands
-    return self.execute(command)
+    compile_process = self.execute(command)
+    # Hide Compilation command so that LLM won't reuse it in the inspection tool
+    # and be distracted by irrelevant errors, e.g., `build/ already exits`.
+    compile_process.args = '# Compiles the fuzz target.'
+    return compile_process
 
   def terminate(self) -> bool:
     """Terminates the container."""

--- a/tool/container_tool.py
+++ b/tool/container_tool.py
@@ -16,6 +16,7 @@ class ProjectContainerTool(BaseTool):
     super().__init__(benchmark, name)
     self.image_name = self._prepare_project_image()
     self.container_id = self._start_docker_container()
+    self._backup_default_build_script()
 
   def tutorial(self) -> str:
     """Constructs a tool guide tutorial for LLM agents."""
@@ -91,8 +92,6 @@ class ProjectContainerTool(BaseTool):
     result = self._execute_command(run_container_command)
     if result.returncode:
       logger.error('Failed to start container of image: %s', self.image_name)
-    else:
-      self._backup_default_build_script()
     container_id = result.stdout.strip()
     return container_id
 

--- a/tool/container_tool.py
+++ b/tool/container_tool.py
@@ -76,8 +76,8 @@ class ProjectContainerTool(BaseTool):
 
   def _backup_default_build_script(self) -> None:
     """Creates a copy of the human-written /src/build.sh for LLM to use"""
-    backup_command = ['cp', '/src/build.sh', '/src/build.bk.sh']
-    process = self._execute_command_in_container(backup_command)
+    backup_command = 'cp /src/build.sh /src/build.bk.sh'
+    process = self.execute(backup_command)
     if process.returncode:
       logger.error('Failed to create a backup of /src/build.sh: %s',
                    self.image_name)

--- a/tool/container_tool.py
+++ b/tool/container_tool.py
@@ -73,6 +73,14 @@ class ProjectContainerTool(BaseTool):
                    e)
       return sp.CompletedProcess(command, returncode=1, stdout='', stderr='')
 
+  def _backup_default_build_script(self) -> None:
+    """Creates a copy of the human-written /src/build.sh for LLM to use"""
+    backup_command = ['cp', '/src/build.sh', '/src/build.bk.sh']
+    process = self._execute_command_in_container(backup_command)
+    if process.returncode:
+      logger.error('Failed to create a backup of /src/build.sh: %s',
+                   self.image_name)
+
   def _start_docker_container(self) -> str:
     """Runs the project's OSS-Fuzz image as a background container and returns
     the container ID."""
@@ -83,6 +91,8 @@ class ProjectContainerTool(BaseTool):
     result = self._execute_command(run_container_command)
     if result.returncode:
       logger.error('Failed to start container of image: %s', self.image_name)
+    else:
+      self._backup_default_build_script()
     container_id = result.stdout.strip()
     return container_id
 


### PR DESCRIPTION
Fixing some issues revealed by full agent experiments earlier:
1. [x] LLM-generated build scripts do not save fuzz target binary into the correct path.
2. [x] Use default build script in the code fixing prompt in this scenario:
    1. The default build scripts builds successfully but failed other checks (i.e., reference), and
    2. The LLM-generated build script does not work.
3. [x] Selectively use the default built script and the LLM-generated built script, depending which is better.
4. [x] Use different code-fixing prompts based on which built script and which result it is:
    * default or LLM built script
    * No reference, no binary, or compilation failure
5. [x] Backup human-writtent `/src/build.sh` to `/src/build.bk.sh` in agent's containers in case LLM wants to reuse it in the new build script.
    * Create the same copy for fuzzing execution.
6. [x] Hide the compile command to prevent LLM from reusing it in the inspection tool and be distracted by irrelevant errors. E.g.:
    * The inspection container always runs compile before LLM analysis. Rerunning it may fail in some projects due to an existing /src/<project>/build directory.
7. [x] Prompt use example fuzz target in the language the same as the generated fuzz target, (not the project).
    * Also dynamically adjust instructions in priming. Do not leave LLM to judge which language the fuzz target is.
8. [x] Remove the agent log when receiving fuzz targets.
9. [x] Do not restrict LLM to send one bash command per query.


Also need to:
1. [ ] Use SemanticAnalyzer in agent workflow, at least to ensure the last Result is Analysis Result.
2. [ ] Add an Enhancer in agent workflow.
3. [ ] Use service account in GKE, hopefully this will solve the [`Service Unavailable` problem](https://github.com/google/oss-fuzz/pull/13042).