### PR TITLE
Fix validation for function reference

### DIFF
--- a/agent/one_prompt_prototyper.py
+++ b/agent/one_prompt_prototyper.py
@@ -236,6 +236,13 @@ class OnePromptPrototyper(BaseAgent):
       cur_round: int, trial: int) -> bool:
     """Validates if the LLM generated fuzz target assembly code references
     function-under-test."""
+
+    # LLVMFuzzerTestOneInput and binary dumps are only valid
+    # for C/C++ projects.
+    # Temporary skipping this check for other language.
+    if benchmark.language in ['jvm', 'python', 'rust']:
+      return True
+
     disassemble_result = compilation_tool.execute(
         'objdump --disassemble=LLVMFuzzerTestOneInput -d '
         f'/out/{benchmark.target_name}')

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -109,6 +109,13 @@ class Prototyper(BaseAgent):
       cur_round: int, trial: int) -> bool:
     """Validates if the LLM generated fuzz target assembly code references
     function-under-test."""
+
+    # LLVMFuzzerTestOneInput and binary dumps are only valid
+    # for C/C++ projects.
+    # Temporary skipping this check for other language.
+    if benchmark.language in ['jvm', 'python', 'rust']:
+      return True
+
     disassemble_result = compilation_tool.execute(
         'objdump --disassemble=LLVMFuzzerTestOneInput -d '
         f'/out/{benchmark.target_name}')


### PR DESCRIPTION
The new approach force the function reference check on the built binary for LLVMTestOneInput and this is only valid for C/C++ projects. This make the prototyper check always failed for other language. This PR temporary skip that validation for other languages which the validation is not valid.