### PR TITLE
pyproject: add results module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ py-modules = [
   "llm_toolkit.prompt_builder",
   "llm_toolkit.prompts",
   "llm_toolkit.models",
-  "utils"
+  "utils",
+  "results"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
otherwise `fuzz-generator` complaints about missing module