### PR TITLE
Fix prompt text return bug

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 import logger
 import utils
 from llm_toolkit.models import LLM
-from llm_toolkit.prompts import OpenAIPrompt, Prompt
+from llm_toolkit.prompts import Prompt
 from results import Result
 from tool.base_tool import BaseTool
 
@@ -116,10 +116,7 @@ class BaseAgent(ABC):
       previous_prompt: Optional[Prompt] = None) -> str:
     """Formats a prompt based on bash execution result."""
     if previous_prompt:
-      if isinstance(previous_prompt, OpenAIPrompt):
-        previous_prompt_text = previous_prompt.gettext()
-      else:
-        previous_prompt_text = previous_prompt.get()
+      previous_prompt_text = previous_prompt.gettext()
     else:
       previous_prompt_text = ''
     stdout = self.llm.truncate_prompt(process.stdout,

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 import logger
 import utils
 from llm_toolkit.models import LLM
-from llm_toolkit.prompts import Prompt
+from llm_toolkit.prompts import Prompt, OpenAIPrompt
 from results import Result
 from tool.base_tool import BaseTool
 
@@ -116,7 +116,10 @@ class BaseAgent(ABC):
       previous_prompt: Optional[Prompt] = None) -> str:
     """Formats a prompt based on bash execution result."""
     if previous_prompt:
-      previous_prompt_text = previous_prompt.get()
+      if isinstance(previous_prompt, OpenAIPrompt):
+        previous_prompt_text = previous_prompt.gettext()
+      else:
+        previous_prompt_text = previous_prompt.get()
     else:
       previous_prompt_text = ''
     stdout = self.llm.truncate_prompt(process.stdout,

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 import logger
 import utils
 from llm_toolkit.models import LLM
-from llm_toolkit.prompts import Prompt, OpenAIPrompt
+from llm_toolkit.prompts import OpenAIPrompt, Prompt
 from results import Result
 from tool.base_tool import BaseTool
 

--- a/llm_toolkit/prompts.py
+++ b/llm_toolkit/prompts.py
@@ -113,7 +113,7 @@ class OpenAIPrompt(Prompt):
   def gettext(self) -> str:
     """Retrieve, group and return all prompt text."""
     result = ''
-    for item in self._prompt:
+    for item in self.get():
       result = f'{result}\n{item.get("content", "")}'
 
     return result

--- a/llm_toolkit/prompts.py
+++ b/llm_toolkit/prompts.py
@@ -35,6 +35,10 @@ class Prompt:
     """Gets the final formatted prompt."""
 
   @abstractmethod
+  def gettext(self) -> Any:
+    """Gets the final formatted prompt in plain text."""
+
+  @abstractmethod
   def create_prompt_piece(self, content: str, role: str) -> Any:
     """Creates prompt based on the |content| and |role|."""
 
@@ -71,6 +75,10 @@ class TextPrompt(Prompt):
   def get(self) -> Any:
     """Gets the final formatted prompt."""
     return self._text
+
+  def gettext(self) -> Any:
+    """Gets the final formatted prompt in plain text."""
+    return self.get()
 
   def add_priming(self, priming_content: str) -> None:
     """Constructs the prompt priming in the required format."""
@@ -111,7 +119,7 @@ class OpenAIPrompt(Prompt):
     return self._prompt
 
   def gettext(self) -> str:
-    """Retrieve, group and return all prompt text."""
+    """Gets the final formatted prompt in plain text."""
     result = ''
     for item in self.get():
       result = f'{result}\n{item.get("content", "")}'

--- a/llm_toolkit/prompts.py
+++ b/llm_toolkit/prompts.py
@@ -110,6 +110,14 @@ class OpenAIPrompt(Prompt):
     """Gets the final formatted prompt."""
     return self._prompt
 
+  def gettext(self) -> str:
+    """Retrieve, group and return all prompt text."""
+    result = ''
+    for item in self._prompt:
+      result = f'{result}\n{item.get("content", "")}'
+
+    return result
+
   def add_priming(self, priming_content: str) -> None:
     """Constructs the prompt priming in the required format."""
     self._prompt.append({


### PR DESCRIPTION
OpenAIPrompt's get function will return a list of prompts with role and content instead of pure string. This will cause error in later bash result handling. This PR adds a new gettext() function in OpenAiPrompt to combine content string from multiple prompt to a single string for processing.