### PR TITLE
c-cpp: Add default value for --max_successful.

### DIFF
--- a/experimental/c-cpp/runner.py
+++ b/experimental/c-cpp/runner.py
@@ -359,7 +359,8 @@ def parse_commandline():
   parser.add_argument('--max_successful',
                       '-ma',
                       help='Max number of successful builds to generate.',
-                      type=int)
+                      type=int,
+                      default=-1)
   return parser.parse_args()
 
 


### PR DESCRIPTION
Otherwise we run into an exception when this evaluates to None.