### PR TITLE
Fix prompt truncation logic

### DIFF
--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -767,7 +767,7 @@ class GeminiV1D5Chat(GeminiV1D5):
     if allowed_tokens < marker_tokens:
       prefix_index = self._estimate_char_index(allowed_tokens, raw_prompt_text)
       logger.warning('Insufficient tokens to add marker: %d', allowed_tokens)
-      return self.truncate_prompt(raw_prompt_text[:prefix_index], extra_tokens)
+      return self.truncate_prompt(raw_prompt_text[:prefix_index], extra_text)
 
     # Prefix of the truncated prompt, 100 tokens by default.
     prefix_tokens = min(100, allowed_tokens - marker_tokens)

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -748,14 +748,15 @@ class GeminiV1D5Chat(GeminiV1D5):
                       raw_prompt_text: Any,
                       extra_text: Any = None) -> Any:
     """Truncates the prompt text to fit in MAX_INPUT_TOKEN."""
-    # TODO(dongge): Move this to prompt builder (e.g., `append()`), dynamically
-    # reduce extra_text size if there is no space for raw_prompt_text.
-
     extra_text = extra_text or ''
     extra_tokens = self.estimate_token_num(extra_text)
     total_tokens = self.estimate_token_num(raw_prompt_text)
 
     # Allow buffer space for potential prompts that will be appended later.
+    # Allocates 1/10 of MAX_INPUT_TOKEN per prompt text block, assuming up to 10
+    # blocks in the final prompt.
+    # TODO(dongge): Move this to prompt builder (e.g., `append()`), dynamically
+    # reduce each prompt text block if there is no space for raw_prompt_text.
     allowed_tokens = self.MAX_INPUT_TOKEN // 10 - extra_tokens
     if allowed_tokens <= 0:
       logger.warning('Insufficient tokens to add any text: %d, %d',

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -270,7 +270,7 @@ def parse_args() -> argparse.Namespace:
   parser.add_argument('-mr',
                       '--agent-max-round',
                       type=int,
-                      default=100,
+                      default=10,
                       help='Max trial round for agents.')
 
   args = parser.parse_args()

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -270,7 +270,7 @@ def parse_args() -> argparse.Namespace:
   parser.add_argument('-mr',
                       '--agent-max-round',
                       type=int,
-                      default=10,
+                      default=100,
                       help='Max trial round for agents.')
 
   args = parser.parse_args()


### PR DESCRIPTION
Given an overlong prompt, we want to truncate it to:
```
<prompt short initial text>
...(truncated due to exceeding input token limit)...
<prompt long ending text>
```

Where `...(truncated due to exceeding input token limit)...` replaces sufficient prompt text so that the final prompt is within token limit.