### PR TITLE
Make number of rounds flexible in PR experiments

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -43,7 +43,7 @@ class BaseAgent(ABC):
     self.args = args
     self.name: str = name or self.__class__.__name__
     self.chat_history: str = ''  # Communication history between LLM and tool.
-    self.max_round = self.args.agent_max_round
+    self.max_round = self.args.max_round
 
   def __repr__(self) -> str:
     return self.__class__.__name__

--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -31,7 +31,7 @@ spec:
         # Modify the follow command to customize one-off experiments.
         # For benchmark sets that need more disk, increase the results volume
         # size too.
-        command: ["/bin/bash", "report/docker_run.sh", "${GKE_EXP_BENCHMARK}", "${GKE_EXP_NAME}", "${GKE_EXP_FUZZING_TIMEOUT}", "ofg-pr", "${GKE_EXP_LLM}", "${GKE_EXP_DELAY}", "${GKE_EXP_LOCAL_INTROSPECTOR}", "${GKE_EXP_NUM_SAMPLES}", "${GKE_EXP_LLM_FIX_LIMIT}", "${GKE_EXP_VARY_TEMPERATURE}", "${GKE_EXP_AGENT}"]
+        command: ["/bin/bash", "report/docker_run.sh", "${GKE_EXP_BENCHMARK}", "${GKE_EXP_NAME}", "${GKE_EXP_FUZZING_TIMEOUT}", "ofg-pr", "${GKE_EXP_LLM}", "${GKE_EXP_DELAY}", "${GKE_EXP_LOCAL_INTROSPECTOR}", "${GKE_EXP_NUM_SAMPLES}", "${GKE_EXP_LLM_FIX_LIMIT}", "${GKE_EXP_VARY_TEMPERATURE}", "${GKE_EXP_AGENT}", "${GKE_EXP_MAX_ROUND}"]
         securityContext:
           privileged: true
         resources:

--- a/ci/request_pr_exp.py
+++ b/ci/request_pr_exp.py
@@ -51,6 +51,7 @@ LARGE_REQUEST_MEM = 1000
 NUM_SAMPLES = 2
 NUM_FIXES = 2
 VARY_TEMPERATURE = True
+MAX_ROUND = 100
 
 PR_LINK_PREFIX = 'https://github.com/google/oss-fuzz-gen/pull'
 JOB_LINK_PREFIX = ('https://console.cloud.google.com/kubernetes/job/'
@@ -159,6 +160,11 @@ def _parse_args(cmd) -> argparse.Namespace:
       default=VARY_TEMPERATURE,
       help=('Use different temperatures for each sample, default: '
             f'{VARY_TEMPERATURE}'))
+  parser.add_argument('-mr',
+                      '--max-round',
+                      type=int,
+                      default=MAX_ROUND,
+                      help=f'Max trial round for agents, default: {MAX_ROUND}.')
   parser.add_argument('-ag',
                       '--agent',
                       action='store_true',
@@ -196,6 +202,9 @@ def _parse_args(cmd) -> argparse.Namespace:
     args.request_memory = LARGE_REQUEST_MEM
     args.gke_template = LARGE_TEMPLATE_PATH
 
+  if (args.max_round == 100 and
+      any(args.name_suffix.startswith(suffix) for suffix in ['ascc-', 'dgk-'])):
+    args.max_round = 10
   return args
 
 
@@ -312,6 +321,7 @@ def _fill_template(args: argparse.Namespace) -> str:
   exp_env_vars['GKE_EXP_VARY_TEMPERATURE'] = f'{args.vary_temperature}'.lower()
   exp_env_vars['GKE_EXP_AGENT'] = f'{args.agent}'.lower()
   exp_env_vars['GKE_REDIRECT_OUTS'] = 'true' if args.redirect_outs else ''
+  exp_env_vars['GKE_EXP_MAX_ROUND'] = args.max_round
 
   with open(args.gke_template, 'r') as file:
     yaml_template = file.read()

--- a/report/docker_run.sh
+++ b/report/docker_run.sh
@@ -39,6 +39,7 @@ NUM_SAMPLES=$8
 LLM_FIX_LIMIT=$9
 VARY_TEMPERATURE=${10}
 AGENT=${11}
+MAX_ROUND=${12:-100}
 
 # Uses python3 by default and /venv/bin/python3 for Docker containers.
 PYTHON="$( [[ -x "/venv/bin/python3" ]] && echo "/venv/bin/python3" || echo "python3" )"
@@ -167,6 +168,7 @@ then
     --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
     --temperature-list "${VARY_TEMPERATURE[@]}" \
     --model "$MODEL" \
+    --max-round "$MAX_ROUND" \
     $AGENT_ARG
 else
   $PYTHON run_all_experiments.py \
@@ -182,6 +184,7 @@ else
     --introspector-endpoint ${INTROSPECTOR_ENDPOINT} \
     --temperature-list "${VARY_TEMPERATURE[@]}" \
     --model "$MODEL" \
+    --max-round "$MAX_ROUND" \
     $AGENT_ARG >> $LOCAL_RESULTS_DIR/logs-from-run.txt 2>&1
 fi
 

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -268,9 +268,9 @@ def parse_args() -> argparse.Namespace:
                       default=False,
                       help='Enables agent enhancement.')
   parser.add_argument('-mr',
-                      '--agent-max-round',
+                      '--max-round',
                       type=int,
-                      default=10,
+                      default=100,
                       help='Max trial round for agents.')
 
   args = parser.parse_args()


### PR DESCRIPTION
Now we can customize the max number of agent rounds in PR experiments with `--max-round` or `-mr`.