### PR TITLE
Fix Incorrect Benchmark Status on Report's Index Page

### DIFF
--- a/report/common.py
+++ b/report/common.py
@@ -267,9 +267,16 @@ class Results:
                FileSystem(self._results_dir).listdir()))
 
   def match_benchmark(self, benchmark_id: str, results: list[evaluator.Result],
-                      targets: list[str]) -> Benchmark:
+                  targets: list[str]) -> Benchmark:
     """Returns a benchmark class based on |benchmark_id|."""
-    status = 'Done' if results and all(results) else 'Running'
+    # Check if all expected trials are present and completed
+    total_expected_trials = len(targets)
+    total_present_trials = len(results)
+    
+    # Mark as 'Done' only if all expected trials are present and completed
+    status = 'Done' if (total_present_trials == total_expected_trials and 
+                        results and all(results)) else 'Running'
+    
     filtered_results = [(i, stat) for i, stat in enumerate(results) if stat]
 
     if filtered_results:


### PR DESCRIPTION
**Description**
This PR fixes issue #721 where the benchmark status is incorrectly reported as 'Done' when not all trials are accounted for. Currently, the status is determined solely by the trials included in the report, leading to misleading statuses when some trials are still pending.

**Changes**
Modified the match_benchmark method in the Results class to properly check if all expected trials are present and completed before marking a benchmark as 'Done'.

**Implementation Details**
The fix compares the number of trials in the results list with the total expected number of trials for the benchmark (from the targets list). It sets the status to 'Done' only if all expected trials are present and completed.