### PR TITLE
Report: Add line numbers to fuzz targets

### DIFF
--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -66,6 +66,40 @@ tbody tr:nth-child(odd) {
     overflow: scroll;
     margin-left: auto;
 }
+
+.code-container {
+    display: flex;
+    border: 1px solid #dedede;
+    background-color: #f8f8f8;
+    overflow-x: auto;
+    font-family: monospace;
+    width: fit-content;
+    max-width: 100%;
+}
+
+.line-numbers {
+    margin: 0;
+    padding: 0.5em;
+    text-align: right;
+    background-color: #f0f0f0;
+    border-right: 1px solid #ddd;
+    user-select: none;
+    min-width: 2.5em;
+    color: #999;
+}
+
+.code-content {
+    margin: 0;
+    padding: 0.5em;
+    flex-grow: 0;
+}
+
+.line-numbers span,
+.code-content code {
+    display: block;
+    line-height: 1.5;
+    white-space: pre;
+}
 </style>
 <body>
     LLM: {{ model }}

--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -52,9 +52,10 @@ Crash reason: {{ sample.result.semantic_error }}
 {% else %}
 <h3>Code #{{ loop.index - 1}}</h3>
 {% endif %}
-<pre>
-{{ target.code }}
-</pre>
+<div class="code-container">
+    <pre class="line-numbers">{% for line in target.code.splitlines() %}<span>{{ loop.index }}</span>{% endfor %}</pre>
+    <pre class="code-content">{% for line in target.code.splitlines() %}<code>{{ line }}</code>{% endfor %}</pre>
+</div>
 {% endfor %}
 
 <h2>Logs</h2>


### PR DESCRIPTION
### Changes

Modified the report templates in `base.html` and `sample.html`:

- Added CSS styling for a two-column code display layout (line numbers + code content)
- Implemented a responsive code container with proper overflow handling for long lines
- Updated the `sample.html` template to use `splitlines()` for proper line-by-line display

### Testing

Tested the solution by viewing fuzz targets with varying code complexity:

- Simple fuzz targets with minimal code
- Complex targets with many lines and various indentation levels
- Code with extra-long lines that require horizontal scrolling

Fixes #335
 
### Demo

https://github.com/user-attachments/assets/70d4a1ea-8e6f-41c9-a9a1-e67cb0bd862d

_Note: The demo uses static sample example code and doesn't contain any sensitive data._