### PR TITLE
Unify cached images

### DIFF
--- a/benchmark-sets/comparison/expat.yaml
+++ b/benchmark-sets/comparison/expat.yaml
@@ -1,0 +1,11 @@
+"functions":
+- "name": "XML_ResumeParser"
+  "params":
+  - "name": "parser"
+    "type": "bool "
+  "return_type": "int"
+  "signature": "DW_TAG_enumeration_typeXML_Status XML_ResumeParser(XML_Parser)"
+"language": "c++"
+"project": "expat"
+"target_name": "xml_parsebuffer_fuzzer_UTF-8"
+"target_path": "/src/expat/expat/fuzz/xml_parsebuffer_fuzzer.c"

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -489,7 +489,22 @@ def prepare_project_image(project: str) -> str:
     rewrite_project_to_cached_project(project, project, 'address')
     # Prepare build
     prepare_build(project, 'address', project)
-    logger.info('Using cached project image for %s', project)
-    return image_name
+    # Build the image
+    command = [
+        'docker', 'build', '-t', image_name,
+        os.path.join('projects', project)
+    ]
+    try:
+      sp.run(command,
+             cwd=OSS_FUZZ_DIR,
+             stdin=sp.DEVNULL,
+             stdout=sp.PIPE,
+             stderr=sp.PIPE,
+             check=True)
+      logger.info('Using cached project image for %s: %s', project, image_name)
+      return image_name
+    except sp.CalledProcessError as e:
+      logger.warning('Failed to build image for %s: %s', project, e)
+
   logger.warning('Unable to find cached project image for %s', project)
   return _build_image(project)

--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -483,9 +483,12 @@ def _build_image(project_name: str) -> str:
 def prepare_project_image(project: str) -> str:
   """Prepares original image of the |project|'s fuzz target build container."""
   image_name = f'gcr.io/oss-fuzz/{project}'
-  if (ENABLE_CACHING and is_image_cached(project, 'address') and
-      (_image_exists_locally(image_name, project_name=project) or
-       _image_exists_online(image_name, project_name=project))):
+  if ENABLE_CACHING and is_image_cached(project, 'address'):
+    logger.info('We should use cached instance.')
+    # Rewrite for caching.
+    rewrite_project_to_cached_project(project, project, 'address')
+    # Prepare build
+    prepare_build(project, 'address', project)
     logger.info('Using cached project image for %s', project)
     return image_name
   logger.warning('Unable to find cached project image for %s', project)


### PR DESCRIPTION
Unify the way to use cached images when building the fuzz targets in agents and Execution stage.