### PR TITLE
Add line numbers to harness code in reports

### DIFF
--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -53,7 +53,7 @@ Crash reason: {{ sample.result.semantic_error }}
 <h3>Code #{{ loop.index - 1}}</h3>
 {% endif %}
 <pre>
-{{ target.code }}
+{{ target.code | add_line_numbers }}
 </pre>
 {% endfor %}
 

--- a/report/web.py
+++ b/report/web.py
@@ -65,6 +65,22 @@ class JinjaEnv:
       return link_path + 'index.html'
     return link_path + 'report.html'
 
+  @staticmethod
+  def _add_line_numbers(code_text):
+    """Add line numbers to code text."""
+    if not code_text:
+        return code_text
+    
+    numbered_lines = []
+    lines = code_text.split('\n')
+    line_number_width = len(str(len(lines)))
+    
+    for i, line in enumerate(lines, 1):
+        line_num = str(i).rjust(line_number_width)
+        numbered_lines.append(f"{line_num}: {line}")
+    
+    return '\n'.join(numbered_lines)
+
   def __init__(self, template_globals: Optional[Dict[str, Any]] = None):
     self._env = jinja2.Environment(
         loader=jinja2.FileSystemLoader("report/templates"),
@@ -73,6 +89,7 @@ class JinjaEnv:
     self._env.filters['urlencode_filter'] = self._urlencode_filter
     self._env.filters['percent'] = self._percent
     self._env.filters['cov_report_link'] = self._cov_report_link
+    self._env.filters['add_line_numbers'] = self._add_line_numbers
 
     if template_globals:
       for key, val in template_globals.items():


### PR DESCRIPTION
# Add line numbers to harness code in reports

Fixes #579

## Description
This PR adds line numbers to code blocks in the OSS-Fuzz-gen reports, making it easier to reference specific lines when triaging issues. When debugging crashes, stack traces often reference line numbers, and this change allows for easier correlation between stack traces and the displayed code.

## Implementation Details
- Added a new `_add_line_numbers` filter function to `JinjaEnv` class in `report/web.py`
- Applied the filter to code blocks in `sample.html` template
- Line numbers are right-aligned with the proper width based on total number of lines

## Testing
Verified the implementation works with different code lengths and content types
Ensured line numbers are properly aligned and formatted

## Screenshots
Earlier: 
<img width="1674" alt="Screenshot 2025-03-14 at 4 48 26 PM" src="https://github.com/user-attachments/assets/e02f32fc-6ef8-4d0f-84cc-60ac21ee5091" />

Updated:

<img width="1680" alt="Screenshot 2025-03-14 at 4 48 43 PM" src="https://github.com/user-attachments/assets/9b9ec5ce-5546-4d26-ab58-57fb7dfc418d" />