### PR TITLE
Add `.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 __pycache__/
 *.swp
 *.egg-info
+.vscode/


### PR DESCRIPTION
This PR adds `.vscode`, which contains configurations such as a `launch.json` for [debugging code with breakpoints on VSCode/Cursor](https://code.visualstudio.com/docs/editor/debugging), to `.gitignore` so that these local configs are not included as part of the git working tree.