### PR TITLE
Move 5 Minute Sleep in Background Process for Immediate Task Invocation

### DIFF
--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -345,12 +345,12 @@ def extend_report_with_coverage_gains_process():
   """A process that continuously runs to update coverage gains in the
   background."""
   while True:
-    time.sleep(300)  # 5 minutes.
     try:
       extend_report_with_coverage_gains()
     except Exception:
       logger.error('Failed to extend report with coverage gains')
       traceback.print_exc()
+    time.sleep(300)  # 5 minutes.
 
 
 def _print_experiment_result(result: Result):


### PR DESCRIPTION
Wanted to put up a quick PR to move the invocation of the `time.sleep(300)` within `extend_report_with_coverage_gains_process()`, which currently runs infinitely in a background process until the main program finishes, to after the initial invocation of the task.

I'm unsure if having the sleep here before `extend_report_with_coverage_gains()` is deliberate. If not, I believe putting the `time.sleep(300)` _**after**_ each invocation of the experiment is more intuitive and a slightly better user experience, as there's not an initial 5 minute wait where the process is not doing anything 