### PR TITLE
Adding a header with logo and status indicator enhancements for benchmark reports

### DIFF
--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -66,8 +66,35 @@ tbody tr:nth-child(odd) {
     overflow: scroll;
     margin-left: auto;
 }
+.dashboard-title {
+  display: flex;
+  justify-content: center;
+  padding: 15px 0;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  background-color: #f8f9fa;
+  width: 100%;
+}
+
+.dashboard-title h1 {
+  display: flex;
+  align-items: center;
+  font-size: 24px;
+  font-weight: 500;
+  margin: 0;
+}
+
+.logo {
+  vertical-align: middle;
+  margin-right: 10px;
+  height: 32px;
+  width: auto;
+} 
+
 </style>
 <body>
+    <div class="dashboard-title">
+        <h1><img class="logo"  src="https://avatars.githubusercontent.com/u/1342004?s=48&v=4" alt="Fuzzing Dashboard" />OSS Fuzz Gen Report</h1>
+    </div>
     LLM: {{ model }}
     {% block content %}{% endblock %}
 </body>

--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -94,7 +94,7 @@ tbody tr:nth-child(odd) {
 <body>
     <div class="dashboard-title">
         <h1><img class="logo"  src="https://avatars.githubusercontent.com/u/1342004?s=48&v=4" alt="Fuzzing Dashboard" />OSS Fuzz Gen Report</h1>
-    </div>
+    </div> 
     LLM: {{ model }}
     {% block content %}{% endblock %}
 </body>

--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -94,7 +94,7 @@ tbody tr:nth-child(odd) {
 <body>
     <div class="dashboard-title">
         <h1><img class="logo"  src="https://avatars.githubusercontent.com/u/1342004?s=48&v=4" alt="Fuzzing Dashboard" />OSS Fuzz Gen Report</h1>
-    </div> 
+    </div>
     LLM: {{ model }}
     {% block content %}{% endblock %}
 </body>

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -61,6 +61,49 @@ td .signature {
     content: ' \25b4';
     color: #000;
 }
+.status-indicator {
+  display: inline-block;
+  width: 80px;
+  height: 16px;
+  border-radius: 8px;
+  background-color: #e0e0e0;
+  margin-right: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+.status-indicator-fill {
+  height: 100%;
+  border-radius: 8px;
+  transition: width 0.5s ease;
+}
+
+.status-running .status-indicator-fill {
+  background-color: #FFC107; /* Yellow for running */
+  width: 60%;
+  animation: pulse 1.5s infinite;
+}
+
+.status-success .status-indicator-fill {
+  background-color: #4CAF50; /* Green for success */
+  width: 100%;
+}
+
+.status-failed .status-indicator-fill {
+  background-color: #F44336; /* Red for failed */
+  width: 100%;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.6; }
+  50% { opacity: 1; }
+  100% { opacity: 0.6; }
+}
+
+.status-text {
+  display: inline-block;
+  vertical-align: middle;
+}
 
 </style>
 
@@ -87,7 +130,12 @@ td .signature {
                     <a href="benchmark/{{ benchmark.id|urlencode }}/index.html">{{ benchmark.signature }}</a>
                 </pre>
             </td>
-            <td data-sort-value="{{ benchmark.status }}">{{ benchmark.status }}</td>
+            <td data-sort-value="{{ benchmark.status }}">
+                <div class="status-indicator status-{{ benchmark.status|lower }}">
+                  <div class="status-indicator-fill"></div>
+                </div>
+                <span class="status-text">{{ benchmark.status }}</span>
+              </td>
             <td data-sort-value="{{ benchmark.result.build_success_rate|percent }}">{{ benchmark.result.build_success_rate|percent}}</td>
             <td data-sort-value="{{ benchmark.result.crash_rate|percent }}"><a href="benchmark/{{ benchmark.id|urlencode }}/crash.json"> {{ benchmark.result.crash_rate|percent }} </a></td>
             <td data-sort-value="{{ benchmark.result.found_bug }}">{{ benchmark.result.found_bug }}</td>


### PR DESCRIPTION
Improved the UI for the report generation system 

- Added a centered header in base.html with the Google logo and 'OSS Fuzz Gen Report' title, providing better context for the report page

- Enhanced the status visualization in benchmark tables with an intuitive tube-like indicator that shows:
  - Yellow partially-filled tube for 'Running' status
  - Green fully-filled tube for 'Success' status
  - Red fully-filled tube for 'Failed' status
  
![Screenshot 2025-03-15 at 11 15 49 PM](https://github.com/user-attachments/assets/8dc5a415-e6d5-4f20-9ad1-2ffd1e4d6c8b)



