### PR TITLE
Add syntax highlighting to code blocks in reports

### DIFF
--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -100,7 +100,30 @@ tbody tr:nth-child(odd) {
     line-height: 1.5;
     white-space: pre;
 }
+
+.hljs {
+    background: transparent;
+    padding: 0;
+}
 </style>
+<!-- added highlight.js for syntax highlighting -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+<!-- some Additional language -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/bash.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/c.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/cpp.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/java.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/python.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/rust.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/go.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', (event) => {
+    document.querySelectorAll('pre code.syntax-highlight').forEach((block) => {
+        hljs.highlightElement(block);
+    });
+});
+</script>
 <body>
     LLM: {{ model }}
     {% block content %}{% endblock %}

--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -16,7 +16,7 @@ limitations under the License.
 #}{% extends 'base.html' %}
 
 {% block content %}
-<h1>{{ benchmark }} / {{ sample.id }}</h1>
+<h1>{{ benchmark_id }} / {{ sample.id }}</h1>
 Bug: {{ sample.result.crashes and not sample.result.is_semantic_error }}
 <br>
 Crash reason: {{ sample.result.semantic_error }}
@@ -52,10 +52,19 @@ Crash reason: {{ sample.result.semantic_error }}
 {% else %}
 <h3>Code #{{ loop.index - 1}}</h3>
 {% endif %}
+
 <div class="code-container">
     <pre class="line-numbers">{% for line in target.code.splitlines() %}<span>{{ loop.index }}</span>{% endfor %}</pre>
-    <pre class="code-content">{% for line in target.code.splitlines() %}<code>{{ line }}</code>{% endfor %}</pre>
+    <pre class="code-content"><code class="syntax-highlight language-{% if benchmark.language %}{{ benchmark.language | lower }}{% else %}plaintext{% endif %}">{{ target.code }}</code></pre>
 </div>
+
+{% if target.build_script_code %}
+<h3>Build Script</h3>
+<div class="code-container">
+    <pre class="line-numbers">{% for line in target.build_script_code.splitlines() %}<span>{{ loop.index }}</span>{% endfor %}</pre>
+    <pre class="code-content"><code class="syntax-highlight language-bash">{{ target.build_script_code }}</code></pre>
+</div>
+{% endif %}
 {% endfor %}
 
 <h2>Logs</h2>

--- a/report/web.py
+++ b/report/web.py
@@ -235,7 +235,8 @@ class GenerateReport:
     try:
       rendered = self._jinja.render(
           'sample.html',
-          benchmark=benchmark.id,
+          benchmark=benchmark,
+          benchmark_id=benchmark.id,
           sample=sample,
           logs=self._results.get_logs(benchmark.id, sample.id),
           run_logs=self._results.get_run_logs(benchmark.id, sample.id),


### PR DESCRIPTION

This PR enhances the report UI by adding syntax highlighting to both fuzz target code and build script code:
reference: https://github.com/google/oss-fuzz-gen/pull/867#issuecomment-2727001909
CC: @DonggeLiu 

- **Fuzz Target Code**: Applies language-specific highlighting based on benchmark YAML language field.
- **Build Scripts**: Used Bash syntax highlighting for all build scripts.
- **Separation of Code Sections**: Properly separates build script code from fixer prompts.

## Implementation Details

- Added `highlight.js` library to `base.html`
- Enhanced `Benchmark` class with language field and extraction from YAML files
- Updated `Target` class to separate build script code from fixer prompts
- Modified `templates` to apply appropriate syntax highlighting

## Testing

- Changes have been tested with a standalone test page that demonstrates syntax highlighting for different programming languages.
- The syntax highlighting applies correctly to all dynamically generated report pages.

## Screenshots
<img width="1169" alt="Screenshot 2025-03-17 at 2 57 32 AM" src="https://github.com/user-attachments/assets/0d5e7730-9bed-4885-b6fd-d6644b0a8a48" />
<img width="1168" alt="Screenshot 2025-03-17 at 2 57 40 AM" src="https://github.com/user-attachments/assets/4ea4764c-0c88-4cd6-87f7-ae74a635a1b5" />
<img width="1107" alt="Screenshot 2025-03-17 at 2 57 50 AM" src="https://github.com/user-attachments/assets/34acf0a7-a704-4233-8ba5-8e2539d04af0" />

