### PR TITLE
Enhance Report UI by Removing Trailing Empty Lines from Code Blocks

### DIFF
--- a/report/templates/sample.html
+++ b/report/templates/sample.html
@@ -16,7 +16,7 @@ limitations under the License.
 #}{% extends 'base.html' %}
 
 {% block content %}
-<h1>{{ benchmark }} / {{ sample.id }}</h1>
+<h1>{{ benchmark_id }} / {{ sample.id }}</h1>
 Bug: {{ sample.result.crashes and not sample.result.is_semantic_error }}
 <br>
 Crash reason: {{ sample.result.semantic_error }}
@@ -52,10 +52,19 @@ Crash reason: {{ sample.result.semantic_error }}
 {% else %}
 <h3>Code #{{ loop.index - 1}}</h3>
 {% endif %}
+
 <div class="code-container">
-    <pre class="line-numbers">{% for line in target.code.splitlines() %}<span>{{ loop.index }}</span>{% endfor %}</pre>
-    <pre class="code-content">{% for line in target.code.splitlines() %}<code>{{ line }}</code>{% endfor %}</pre>
+    <pre class="line-numbers">{% for line in target.code|remove_trailing_empty_lines|splitlines %}<span>{{ loop.index }}</span>{% endfor %}</pre>
+    <pre class="code-content"><code class="syntax-highlight language-{% if benchmark.language %}{{ benchmark.language | lower }}{% else %}plaintext{% endif %}">{{ target.code|remove_trailing_empty_lines }}</code></pre>
 </div>
+
+{% if target.build_script_code %}
+<h3>Build Script</h3>
+<div class="code-container">
+    <pre class="line-numbers">{% for line in target.build_script_code|remove_trailing_empty_lines|splitlines %}<span>{{ loop.index }}</span>{% endfor %}</pre>
+    <pre class="code-content"><code class="syntax-highlight language-bash">{{ target.build_script_code|remove_trailing_empty_lines }}</code></pre>
+</div>
+{% endif %}
 {% endfor %}
 
 <h2>Logs</h2>

--- a/report/web.py
+++ b/report/web.py
@@ -65,6 +65,18 @@ class JinjaEnv:
       return link_path + 'index.html'
     return link_path + 'report.html'
 
+  @staticmethod
+  def _remove_trailing_empty_lines(code: str) -> str:
+    """Remove trailing empty lines from code."""
+    if not code:
+      return code
+    
+    lines = code.splitlines()
+    while lines and not lines[-1].strip():
+      lines.pop()
+    
+    return '\n'.join(lines)
+
   def __init__(self, template_globals: Optional[Dict[str, Any]] = None):
     self._env = jinja2.Environment(
         loader=jinja2.FileSystemLoader("report/templates"),
@@ -73,6 +85,7 @@ class JinjaEnv:
     self._env.filters['urlencode_filter'] = self._urlencode_filter
     self._env.filters['percent'] = self._percent
     self._env.filters['cov_report_link'] = self._cov_report_link
+    self._env.filters['remove_trailing_empty_lines'] = self._remove_trailing_empty_lines
 
     if template_globals:
       for key, val in template_globals.items():
@@ -235,7 +248,8 @@ class GenerateReport:
     try:
       rendered = self._jinja.render(
           'sample.html',
-          benchmark=benchmark.id,
+          benchmark=benchmark,
+          benchmark_id=benchmark.id,
           sample=sample,
           logs=self._results.get_logs(benchmark.id, sample.id),
           run_logs=self._results.get_run_logs(benchmark.id, sample.id),


### PR DESCRIPTION

This PR enhances the report UI by automatically removing trailing empty lines from both fuzz target code and build script code displays

Reference: https://github.com/google/oss-fuzz-gen/pull/867#issuecomment-2727001909
CC: @DonggeLiu 

## Features
- Automatically removes unnecessary trailing empty lines from all code blocks.
- Eliminates excess vertical whitespace at the end of fuzz target code snippets.
- Removes trailing empty lines from build script code blocks.

## Implementation Details
- Added `remove_trailing_empty_lines` filter function to process code before display.
- Implemented the filter in the report template system to apply to all code blocks.
- Maintained the original line numbering system while eliminating unnecessary whitespace.

## ScreenShots
### Before
<img width="636" alt="Screenshot 2025-03-17 at 4 21 24 AM" src="https://github.com/user-attachments/assets/df1b91e2-790d-4ea3-b3c8-852cb462f8a3" />

### After
<img width="605" alt="Screenshot 2025-03-17 at 4 21 29 AM" src="https://github.com/user-attachments/assets/5d9970ed-d0d6-4c1d-a81a-570b41a4daed" />
