### PR TITLE
Extend web.py and add local hot reload

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -171,10 +171,13 @@ python -m report.web -r <results-dir> -o <output-dir>
 python -m http.server <port> -d <output-dir>
 ```
 Where `<results-dir>` is the directory passed to `--work-dir` in your
-experiments (default value `./results`).
+experiments (default value `./results`). 
 
 Then navigate to `http://localhost:<port>` to view the result in [a table](#result-table).
 
+> Tip:
+You can also pass `-w` to watch for changes in `results-dir` and automatically
+update the results report. Refresh the page to see the updated report.
 
 ## Detailed workflows
 Configure and use framework in the following steps:

--- a/report/web.py
+++ b/report/web.py
@@ -28,7 +28,6 @@ from typing import Any, Dict, List, Optional
 
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
-import subprocess
 import threading
 
 
@@ -263,10 +262,12 @@ class ReportWatcher(FileSystemEventHandler):
     self.server = None  
     
     if args.watch_filesystem:
+      logging.info(f"Watching filesystem for changes in {args.results_dir}")
       self.observer.schedule(self, args.results_dir, recursive=True)
         
     if args.watch_template:
-      self.observer.schedule(self, "report/", recursive=True)
+      logging.info(f"DEV: Watching for changes in the report folder")
+      self.observer.schedule(self, "report", recursive=True)
 
     if args.serve:
       self.server_thread = threading.Thread(target=self._start_server)
@@ -292,6 +293,7 @@ class ReportWatcher(FileSystemEventHandler):
     self.observer.join()
 
   def on_modified(self, event):
+    """Restart the server when the watcher detects a change"""
     logging.info(f"{event.src_path} has been modified. Regenerating report...")
     generate_report(self.args)
     

--- a/report/web.py
+++ b/report/web.py
@@ -301,6 +301,19 @@ def _parse_arguments() -> argparse.Namespace:
                       help='Port to launch webserver on.',
                       type=int,
                       default=8012)
+  parser.add_argument('--interval-seconds',
+                      '-i',
+                      help='Interval in seconds to generate report.',
+                      type=int,
+                      default=600)
+  parser.add_argument('--watch-filesystem',
+                      '-w',
+                      help='Watch filesystem for changes and generate report.',
+                      action='store_true')
+  parser.add_argument('--watch-template',
+                      '-t',
+                      help='Watch the report templates for changes and generate report. For development purposes.',
+                      action='store_true')
 
   return parser.parse_args()
 


### PR DESCRIPTION
Related discussion #862 

This PR extends the command line parser in [`web.py`](https://github.com/google/oss-fuzz-gen/blob/main/report/web.py) to take in some additional inputs as outlined [here](https://github.com/google/oss-fuzz-gen/issues/862#issuecomment-2727160204). It also adds an optional server-side hot-reloading functionality with the `watchdog` library. 

Happy to iterate upon this @DonggeLiu!