### PR TITLE
Store trial count in report.json instead of environment variable

### DIFF
--- a/report/common.py
+++ b/report/common.py
@@ -284,11 +284,16 @@ class Results:
 
   def _get_expected_trials_count(self, benchmark_id: str) -> int:
     """Returns the expected number of trials for a benchmark."""
-    env_trial_count = os.environ.get('BENCHMARK_TRIAL_COUNT')
-    if env_trial_count:
+    # First try to get the value from report.json
+    report_path = os.path.join(self._results_dir, 'report.json')
+    if os.path.exists(report_path):
       try:
-        return int(env_trial_count)
-      except ValueError:
+        with open(report_path, 'r') as f:
+          report_data = json.load(f)
+          if 'num_samples' in report_data:
+            return report_data['num_samples']
+      except (json.JSONDecodeError, OSError):
+        # If there's an error reading the file, continue to fallbacks
         pass
 
     # Check fuzz_targets directory for new experiments

--- a/report/common.py
+++ b/report/common.py
@@ -286,15 +286,14 @@ class Results:
     """Returns the expected number of trials for a benchmark."""
     # First try to get the value from report.json
     report_path = os.path.join(self._results_dir, 'report.json')
-    if os.path.exists(report_path):
-      try:
-        with open(report_path, 'r') as f:
-          report_data = json.load(f)
-          if 'num_samples' in report_data:
-            return report_data['num_samples']
-      except (json.JSONDecodeError, OSError):
-        # If there's an error reading the file, continue to fallbacks
-        pass
+    try:
+      with open(report_path, 'r') as f:
+        report_data = json.load(f)
+        if 'num_samples' in report_data:
+          return report_data['num_samples']
+    except (json.JSONDecodeError, OSError, FileNotFoundError):
+      # If there's an error reading the file, continue to fallbacks
+      pass
 
     # Check fuzz_targets directory for new experiments
     fuzz_targets_dir = os.path.join(self._results_dir, benchmark_id,

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -535,13 +535,12 @@ def main():
   _setup_logging(args.log_level, is_cloud=args.cloud_experiment_name != '')
   logger.info('Starting experiments on PR branch')
 
-  # Store the trial count in an environment variable
-  os.environ['BENCHMARK_TRIAL_COUNT'] = str(args.num_samples)
-
   # Capture time at start
   start = time.time()
   add_to_json_report(args.work_dir, 'start_time',
                      time.strftime(TIME_STAMP_FMT, time.gmtime(start)))
+  # Add num_samples to report.json
+  add_to_json_report(args.work_dir, 'num_samples', args.num_samples)
 
   # Set introspector endpoint before performing any operations to ensure the
   # right API endpoint is used throughout.


### PR DESCRIPTION
### Changes

These changes are based on the discussion in #859.

- Removed environment variable for storing `num_samples` from `run_all_experiments.py`
- Added trial count directly to `report.json` using existing `add_to_json_report` function
- Modified `_get_expected_trials_count()` to first check `report.json` for `num_samples`
