### PR TITLE
fix: correct args order in CI trial build script

### DIFF
--- a/ci/ci_trial_build.py
+++ b/ci/ci_trial_build.py
@@ -68,7 +68,7 @@ def exec_command_from_github(pull_request_number):
 
   # Set the branch so that the trial_build builds the projects from the PR
   # branch.
-  command.extend(['-p', str(pull_request_number)])
+  command = ['-p', str(pull_request_number)] + command
   command = [c for c in command if c]
   logging.info('Command: %s.', command)
   return request_pr_exp.main(command)


### PR DESCRIPTION
For #885