### PR TITLE
Add proper JSON escaping in crash report templates

### DIFF
--- a/report/templates/crash.json
+++ b/report/templates/crash.json
@@ -17,7 +17,7 @@
         "target_binary": "{{ sample.target_binary }}",
         "reproducer": "{{ sample.reproducer }}",
         "run_log": "{{ sample.run_log }}",
-        "source_code": {{ get_benchmark_final_target_code(sample.id) | replace('\\n', '\\\\n')}},
+        "source_code": "{{ get_benchmark_final_target_code(sample.id) | replace('"', '\\"') | replace('\n', '\\n') }}",
         "model": "{{ model }}"
     }{% if not loop.last %},{% endif %}
 {% endfor %}


### PR DESCRIPTION
# Fix JSON format errors in crash reports

## Description
This PR fixes JSON format errors in crash reports due to improper escaping or were missing quotes entirely, causing parsing errors referenced in issue.

fixes: #903 

## Changes
* Added proper quotes around template expressions
* Added proper escaping for double quotes with `\"`
* Added proper formatting for newlines as `\n`

## Example
Before:
```json
{
  "samples": [
    {
      "coverage_report": "#",
      "stacktrace": "/stacktrace",
      "target_binary": "/target_binary",
      "reproducer": "/artifacts",
      "run_log": "run.log",
      "source_code": ,
      "model": "claude-3-opus-20240229"
    }
  ]
}
```

After:
```json
{
  "samples": [
    {
      "coverage_report": "#",
      "stacktrace": "SIGSEGV\ncrash at 0x004a3f21\n#0 0x004a3f21 in function()",
      "target_binary": "/target_binary",
      "reproducer": "/artifacts",
      "run_log": "run.log",
      "source_code": "#include <stdint.h>\n#include <stdlib.h>\nint LLVMFuzzerTestOneInput() {...}",
      "model": "claude-3-opus-20240229"
    }
  ]
}
```
