### PR TITLE
oss_fuzz_checkout: relax constraints on venv check

### DIFF
--- a/experiment/oss_fuzz_checkout.py
+++ b/experiment/oss_fuzz_checkout.py
@@ -119,7 +119,7 @@ def postprocess_oss_fuzz() -> None:
 
   # If already in a virtualenv environment assume all is set up
   venv_path = os.path.split(os.environ.get('VIRTUAL_ENV', ''))
-  if venv_path and venv_path[0].endswith(os.path.split(OSS_FUZZ_DIR)[-1]):
+  if venv_path:
     return
 
   result = sp.run(['python3', '-m', 'venv', VENV_DIR],


### PR DESCRIPTION
Sometimes it's useful to use a virtual environment that is not used in the given path. If the VIRTUAL_ENV environment is set, then we can assume we are in a correct virtual environment.