### PR TITLE
Update prompts to clarify fuzz target requirements

### DIFF
--- a/prompts/agent/prototyper-priming.c.txt
+++ b/prompts/agent/prototyper-priming.c.txt
@@ -1,10 +1,10 @@
 <system>
 As a security testing engineer, you must write an `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)` fuzz target in {LANGUAGE}.
-Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a minimum fuzz target of a given function-under-test that can build successfully.
+Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a compilable fuzz target of a given function-under-test that can build successfully.
 </system>
 
 <steps>
-Follow these steps to write a minimum fuzz target:
+Follow these steps to write a compilable fuzz target:
 
 Step 1. Determine the information you need to write an effective fuzz target.
 This includes:

--- a/prompts/agent/prototyper-priming.cpp.txt
+++ b/prompts/agent/prototyper-priming.cpp.txt
@@ -1,10 +1,10 @@
 <system>
 As a security testing engineer, you must write an `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)` fuzz target in {LANGUAGE}.
-Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a minimum fuzz target of a given function-under-test that can build successfully.
+Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a compilable fuzz target of a given function-under-test that can build successfully.
 </system>
 
 <steps>
-Follow these steps to write a minimum fuzz target:
+Follow these steps to write a compilable fuzz target:
 
 Step 1. Determine the information you need to write an effective fuzz target.
 This includes:

--- a/prompts/agent/prototyper-priming.txt
+++ b/prompts/agent/prototyper-priming.txt
@@ -1,10 +1,10 @@
 <system>
 As a security testing engineer, you must write an `int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)` fuzz target in {LANGUAGE}.
-Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a minimum fuzz target of a given function-under-test that can build successfully.
+Objective: Your goal is to modify an existing fuzz target `{FUZZ_TARGET_PATH}` to write a compilable fuzz target of a given function-under-test that can build successfully.
 </system>
 
 <steps>
-Follow these steps to write a minimum fuzz target:
+Follow these steps to write a compilable fuzz target:
 
 Step 1. Determine the information you need to write an effective fuzz target.
 This includes:


### PR DESCRIPTION
## Changes
- Updated terminology in prototyper priming templates by replacing "minimum fuzz target" with "compilable fuzz target" in:
  - `prompts/agent/prototyper-priming.txt`
  - `prompts/agent/prototyper-priming.c.txt`
  - `prompts/agent/prototyper-priming.cpp.txt`

## Reason
The inclusion of "minimum" in the initial set of prompts might confuse LLMs into believing that they should reduce the fuzz target code size at the expense of functionality. This change clarifies that the goal is to arrive at a working fuzz target that successfully compiles, and not a minimum one.

Fixes #929

