### PR TITLE
end-to-end: remove dependency on scripts /run-new-oss-fuzz-project/

### DIFF
--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -30,6 +30,43 @@ LOG_FMT = ('%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] '
            ': %(funcName)s: %(message)s')
 
 
+
+def setup_workdirs():
+  """Sets up the working directory."""
+
+  os.makedirs('work', exist_ok=True)
+
+  # Clone two OSS-Fuzz projects
+  subprocess.check_call('git clone https://github.com/google/oss-fuzz oss-fuzz-1', shell=True, cwd='work')
+
+  # Clone another OSS-Fuzz, for OFG core
+  subprocess.check_call('git clone https://github.com/google/oss-fuzz oss-fuzz', shell=True, cwd='work')
+
+  # Clone Fuzz Introspector
+  subprocess.check_call('git clone https://github.com/ossf/fuzz-introspector', shell=True, cwd='work')
+
+def extract_introspector_reports_for_benchmarks():
+  """Runs introspector through each report to collect program analysis data."""
+  return
+
+def shutdown_fi_webapp():
+  """Shutsdown the FI webapp if it exists."""
+  return
+
+def create_fi_db():
+  """Creates the FI webapp database"""
+  return
+
+def launch_fi_webapp():
+  return
+
+def wait_until_fi_webapp_is_launched():
+  return
+
+def run_ofg_generation():
+  return
+
+
 def run_harness_generation(out_gen, model, agent):
   """Runs harness generation based on the projects in `out_gen`"""
 
@@ -39,9 +76,9 @@ def run_harness_generation(out_gen, model, agent):
     return
 
   # Set up if needed
-  if not os.path.isdir('work'):
-    subprocess.check_call('./scripts/run-new-oss-fuzz-project/setup.sh',
-                          shell=True)
+  #if not os.path.isdir('work'):
+  #  subprocess.check_call('./scripts/run-new-oss-fuzz-project/setup.sh',
+  #                        shell=True)
 
   # Copy projects over
   projects_to_run = []
@@ -52,6 +89,15 @@ def run_harness_generation(out_gen, model, agent):
     shutil.copytree(os.path.join(projects_dir, project),
                     os.path.join('work', 'oss-fuzz', 'projects', project))
     projects_to_run.append(project)
+
+  extract_introspector_reports_for_benchmarks()
+  shutdown_fi_webapp()
+  create_fi_db()
+  shutdown_fi_webapp()
+  launch_fi_webapp()
+  wait_until_fi_webapp_is_launched()
+  # make venv dir
+  run_ofg_generation()
 
   # Run project generation
   project_string = ' '.join(projects_to_run)
@@ -67,7 +113,7 @@ def run_harness_generation(out_gen, model, agent):
 def parse_commandline():
   """Parse the commandline."""
   parser = argparse.ArgumentParser()
-  parser.add_argument('--oss-fuzz', '-of', help='OSS-Fuzz base')
+  # parser.add_argument('--oss-fuzz', '-of', help='OSS-Fuzz base')
   parser.add_argument('--input', '-i', help='Input to analyze')
   parser.add_argument('--out',
                       '-o',
@@ -93,7 +139,10 @@ def setup_logging():
   logging.basicConfig(level=logging.INFO, format=LOG_FMT)
 
 
-def run_analysis(oss_fuzz_dir, input_file, out, model, agent):
+def run_analysis(input_file, out, model, agent):
+  setup_workdirs()
+
+  oss_fuzz_dir = os.path.join('work', 'oss-fuzz-1')
   target_repositories = runner.extract_target_repositories(input_file)
   runner.run_parallels(os.path.abspath(oss_fuzz_dir), target_repositories,
                        model, 'all', out)
@@ -106,7 +155,7 @@ def main():
   args = parse_commandline()
   setup_logging()
   silent_global = args.silent
-  run_analysis(args.oss_fuzz, args.input, args.out, args.model, args.agent)
+  run_analysis(args.input, args.out, args.model, args.agent)
 
 
 if __name__ == '__main__':

--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -17,8 +17,11 @@
 import argparse
 import logging
 import os
+import sys
 import shutil
+import time
 import subprocess
+import requests
 
 from experimental.build_generator import runner
 from llm_toolkit import models
@@ -30,55 +33,155 @@ LOG_FMT = ('%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] '
            ': %(funcName)s: %(message)s')
 
 
-
 def setup_workdirs():
   """Sets up the working directory."""
 
-  os.makedirs('work', exist_ok=True)
+  workdir = 'work'
+  os.makedirs(workdir, exist_ok=True)
 
   # Clone two OSS-Fuzz projects
-  subprocess.check_call('git clone https://github.com/google/oss-fuzz oss-fuzz-1', shell=True, cwd='work')
+  subprocess.check_call(
+      'git clone https://github.com/google/oss-fuzz oss-fuzz-1',
+      shell=True,
+      cwd=workdir)
 
   # Clone another OSS-Fuzz, for OFG core
-  subprocess.check_call('git clone https://github.com/google/oss-fuzz oss-fuzz', shell=True, cwd='work')
+  subprocess.check_call('git clone https://github.com/google/oss-fuzz oss-fuzz',
+                        shell=True,
+                        cwd=workdir)
 
   # Clone Fuzz Introspector
-  subprocess.check_call('git clone https://github.com/ossf/fuzz-introspector', shell=True, cwd='work')
+  subprocess.check_call('git clone https://github.com/ossf/fuzz-introspector',
+                        shell=True,
+                        cwd=workdir)
 
-def extract_introspector_reports_for_benchmarks():
+  # Ensure fuzz introspector's requirements.txt is installed
+  subprocess.check_call('python3 -m pip install -r requirements.txt',
+                        shell=True,
+                        cwd=os.path.join(workdir, 'fuzz-introspector'))
+  subprocess.check_call('python3 -m pip install -r requirements.txt',
+                        shell=True,
+                        cwd=os.path.join(workdir, 'fuzz-introspector', 'tools',
+                                         'web-fuzzing-introspection'))
+  return workdir
+
+
+def extract_introspector_reports_for_benchmarks(projects_to_run, workdir):
   """Runs introspector through each report to collect program analysis data."""
-  return
+  oss_fuzz_dir = os.path.join(workdir, 'oss-fuzz')
+  runner_script = os.path.join(workdir, 'fuzz-introspector',
+                               'oss_fuzz_integration', 'runner.py')
+  for project in projects_to_run:
+    cmd = ['python3']
+    cmd.append(runner_script)  # introspector helper script
+    cmd.append('introspector')  # force an introspector run
+    cmd.append(project)  # target project
+    cmd.append('1')  # run the harness for 1 second
+    cmd.append('--disable-webserver')  # do not launch FI webapp
+    subprocess.check_call(' '.join(cmd), shell=True, cwd=oss_fuzz_dir)
+
 
 def shutdown_fi_webapp():
   """Shutsdown the FI webapp if it exists."""
-  return
+  try:
+    subprocess.check_call('curl --silent http://localhost:8080/api/shutdown',
+                          shell=True)
+  except subprocess.CalledProcessError:
+    pass
 
-def create_fi_db():
+
+def create_fi_db(workdir):
   """Creates the FI webapp database"""
+  oss_fuzz_dir = os.path.join(workdir, 'oss-fuzz')
+
+  fi_db_dir = os.path.join(workdir, 'fuzz-introspector', 'tools',
+                           'web-fuzzing-introspection', 'app', 'static',
+                           'assets', 'db')
+  cmd = ['python3']
+  cmd.append('web_db_creator_from_summary.py')
+  cmd.append('--local-oss-fuzz')
+  cmd.append(oss_fuzz_dir)
+  try:
+    logger.info('Creating fuzz introspector database')
+    subprocess.check_call(' '.join(cmd), shell=True, cwd=fi_db_dir)
+    logger.info('Created database successfully')
+  except subprocess.CalledProcessError:
+    logger.info('Failed creation of DB')
   return
 
-def launch_fi_webapp():
+
+def launch_fi_webapp(workdir):
+  """Launches webapp so OFG can query projects."""
+  logger.info('Launching webapp')
+  oss_fuzz_dir = os.path.join(workdir, 'oss-fuzz')
+  fi_webapp_dir = os.path.join(workdir, 'fuzz-introspector', 'tools',
+                               'web-fuzzing-introspection', 'app')
+  environ = os.environ.copy()
+  environ['FUZZ_INTROSPECTOR_LOCAL_OSS_FUZZ'] = oss_fuzz_dir
+  cmd = ['python3']
+  cmd.append('main.py')
+  cmd.append('>> /dev/null &')
+  subprocess.check_call(' '.join(cmd),
+                        shell=True,
+                        cwd=fi_webapp_dir,
+                        env=environ)
+
   return
+
 
 def wait_until_fi_webapp_is_launched():
-  return
+  """Return when the webapp has started"""
+  logger.info('Waiting for the webapp to start')
 
-def run_ofg_generation():
-  return
+  sec_to_wait = 10
+  for _ in range(10):
+    time.sleep(sec_to_wait)
+
+    resp = requests.get('http://127.0.0.1:8080', timeout=10)
+    if 'Fuzzing' in resp.text:
+      return
+  # If this is reached then the webapp likely didn't start.
+  # Exit.
+  logger.info('Could not start FI webapp')
+  sys.exit(0)
 
 
-def run_harness_generation(out_gen, model, agent):
-  """Runs harness generation based on the projects in `out_gen`"""
+def run_ofg_generation(model, projects_to_run, agent, workdir):
+  """Runs harness generation"""
+  logger.info('Running OFG experiment: %s', os.getcwd())
+  oss_fuzz_dir = os.path.join(workdir, 'oss-fuzz')
+  cmd = ['python3', 'run_all_experiments.py']
+  cmd.append('--model')
+  cmd.append(model)
+  cmd.append('-g')
+  cmd.append(
+      'far-reach-low-coverage,low-cov-with-fuzz-keyword,easy-params-far-reach')
+  cmd.append('-gp')
+  cmd.append(','.join(projects_to_run))
+  cmd.append('-gm')
+  cmd.append('4')
+  cmd.append('-of')
+  cmd.append(oss_fuzz_dir)
+  cmd.append('-e')
+  cmd.append('http://127.0.0.1:8080/api')
+  if agent:
+    cmd.append('--agent')
 
+  environ = os.environ.copy()
+
+  environ['LLM_NUM_EVA'] = '4'
+  environ['LLM_NUM_EXP'] = '4'
+  environ['OFG_CLEAN_UP_OSS_FUZZ'] = '0'
+
+  subprocess.check_call(' '.join(cmd), shell=True, env=environ)
+
+
+def copy_generated_projects_to_harness_gen(out_gen):
+  """Copies projects from build generation ready for harness generation."""
   projects_dir = os.path.join(out_gen, 'oss-fuzz-projects')
   if not os.path.isdir(projects_dir):
     logger.info('Found no projects.')
     return
-
-  # Set up if needed
-  #if not os.path.isdir('work'):
-  #  subprocess.check_call('./scripts/run-new-oss-fuzz-project/setup.sh',
-  #                        shell=True)
 
   # Copy projects over
   projects_to_run = []
@@ -86,28 +189,41 @@ def run_harness_generation(out_gen, model, agent):
     dst = os.path.join('work', 'oss-fuzz', 'projects', project)
     if os.path.isdir(dst):
       shutil.rmtree(dst)
+    logger.info('Copying: %s :: %s', os.path.join(projects_dir, project),
+                os.path.join('work', 'oss-fuzz', 'projects', project))
     shutil.copytree(os.path.join(projects_dir, project),
                     os.path.join('work', 'oss-fuzz', 'projects', project))
     projects_to_run.append(project)
+  return projects_to_run
 
-  extract_introspector_reports_for_benchmarks()
+
+def run_harness_generation(out_gen, model, agent, workdir):
+  """Runs harness generation based on the projects in `out_gen`"""
+
+  abs_workdir = os.path.abspath(workdir)
+  projects_to_run = copy_generated_projects_to_harness_gen(out_gen)
+  extract_introspector_reports_for_benchmarks(projects_to_run, abs_workdir)
   shutdown_fi_webapp()
-  create_fi_db()
+  create_fi_db(abs_workdir)
   shutdown_fi_webapp()
-  launch_fi_webapp()
+  launch_fi_webapp(abs_workdir)
   wait_until_fi_webapp_is_launched()
-  # make venv dir
-  run_ofg_generation()
+  run_ofg_generation(model, projects_to_run, agent, abs_workdir)
 
-  # Run project generation
-  project_string = ' '.join(projects_to_run)
-  environ = os.environ
-  environ['MODEL'] = model
-  if agent:
-    environ['EXTRA_OFG_ARGS'] = '--agent'
-  subprocess.check_call(
-      f'./scripts/run-new-oss-fuzz-project/run-project.sh {project_string}',
-      shell=True)
+
+def setup_logging():
+  logging.basicConfig(level=logging.INFO, format=LOG_FMT)
+
+
+def run_analysis(input_file, out, model, agent):
+  workdir = setup_workdirs()
+
+  oss_fuzz_dir = os.path.join('work', 'oss-fuzz-1')
+  target_repositories = runner.extract_target_repositories(input_file)
+  runner.run_parallels(os.path.abspath(oss_fuzz_dir), target_repositories,
+                       model, 'all', out)
+
+  run_harness_generation(out, model, agent, workdir)
 
 
 def parse_commandline():
@@ -133,21 +249,6 @@ def parse_commandline():
                       help='Enable agent workflow',
                       action='store_true')
   return parser.parse_args()
-
-
-def setup_logging():
-  logging.basicConfig(level=logging.INFO, format=LOG_FMT)
-
-
-def run_analysis(input_file, out, model, agent):
-  setup_workdirs()
-
-  oss_fuzz_dir = os.path.join('work', 'oss-fuzz-1')
-  target_repositories = runner.extract_target_repositories(input_file)
-  runner.run_parallels(os.path.abspath(oss_fuzz_dir), target_repositories,
-                       model, 'all', out)
-
-  run_harness_generation(out, model, agent)
 
 
 def main():

--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -17,10 +17,11 @@
 import argparse
 import logging
 import os
-import sys
 import shutil
-import time
 import subprocess
+import sys
+import time
+
 import requests
 
 from experimental.build_generator import runner
@@ -107,7 +108,6 @@ def create_fi_db(workdir):
     logger.info('Created database successfully')
   except subprocess.CalledProcessError:
     logger.info('Failed creation of DB')
-  return
 
 
 def launch_fi_webapp(workdir):
@@ -125,8 +125,6 @@ def launch_fi_webapp(workdir):
                         shell=True,
                         cwd=fi_webapp_dir,
                         env=environ)
-
-  return
 
 
 def wait_until_fi_webapp_is_launched():
@@ -181,7 +179,7 @@ def copy_generated_projects_to_harness_gen(out_gen):
   projects_dir = os.path.join(out_gen, 'oss-fuzz-projects')
   if not os.path.isdir(projects_dir):
     logger.info('Found no projects.')
-    return
+    return set()
 
   # Copy projects over
   projects_to_run = []


### PR DESCRIPTION
Removes dependency on https://github.com/google/oss-fuzz-gen/tree/main/scripts/run-new-oss-fuzz-project so that we do it all in python itself now.

There's still calls to various `subprocess.check_call`. Some of these are tricky to get away from, since not all dependencies are build like libraries as such. Will keep these for now.