### PR TITLE
Update and Retrieval Scripts for Cloud Buckets

### DIFF
--- a/data_prep/bucket_retrieval.py
+++ b/data_prep/bucket_retrieval.py
@@ -1,0 +1,92 @@
+"""Retrieves Project Info from the Cloud Bucket"""
+
+import argparse
+import os
+import json
+import yaml
+from google.cloud import storage  
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+OSS_FUZZ_EXP_BUCKET = 'oss-fuzz-llm-public'
+CACHE_DIR = os.path.join(os.path.dirname(__file__), "cached-info")
+
+#TO DO: Implement functions to retrieve signatures, paths, and targets separately
+def retrieve_from_bucket(project_name: str) -> dict:
+    """Connects and Fetches the Project Info from the Cloud Bucket."""
+    storage_client = storage.Client.create_anonymous_client()
+    bucket = storage_client.bucket(OSS_FUZZ_EXP_BUCKET)
+    #TO DO: To actually check and download the yaml in the cloud bucket
+    #Actual Path for Blob Found in Bucket, currently simulates behaviour when blob not found
+    # blob_name = f"human_written_targets/{project_name}/{project_name}.yaml"
+
+    #Dummy Path for Blob Found in Bucket, to simulate behaviour when blob is found
+    blob_name = f"human_written_targets/ndpi/fuzz_alg_bins.cpp"
+    
+    blob = bucket.blob(blob_name)
+
+    if blob.exists():
+        logger.info(f"Found YAML file in Bucket ({project_name}.yaml)")
+        #Dummy yaml for testing
+        dummy_file_path = 'data_prep/uploads/avahi.yaml'
+        with open(dummy_file_path, "r") as dummy_file:
+            return yaml.safe_load(dummy_file)
+        
+        #Actual Downloading and returning of the bucket yaml
+        # content = blob.download_as_text()
+        # project_data = yaml.safe_load(content)
+        # return project_data
+
+    elif not blob.exists():
+        logger.warning(f" YAML file not found in Bucket ({project_name}.yaml)")
+        return None
+
+def cache_project_info(project_name: str, project_data: dict):
+    """Caches Project Info Locally."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    cache_path = os.path.join(CACHE_DIR,f"{project_name}.yaml")
+    with open(cache_path, "w") as cache_file:
+        yaml.dump(project_data, cache_file)
+    logger.info(f"Cached Project {project_name} Locally")
+
+def retrieve_project_info(project_name: str) -> dict:
+    """Retrieves Project Info using Local Cache if Available 
+    else Retrieve it from Bucket and Cache Locally."""
+    cache_path = os.path.join(CACHE_DIR, f"{project_name}.yaml")
+    if os.path.exists(cache_path):
+        logger.info("Fetching Project Info from Local Cache")
+        with open(cache_path, "r") as cache_file:
+            return yaml.safe_load(cache_file)
+
+    logger.info(f"Fetching Project Info for project {project_name} from Bucket.")
+    project_data = retrieve_from_bucket(project_name)
+    if project_data:
+        cache_project_info(project_name, project_data)
+    return project_data
+
+def _parse_arguments():
+    """Parses command line args."""
+    parser = argparse.ArgumentParser(
+      description='Parse project-related arguments')
+
+    # project_name argument
+    parser.add_argument('-p',
+                        '--project-name',
+                        type=str,
+                        required=True,
+                        help='Name of the project')
+    parsed_args = parser.parse_args()
+    return parsed_args
+  
+if __name__ == "__main__":
+    args = _parse_arguments()
+    project_name = args.project_name
+
+    project_data = retrieve_project_info(project_name)
+
+    if project_data:
+        print(yaml.dump(project_data, indent=2))
+    else:
+        logger.error("Failed to retrieve Project Info")

--- a/data_prep/bucket_update.py
+++ b/data_prep/bucket_update.py
@@ -1,0 +1,189 @@
+import sys
+import argparse
+import os
+import yaml
+from google.cloud import storage
+import logging
+from datetime import datetime, timezone
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from experiment.benchmark import Benchmark  
+from introspector import get_project_funcs, query_introspector_function_signature
+from datetime import datetime
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+OSS_FUZZ_EXP_BUCKET = 'oss-fuzz-llm-public'
+YAML_DIR = 'benchmark-sets/all'
+
+def extract_from_bucket(bucket, project_name: str) -> list:
+    """Retrieve all fuzz target files and their content from the bucket."""
+    fuzz_targets = []
+    project_prefix = f"human_written_targets/{project_name}/"
+    blobs = bucket.list_blobs(prefix=project_prefix)
+
+    for blob in blobs:
+        # Change current language logic
+        logger.info(f"Retrieving content for fuzz target: {blob.name}")
+        content = blob.download_as_text()
+
+        fuzz_targets.append({
+            "full_path": f"/src/{blob.name.split('/')[-1]}",
+            "content": content,
+            "signatures": [],  
+            "metadata": {
+                "language": "c++" if blob.name.endswith(".cpp") else "c",
+                "dependencies": [],
+                "notes": f"Extracted from {blob.name}"
+            },
+        })
+    return fuzz_targets
+
+def extract_from_benchmark(project_name: str) -> list:
+    """Extract fuzz targets and Project Info from benchmark YAML files."""
+    yaml_path = os.path.join(YAML_DIR, f"{project_name}.yaml")
+    if not os.path.exists(yaml_path):
+        logger.error(f"YAML file for project '{project_name}' not found")
+        return []
+
+    benchmarks = Benchmark.from_yaml(yaml_path)
+    fuzz_targets = []
+    for benchmark in benchmarks:
+        fuzz_targets.append({
+            "full_path": benchmark.target_path,
+            "content": "",
+            "signatures": [benchmark.function_signature],
+            "metadata": {
+                "language": benchmark.language,
+                "dependencies": [],
+                "notes": f"Extracted from {yaml_path}"
+            }
+        })
+    return fuzz_targets
+
+def extract_from_fi(project_name: str) -> list:
+    """Extract fuzz targets and Project Info from FuzzIntrospector."""
+    try:
+        project_funcs = get_project_funcs(project_name)
+        fuzz_targets = []
+        for target_path, functions in project_funcs.items():
+            target_entry = {
+                "full_path": target_path,
+                "content": "",
+                "signatures": [],
+                "metadata": { 
+                    "language": "c++" if target_path.endswith(".cpp") else "c",
+                    "dependencies": [],
+                    "notes": f"Extracted from FuzzIntrospector for {project_name}"
+                }
+            }
+            for function in functions:
+                function_name = function.get("function-name")
+                if function_name:
+                    signature = query_introspector_function_signature(project_name, function_name)
+                    if signature:
+                        target_entry["signatures"].append(signature)
+                    else:
+                        logger.info(f"Error: No signature found for function '{function_name}' in project '{project_name}'.")
+            fuzz_targets.append(target_entry)
+        return fuzz_targets
+    except Exception as e:
+        logger.error(f"Error extracting data from FI for project '{project_name}': {e}")
+        return []
+    
+
+def merge_fuzz_targets(info_targets: list, bucket_targets: list) -> list:
+    """Merge fuzz targets from either benchmark or FI and the bucket."""
+    merged_targets = {}
+
+    for bucket_target in bucket_targets:
+        key = os.path.basename(bucket_target["full_path"])
+        bucket_target["metadata"]["version"] = datetime.now(timezone.utc)
+        merged_targets[key] = bucket_target
+
+    for info_target in info_targets:
+        key = os.path.basename(info_target["full_path"])
+        if key in merged_targets:
+            merged_target = merged_targets[key]
+            merged_target["metadata"].update(info_target["metadata"])
+            for sig in info_target.get("signatures", []):
+                if sig not in merged_target.get("signatures", []):
+                    merged_target.setdefault("signatures", []).append(sig)
+        else:
+            info_target["metadata"]["version"] = datetime.now(timezone.utc)
+            merged_targets[key] = info_target
+
+    return list(merged_targets.values())
+
+
+def prepare_project(project_name: str, fuzz_targets: list) -> dict:
+    """Prepare Project Info for the project."""
+    return {
+        "project_name": project_name,
+        "last_updated": datetime.now(timezone.utc),
+        "fuzz_targets": fuzz_targets
+    }
+
+def upload_project(bucket,project_name: str, yaml_data: dict):
+    """Upload Project Info to the cloud bucket."""
+    try:
+        temp = f"data_prep/tmp/{project_name}.yaml"
+        os.makedirs("data_prep/tmp", exist_ok=True)
+        with open(temp, "w") as tempf:
+            yaml.dump(yaml_data, tempf, sort_keys=False)
+        destination_path = f"human_written_targets/{project_name}/{project_name}.yaml"
+        blob = bucket.blob(destination_path)
+        blob.upload_from_filename(temp)
+        logger.info(f"Uploaded project info for '{project_name}' to GCS at '{destination_path}'.")
+    except Exception as e:
+        logger.error(f"Failed to upload project info for '{project_name}' to GCS: {e}")
+
+def update_project(project_name: str, use_info: str):
+    """Update project info in the cloud bucket."""
+    try:
+        logger.info(f"Retrieving fuzz target content from the bucket for project '{project_name}'...")
+        storage_client = storage.Client.create_anonymous_client()
+        bucket = storage_client.bucket(OSS_FUZZ_EXP_BUCKET)
+
+        bucket_targets = extract_from_bucket(bucket, project_name)
+        
+        if use_info == 1:
+            logger.info(f"Extracting fuzz targets from FI for project '{project_name}'...")
+            info_targets = extract_from_fi(project_name)
+
+        else: 
+            logger.info(f"Extracting fuzz targets from benchmark YAML for project '{project_name}'...")
+            info_targets = extract_from_benchmark(project_name)
+
+        logger.info(f"Merging fuzz targets")
+        merged_targets = merge_fuzz_targets(info_targets, bucket_targets)
+
+        logger.info(f"Preparing metadata for project '{project_name}'...")
+        yaml_data = prepare_project(project_name, merged_targets)
+
+        logger.info(f"Upload project '{project_name}' to Bucket.")
+        upload_project(bucket,project_name, yaml_data)
+
+    except Exception as e:
+        logger.error(f"An error occurred while updating project '{project_name}': {e}")
+
+def _parse_arguments():
+    """Parses command line args."""
+    parser = argparse.ArgumentParser(
+      description='Parse project-related arguments')
+    parser.add_argument('-p',
+                        '--project-name',
+                        type=str,
+                        required=True,
+                        help='Name of the project')
+    parser.add_argument('--use_info',
+                        type=int,
+                        default = 1,
+                        help='Use info from benchmark(0) or fuzz introspector(1)',)
+    parsed_args = parser.parse_args()
+    return parsed_args
+  
+if __name__ == "__main__":
+    args = _parse_arguments()
+    update_project(args.project_name,args.use_info)


### PR DESCRIPTION
### **Description**

Introduces two key scripts, **`bucket_update.py`** and **`bucket_retrieval.py`** that handle retrieving, updating, and caching for projects in the cloud bucket.  The changes in this PR are a direct continuation of the discussions with @DonggeLiu  in #134  suggesting the need for re-structuring and storing project information in the bucket

#### **`bucket_update.py`**
This script is responsible for updating project information in the bucket by merging existing data from the cloud bucket along with data from the fuzz-target under test. Current Workflow:
1.  Retrieves all fuzz target files and their content from the cloud bucket
2. Matches fuzz targets under test with those in the bucket. For matched targets, it merges the `signatures` into the bucket data
3. Includes fuzz targets from the bucket that are not in the benchmark YAML, leaving their `signatures` empty for now. These can later be populated using FuzzIntrospector or other tools
4. Currently saves the final metadata to a local file (`data_prep/uploads/<project_name>.yaml`) for testing purposes. Can be extended to the bucket with appropriate permissions

#### **2. `bucket_retrieval.py`**
This script complements bucket_update.py by providing a mechanism to retrieve project metadata from either the cloud bucket or a local cache. Current Workflow:

1.  Checks for a locally cached YAML file before querying the bucket. This reduces redundant bucket queries 
2. If the Projectis not available in the local cache, it fetches the data from the cloud bucket and caches it locally for future use. For testing purposes, it reads either from cached file or local file (`data_prep/uploads/<project_name>.yaml`), extensible to cloud bucket with permissions

### **Work Under Development**
  - Populating `signatures`  for unmatched targets  and optional metadata using FuzzIntrospector or other tools.
  - Replacing the simulated upload logic in bucket_update.py with actual bucket uploads with due permission
  - Implementing querying functions to retrieve different parts of the metadata separately
  - Improving the retrieval and merging logic for larger scales 