### PR TITLE
Refine the status in reports

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -44,6 +44,7 @@ OSS_FUZZ_INTROSPECTOR_BUCKET = 'oss-fuzz-introspector'
 @dataclasses.dataclass
 class Result:
   """Evaluation result."""
+  finished: bool = False
   compiles: bool = False
   crashes: bool = False
   coverage: float = 0.0
@@ -513,6 +514,7 @@ class Evaluator:
       return dual_logger.return_result(
           Result(False,
                  False,
+                 False,
                  0.0,
                  0.0,
                  '',
@@ -531,7 +533,8 @@ class Evaluator:
       dual_logger.log(
           f'Warning: no run result in {generated_oss_fuzz_project}.')
       return dual_logger.return_result(
-          Result(True,
+          Result(False,
+                 True,
                  False,
                  0.0,
                  0.0,
@@ -559,7 +562,8 @@ class Evaluator:
           f'Warning: No cov info in run result of {generated_oss_fuzz_project}.'
       )
       return dual_logger.return_result(
-          Result(True,
+          Result(False,
+                 True,
                  run_result.crashes,
                  0.0,
                  0.0,
@@ -578,7 +582,8 @@ class Evaluator:
         f'coverage diff={coverage_diff} '
         f'({run_result.coverage.covered_lines}/{total_lines})')
     return dual_logger.return_result(
-        Result(True,
+        Result(False,
+               True,
                run_result.crashes,
                coverage_percent,
                coverage_diff,

--- a/logger.py
+++ b/logger.py
@@ -57,12 +57,15 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
                                      f'{result.trial:02d}.build_script')
     self.write_to_file(build_script_path, result.build_script_source, 'w')
 
-  def write_result(self, result_status_dir: str, result: TrialResult) -> None:
+  def write_result(self,
+                   result_status_dir: str,
+                   result: TrialResult,
+                   finished: bool = False) -> None:
     """Writes the final result into JSON for report generation."""
     trial_result_dir = os.path.join(result_status_dir, f'{result.trial:02d}')
     os.makedirs(trial_result_dir, exist_ok=True)
     with open(os.path.join(trial_result_dir, FINAL_RESULT_JSON), 'w') as f:
-      json.dump(result.to_dict(), f)
+      json.dump(result.to_dict() | {'finished': finished}, f)
 
   def write_chat_history(self, result: Result) -> None:
     """Writes chat history."""

--- a/pipeline.py
+++ b/pipeline.py
@@ -138,6 +138,7 @@ class Pipeline():
     """
     self.logger.debug('Pipeline starts')
     cycle_count = 0
+    self._update_status(result_history=result_history)
     while not self._terminate(result_history=result_history,
                               cycle_count=cycle_count):
       cycle_count += 1

--- a/pipeline.py
+++ b/pipeline.py
@@ -144,5 +144,4 @@ class Pipeline():
       cycle_count += 1
       self._execute_one_cycle(result_history=result_history,
                               cycle_count=cycle_count)
-    self._update_status(result_history=result_history, finished=True)
     return result_history

--- a/pipeline.py
+++ b/pipeline.py
@@ -82,14 +82,17 @@ class Pipeline():
                         last_result)
     return True
 
-  def _update_status(self, result_history: list[Result]) -> None:
+  def _update_status(self,
+                     result_history: list[Result],
+                     finished: bool = False) -> None:
     trial_result = TrialResult(benchmark=result_history[-1].benchmark,
                                trial=self.trial,
                                work_dirs=result_history[-1].work_dirs,
                                result_history=result_history)
     self.logger.write_result(
         result_status_dir=trial_result.best_result.work_dirs.status,
-        result=trial_result)
+        result=trial_result,
+        finished=finished)
 
   def _execute_one_cycle(self, result_history: list[Result],
                          cycle_count: int) -> None:
@@ -140,4 +143,5 @@ class Pipeline():
       cycle_count += 1
       self._execute_one_cycle(result_history=result_history,
                               cycle_count=cycle_count)
+    self._update_status(result_history=result_history, finished=True)
     return result_history

--- a/report/common.py
+++ b/report/common.py
@@ -269,9 +269,9 @@ class Results:
   def match_benchmark(self, benchmark_id: str, results: list[evaluator.Result],
                       targets: list[str]) -> Benchmark:
     """Returns a benchmark class based on |benchmark_id|."""
-    expected_trials = self._get_expected_trials_count(benchmark_id)
-    status = 'Done' if all(result.finished for result in results) else (
-        f'Running ({len(results)}/{expected_trials})')
+    num_finished_trials = [result for result in results if result.finished]
+    status = 'Done' if num_finished_trials == len(results) else (
+        f'Running ({num_finished_trials}/{len(results)})')
 
     filtered_results = [(i, stat) for i, stat in enumerate(results) if stat]
 
@@ -281,58 +281,6 @@ class Results:
       result = run_one_experiment.AggregatedResult()
 
     return self._create_benchmark(benchmark_id, status, result)
-
-  def _get_expected_trials_count(self, benchmark_id: str) -> int:
-    """Returns the expected number of trials for a benchmark."""
-    # First try to get the value from report.json
-    report_path = os.path.join(self._results_dir, 'report.json')
-    try:
-      with open(report_path, 'r') as f:
-        report_data = json.load(f)
-        if 'num_samples' in report_data:
-          return report_data['num_samples']
-    except (json.JSONDecodeError, OSError, FileNotFoundError):
-      # If there's an error reading the file, continue to fallbacks
-      pass
-
-    # Check fuzz_targets directory for new experiments
-    fuzz_targets_dir = os.path.join(self._results_dir, benchmark_id,
-                                    'fuzz_targets')
-    if FileSystem(fuzz_targets_dir).exists():
-      # For new experiments, use the max trial ID as the expected count
-      # This handles the case where trials come out of order
-      max_trial_id = 0
-      trial_ids = set()
-
-      for filename in FileSystem(fuzz_targets_dir).listdir():
-        if os.path.splitext(filename)[1] in TARGET_EXTS:
-          # Extract trial ID from filenames like "01.fuzz_target"
-          trial_id = os.path.splitext(filename)[0]
-          trial_ids.add(trial_id)
-          try:
-            trial_num = int(trial_id)
-            max_trial_id = max(max_trial_id, trial_num)
-          except ValueError:
-            pass
-
-      if max_trial_id > 0:
-        return max_trial_id
-
-      # Fallback: if we couldn't parse trial IDs as integers, use the count
-      if trial_ids:
-        return len(trial_ids)
-
-    # Check raw_targets directory for older experiments
-    raw_targets_dir = os.path.join(self._results_dir, benchmark_id,
-                                   'raw_targets')
-    if FileSystem(raw_targets_dir).exists():
-      targets = [
-          f for f in FileSystem(raw_targets_dir).listdir()
-          if os.path.splitext(f)[1] in TARGET_EXTS
-      ]
-      return len(targets)
-
-    return 1
 
   def get_final_target_code(self, benchmark: str, sample: str) -> str:
     """Gets the targets of benchmark |benchmark| with sample ID |sample|."""

--- a/report/common.py
+++ b/report/common.py
@@ -269,7 +269,7 @@ class Results:
   def match_benchmark(self, benchmark_id: str, results: list[evaluator.Result],
                       targets: list[str]) -> Benchmark:
     """Returns a benchmark class based on |benchmark_id|."""
-    num_finished_trials = [result for result in results if result.finished]
+    num_finished_trials = len([result for result in results if result.finished])
     status = 'Done' if num_finished_trials == len(results) else (
         f'Running ({num_finished_trials}/{len(results)})')
 

--- a/report/common.py
+++ b/report/common.py
@@ -270,8 +270,8 @@ class Results:
                       targets: list[str]) -> Benchmark:
     """Returns a benchmark class based on |benchmark_id|."""
     expected_trials = self._get_expected_trials_count(benchmark_id)
-    status = 'Done' if (results and len(results) == expected_trials and
-                        all(results)) else 'Running'
+    status = 'Done' if all(result.finished for result in results) else (
+        f'Running ({len(results)}/{expected_trials})')
 
     filtered_results = [(i, stat) for i, stat in enumerate(results) if stat]
 

--- a/results.py
+++ b/results.py
@@ -64,7 +64,7 @@ class Result:
         'trial': self.trial,
         'fuzz_target_source': self.fuzz_target_source,
         'build_script_source': self.build_script_source,
-        'author': self.author.name,
+        'author': self.author.name if self.author else '',
         'chat_history': self.chat_history,
     }
 

--- a/results.py
+++ b/results.py
@@ -525,7 +525,7 @@ class TrialResult:
         'build_script_source':
             self.build_script_source,
         'author':
-            self.author.name,
+            self.author.name if self.author else '',
         'chat_history':
             self.chat_history,
         'compiles':

--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -280,7 +280,8 @@ def _fuzzing_pipeline(benchmark: Benchmark, model: models.LLM,
                              result_history=results)
   trial_logger.write_result(
       result_status_dir=trial_result.best_result.work_dirs.status,
-      result=trial_result)
+      result=trial_result,
+      finished=True)
   return trial_result
 
 


### PR DESCRIPTION
1. Add a field to result representing a trial's status (finished or not).
2. Include `finished/all` ratio in report index page.