### PR TITLE
Added activeDeadlineSeconds for Kubernetes Job Resource Management  Description:

### DIFF
--- a/ci/k8s/pr-exp.yaml
+++ b/ci/k8s/pr-exp.yaml
@@ -20,6 +20,7 @@ metadata:
     customLabel: "myCustomValue"
 spec:
   template:
+     activeDeadlineSeconds: 43200  # 12 hours. We don't want large experiments to run indefinitely and eat up resources.
     spec:
       nodeSelector:
         cloud.google.com/gke-nodepool: ofg-pr-exp


### PR DESCRIPTION
Description:
This pull request addresses an issue in the pr-exp.yaml file, where the second Kubernetes job was missing the activeDeadlineSeconds field. The absence of this field could have caused the job to run indefinitely, consuming excessive resources and leading to unpredictable behavior. This fix ensures that both jobs have the same resource management strategy.

Changes:
Added activeDeadlineSeconds: 43200 (12 hours) to the second Kubernetes job configuration. This prevents the job from running indefinitely and reduces resource consumption.

Fix:
By adding this field, we align the second job’s configuration with the first job, which already has a similar field, ensuring consistent resource management across both jobs.

Additional Notes:
The change aims to prevent excessive resource consumption by limiting the runtime of the job to 12 hours. This is a more reasonable timeframe compared to the original 7 days, ensuring better resource allocation for quicker jobs.
#931