### PR TITLE
ci: osv-scanner: fix wrong cli argument

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -32,5 +32,4 @@ jobs:
       # Example of specifying custom arguments
       scan-args: |-
         -r
-        --skip-git
         ./


### PR DESCRIPTION
--skip-git is not used anymore:
https://github.com/google/osv-scanner/blob/main/docs/migration-guide.md