### PR TITLE
Safer dictionary access on report index page

### DIFF
--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -146,11 +146,11 @@ td .signature {
         {% for language in coverage_language_gains['coverage_gains_per_language'] %}
         <tr>
             <td>{{language}}</td>
-            <td>{{coverage_language_gains['oss_fuzz_language_status'][language]['total']}}</td>
-            <td>{{coverage_language_gains['oss_fuzz_language_status'][language]['covered']}}</td>
-            <td>{{coverage_language_gains['coverage_gains_per_language'][language]}}</td>
-            <td>{{coverage_language_gains['comperative_coverage_gains'][language]['total_coverage_increase']}}%</td>
-            <td>{{coverage_language_gains['comperative_coverage_gains'][language]['relative_coverage_increase']}}%</td>
+            <td>{{ coverage_language_gains['oss_fuzz_language_status'].get(language, {}).get('total', 'N/A') }}</td>
+            <td>{{ coverage_language_gains['oss_fuzz_language_status'].get(language, {}).get('covered', 'N/A') }}</td>
+            <td>{{ coverage_language_gains['coverage_gains_per_language'].get(language, 'N/A') }}</td>
+            <td>{{ coverage_language_gains['comperative_coverage_gains'].get(language, {}).get('total_coverage_increase', 'N/A') }}%</td>
+            <td>{{ coverage_language_gains['comperative_coverage_gains'].get(language, {}).get('relative_coverage_increase', 'N/A') }}%</td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
Seeing some rare failures caused by missing keys in dictionary:
```python
ERROR 2025-04-02T10:58:43.024642067Z Traceback (most recent call last): File "<frozen runpy>", line 198, in _run_module_as_main File "<frozen runpy>", line 88, in _run_code File "/experiment/report/web.py", line 331, in <module> main() File "/experiment/report/web.py", line 312, in main generate_report(args) File "/experiment/report/web.py", line 260, in generate_report gr.generate() File "/experiment/report/web.py", line 169, in generate self._write_index_html(benchmarks, accumulated_results, time_results, File "/experiment/report/web.py", line 194, in _write_index_html rendered = self._jinja.render(
ERROR 2025-04-02T10:58:43.024864987Z ^^^^^^^^^^^^^^^^^^^
ERROR 2025-04-02T10:58:43.024869177Z File "/experiment/report/web.py", line 83, in render
ERROR 2025-04-02T10:58:43.024884267Z return self._env.get_template(template_name).render(**kwargs)
ERROR 2025-04-02T10:58:43.024886437Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2025-04-02T10:58:43.024889277Z File "/venv/lib/python3.11/site-packages/jinja2/environment.py", line 1295, in render
ERROR 2025-04-02T10:58:43.025000437Z self.environment.handle_exception()
ERROR 2025-04-02T10:58:43.025007807Z File "/venv/lib/python3.11/site-packages/jinja2/environment.py", line 942, in handle_exception
ERROR 2025-04-02T10:58:43.025068287Z raise rewrite_traceback_stack(source=source)
ERROR 2025-04-02T10:58:43.025074497Z File "report/templates/index.html", line 16, in top-level template code
ERROR 2025-04-02T10:58:43.025098077Z #}{% extends 'base.html' %}
ERROR 2025-04-02T10:58:43.025101607Z ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2025-04-02T10:58:43.025103817Z File "report/templates/base.html", line 106, in top-level template code
ERROR 2025-04-02T10:58:43.025139797Z {% block content %}{% endblock %}
ERROR 2025-04-02T10:58:43.025166727Z ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2025-04-02T10:58:43.025169627Z File "report/templates/index.html", line 149, in block 'content'
ERROR 2025-04-02T10:58:43.025204257Z <td>{{coverage_language_gains['oss_fuzz_language_status'][language]['total']}}</td>
ERROR 2025-04-02T10:58:43.025209847Z ^^^^^^^^^^^^^^^^^
ERROR 2025-04-02T10:58:43.025211847Z File "/venv/lib/python3.11/site-packages/jinja2/environment.py", line 471, in getitem
ERROR 2025-04-02T10:58:43.025275827Z return obj[argument]
ERROR 2025-04-02T10:58:43.025279187Z ~~~^^^^^^^^^^
ERROR 2025-04-02T10:58:43.025283767Z jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'c++'
```

This should mitigate the error, but please let me know if you have a better solution to fix the root cause @DavidKorczynski.