### PR TITLE
end-to-end: add simple post-harness-gen merging

### DIFF
--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -15,6 +15,7 @@
 """Create OSS-Fuzz projects from scratch."""
 
 import argparse
+import json
 import logging
 import os
 import shutil
@@ -22,9 +23,9 @@ import subprocess
 import sys
 import tempfile
 import time
-import yaml
-import json
+
 import requests
+import yaml
 
 from experimental.build_generator import runner
 from llm_toolkit import models


### PR DESCRIPTION
To create complete OSS-Fuzz projects with multiple harnesses.