### PR TITLE
Fix Race Condition in Build Pipeline Using Semaphore 

### DIFF
--- a/stage/execution_stage.py
+++ b/stage/execution_stage.py
@@ -21,7 +21,7 @@ from experiment import evaluator as evaluator_lib
 from experiment.evaluator import Evaluator
 from results import BuildResult, Result, RunResult
 from stage.base_stage import BaseStage
-
+from threading import Semaphore  
 
 class ExecutionStage(BaseStage):
   """Executes fuzz targets and build scripts. This stage takes a fuzz target
@@ -29,9 +29,11 @@ class ExecutionStage(BaseStage):
   and outputs code coverage report and run-time crash information for later
   stages to analyze and improve on. It uses OSS-Fuzz infra to perform these
   tasks."""
+  _build_semaphore = Semaphore(4)
 
   def execute(self, result_history: list[Result]) -> Result:
-    """Executes the fuzz target and build script in the latest result."""
+   """Executes the fuzz target and build script in the latest result."""
+   with self._build_semaphore:
     last_result = result_history[-1]
     benchmark = last_result.benchmark
     if self.args.cloud_experiment_name:


### PR DESCRIPTION

##  Problem Summary  
A race condition in the build pipeline leads to corrupted build artifacts when multiple threads or processes concurrently access shared resources. This occurs due to the lack of synchronization mechanisms in critical sections of the build process.  
#963
## Affected Components  
- **File I/O Operations:** Concurrent writes to shared files (e.g., `build.sh`, `target.o`, coverage reports).  
- **OSS-Fuzz Configuration:** Simultaneous modifications to project configurations.  
- **Artifact Generation:** Race conditions during binary compilation and coverage data aggregation.  

##  Proposed Fix  
This PR introduces a **semaphore** to control concurrent build operations and ensure proper synchronization:  
- Added **`Semaphore(4)`** to limit concurrent builds to four at a time, reducing the risk of corrupted artifacts.  
- The `execute()` method now acquires a semaphore before running the build process, ensuring proper access control.  

##  Impact & Benefits  
- Prevents build artifacts from being corrupted.  
- Ensures stability for distributed fuzzing experiments.  
- Reduces flaky builds and improves reproducibility.  

##  Next Steps & Considerations  
- The semaphore limit (`4`) is currently hardcoded—should this be configurable?  
- Further testing required to evaluate performance impact, especially in high-concurrency scenarios.  
---  
