### PR TITLE
agent: one-prompt*: use gettext for logs

### DIFF
--- a/agent/one_prompt_enhancer.py
+++ b/agent/one_prompt_enhancer.py
@@ -68,7 +68,7 @@ class OnePromptEnhancer(OnePromptPrototyper):
                                trial=last_result.trial,
                                work_dirs=last_result.work_dirs,
                                author=self,
-                               chat_history={self.name: prompt.get()})
+                               chat_history={self.name: prompt.gettext()})
 
     while prompt and cur_round <= self.max_round:
       self._generate_fuzz_target(prompt, result_history, build_result,

--- a/agent/one_prompt_prototyper.py
+++ b/agent/one_prompt_prototyper.py
@@ -108,7 +108,7 @@ class OnePromptPrototyper(BaseAgent):
                                trial=last_result.trial,
                                work_dirs=last_result.work_dirs,
                                author=self,
-                               chat_history={self.name: prompt.get()})
+                               chat_history={self.name: prompt.gettext()})
 
     while prompt and cur_round <= self.max_round:
       self._generate_fuzz_target(prompt, result_history, build_result,


### PR DESCRIPTION
The logs when shown in the report a not formatted well for openai models, as they are dictionaries not plaintext. We want only the plaintext in the logs.