### PR TITLE
build_generation: Add LLM approach

### DIFF
--- a/experimental/build_generator/build_script_generator.py
+++ b/experimental/build_generator/build_script_generator.py
@@ -23,7 +23,6 @@ from abc import abstractmethod
 from typing import Dict, Iterator, List, Optional, Tuple
 
 import constants
-import manager
 import file_utils as utils
 
 logger = logging.getLogger(name=__name__)

--- a/experimental/build_generator/build_script_generator.py
+++ b/experimental/build_generator/build_script_generator.py
@@ -24,6 +24,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 import constants
 import manager
+import file_utils as utils
 
 logger = logging.getLogger(name=__name__)
 
@@ -843,7 +844,7 @@ def match_build_heuristics_on_folder(abspath_of_target: str):
   Traverses the files in the target folder. Uses the file list as input to
   auto build heuristics, and for each heuristic will yield any of the
   build steps that are deemed matching."""
-  all_files = manager.get_all_files_in_path(abspath_of_target)
+  all_files = utils.get_all_files_in_path(abspath_of_target)
   all_checks = [
       AutogenConfScanner(),
       PureCFileCompiler(),
@@ -887,7 +888,7 @@ def match_build_heuristics_on_folder(abspath_of_target: str):
 
 def get_all_binary_files_from_folder(path: str) -> Dict[str, List[str]]:
   """Extracts binary artifacts from a list of files, based on file suffix."""
-  all_files = manager.get_all_files_in_path(path, path)
+  all_files = utils.get_all_files_in_path(path, path)
 
   executable_files = {'static-libs': [], 'dynamic-libs': [], 'object-files': []}
   for fil in all_files:

--- a/experimental/build_generator/file_utils.py
+++ b/experimental/build_generator/file_utils.py
@@ -1,0 +1,57 @@
+import os
+from typing import List, Optional
+
+try:
+  # For execution outside of a docker container
+  from experimental.build_generator import templates
+except (ImportError, SystemError):
+  # For execution inside of a docker container
+  import templates
+
+
+def determine_project_language(path: str) -> str:
+  """Returns the likely language of a project by looking at file suffixes."""
+  all_files = get_all_files_in_path(path, path)
+
+  language_dict = {'c': 0, 'c++': 0}
+  for source_file in all_files:
+    if source_file.endswith('.c'):
+      language_dict['c'] = language_dict['c'] + 1
+    elif source_file.endswith('.cpp'):
+      language_dict['c++'] = language_dict['c++'] + 1
+    elif source_file.endswith('.cc'):
+      language_dict['c++'] = language_dict['c++'] + 1
+
+  target_language = 'c++'
+  max_count = 0
+  for language, count in language_dict.items():
+    if count > max_count:
+      target_language = language
+      max_count = count
+  return target_language
+
+
+def get_language_defaults(language: str):
+  compilers_and_flags = {
+      'c': ('$CC', '$CFLAGS', '/src/empty-fuzzer.c', templates.C_BASE_TEMPLATE),
+      'c++': ('$CXX', '$CXXFLAGS', '/src/empty-fuzzer.cpp',
+              templates.CPP_BASE_TEMPLATE),
+  }
+  return compilers_and_flags[language]
+
+
+def get_all_files_in_path(base_path: str,
+                          path_to_subtract: Optional[str] = None) -> List[str]:
+  """Gets all files in a tree and returns as a list of strings."""
+  all_files = []
+  if path_to_subtract is None:
+    path_to_subtract = os.getcwd()
+  for root, _, files in os.walk(base_path):
+    for fi in files:
+      path = os.path.join(root, fi)
+      if path.startswith(path_to_subtract):
+        path = path[len(path_to_subtract):]
+      if len(path) > 0 and path[0] == '/':
+        path = path[1:]
+      all_files.append(path)
+  return all_files

--- a/experimental/build_generator/file_utils.py
+++ b/experimental/build_generator/file_utils.py
@@ -1,3 +1,18 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""File utils for target repository"""
+
 import os
 from typing import List, Optional
 

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -16,7 +16,6 @@
 import argparse
 import os
 import re
-import shutil
 import subprocess
 from typing import Optional
 
@@ -238,7 +237,6 @@ class BuildSystemBuildScriptAgent(BuildScriptAgent):
         with open(file, 'r') as f:
           self.build_files[file.replace(target_path, '')] = f.read()
 
-    self.target_path = target_path
     return len(self.build_files) > 0
 
   def _initial_prompt(self, results: list[Result]) -> Prompt:  # pylint: disable=unused-argument
@@ -283,9 +281,5 @@ class BuildSystemBuildScriptAgent(BuildScriptAgent):
                          work_dirs=result_history[-1].work_dirs,
                          author=self,
                          chat_history={self.name: ''})
-
-    # Clean up directory
-    if os.path.isdir(self.target_path):
-      shutil.rmtree(self.target_path)
 
     return super().execute(result_history)

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -1,0 +1,234 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""LLM Build Script Agent"""
+
+import argparse
+import copy
+import os
+import re
+import subprocess
+from typing import Optional
+
+import logger
+from agent.base_agent import BaseAgent
+from experimental.build_generator import templates
+from llm_toolkit.models import LLM
+from llm_toolkit.prompts import Prompt
+from results import BuildResult, Result
+from tool.base_tool import BaseTool
+from tool.container_tool import ProjectContainerTool
+
+MAX_PROMPT_LENGTH = 25000
+
+
+class BuildScriptAgent(BaseAgent):
+  """Generate a working Dockerfile and build script from scratch."""
+
+  def __init__(self,
+               trial: int,
+               llm: LLM,
+               args: argparse.Namespace,
+               github_url: str,
+               tools: Optional[list[BaseTool]] = None,
+               name: str = ''):
+    super().__init__(trial, llm, args, tools, name)
+    self.github_url = github_url
+    self.build_files = {}
+    self.last_result = ''
+    self.target_files = {
+        'Makefile': [],
+        'configure.ac': [],
+        'Makefile.am': [],
+        'autogen.sh': [],
+        'bootstrap.sh': [],
+        'CMakeLists.txt': [],
+        'Config.in': [],
+    }
+
+  def _discover_build_configurations(self) -> None:
+    """Helper to discover the build configuartions of a repository."""
+    # Clone targert repository
+    target_source_path = os.path.join(os.getcwd(), self.args.work_dirs,
+                                      self.github_url.split('/')[-1])
+    dst_folder = os.path.join(self.args.work_dirs,
+                              self.github_url.split('/')[-1])
+    if not os.path.isdir(target_source_path):
+      subprocess.check_call(
+          f'git clone --recurse-submodules {self.github_url} {dst_folder}',
+          shell=True)
+
+    # Locate common build configuration files
+    for root_dir, _, files in os.walk(target_source_path):
+      for file in files:
+        if file in self.target_files:
+          full_path = os.path.join(root_dir, file)
+          self.target_files[file].append(full_path)
+
+    # Extract content of build files
+    for files in self.target_files.values():
+      for file in files:
+        with open(file, 'r') as f:
+          self.build_files[file] = f.read()
+
+  def _parse_tag(self, response: str, tag: str) -> str:
+    """Parses the tag from LLM response."""
+    patterns = [rf'<{tag}>(.*?)</{tag}>', rf'```{tag}(.*?)```']
+
+    # Matches both xml and code style tags
+    for pattern in patterns:
+      match = re.search(pattern, response, re.DOTALL)
+      if match:
+        return match.group(1).strip()
+
+    return ''
+
+  def _parse_tags(self, response: str, tag: str) -> list[str]:
+    """Parses the tags from LLM response."""
+    patterns = [rf'<{tag}>(.*?)</{tag}>', rf'```{tag}(.*?)```']
+    found_matches = []
+
+    # Matches both xml and code style tags
+    for pattern in patterns:
+      matches = re.findall(pattern, response, re.DOTALL)
+      found_matches.extend([content.strip() for content in matches])
+
+    return found_matches
+
+  def _initial_prompt(self, results: list[Result]) -> Prompt:
+    """Constructs initial prompt of the agent."""
+    self.prompt = self.llm.prompt_type()(None)
+
+    # Extract build configuration files content
+    build_files_str = []
+    for file, content in self.build_files.items():
+      target_str = templates.LLM_BUILD_FILE_TEMPLATE.replace('{PATH}', file)
+      target_str = target_str.replace('{CONTENT}', content)
+      build_files_str.append(target_str)
+
+    # Extract template Dockerfile content
+    dockerfile_str = templates.CLEAN_OSS_FUZZ_DOCKER
+    dockerfile_str = dockerfile_str.replace('{additional_packages}', '')
+    dockerfile_str = dockerfile_str.replace('{repo_url}', self.github_url)
+    dockerfile_str = dockerfile_str.replace('{project_repo_dir}',
+                                            self.github_url.split('/')[-1])
+
+    # Prepare prompt problem string
+    problem = templates.LLM_PROBLEM.replace('{BUILD_FILES}',
+                                            '\n'.join(build_files_str))
+    problem = problem.replace('{DOCKERFILE}', dockerfile_str)
+
+    self.prompt.add_priming(templates.LLM_PRIMING)
+    self.prompt.add_problem(problem)
+
+    return self.prompt
+
+  def _container_handle_bash_commands(self, response: str, tool: BaseTool,
+                                      prompt: Prompt) -> Prompt:
+    """Handles the command from LLM with container |tool|."""
+    prompt_text = ''
+    success = True
+    for command in self._parse_tags(response, 'bash'):
+      result = tool.execute(command)
+      success = success and (result.returncode == 0)
+      prompt_text += self._format_bash_execution_result(
+          result, previous_prompt=prompt) + '\n'
+
+    self.last_status = success
+    self.last_result = prompt_text
+
+    return prompt
+
+  def _container_handle_conclusion(self, cur_round: int, response: str,
+                                   build_result: BuildResult,
+                                   prompt: Prompt) -> Optional[Prompt]:
+    """Runs a compilation tool to validate the new build script from LLM."""
+    logger.info('----- ROUND %02d Received conclusion -----',
+                cur_round,
+                trial=build_result.trial)
+
+    # Execution fail
+    if not self.last_status:
+      retry = templates.LLM_RETRY.replace('{BASH_RESULT}', self.last_result)
+
+      # Refine prompt text to max prompt count and add to prompt
+      length = min(len(retry), (MAX_PROMPT_LENGTH - len(prompt.gettext())))
+      prompt.add_problem(retry[-length:])
+
+      # Store build result
+      build_result.compiles = False
+      build_result.compile_error = self.last_result
+
+      return prompt
+
+    # Execution success
+    build_result.compiles = True
+    build_result.build_script_source = '\n'.join(
+        self._parse_tags(response, 'bash'))
+
+    return None
+
+  def _container_tool_reaction(self, cur_round: int, response: str,
+                               build_result: BuildResult) -> Optional[Prompt]:
+    """Validates LLM conclusion or executes its command."""
+    prompt = copy.deepcopy(self.prompt)
+
+    if response:
+      prompt = self._container_handle_bash_commands(response, self.inspect_tool,
+                                                    prompt)
+
+      # Check result and try building with the new builds script
+      prompt = self._container_handle_conclusion(cur_round, response,
+                                                 build_result, prompt)
+
+      if prompt is None:
+        return None
+
+    if not response or not prompt or not prompt.get():
+      prompt = self._container_handle_invalid_tool_usage(
+          self.inspect_tool, cur_round, response, prompt)
+
+    return prompt
+
+  def execute(self, result_history: list[Result]) -> BuildResult:
+    """Executes the agent based on previous result."""
+    last_result = result_history[-1]
+    logger.info('Executing %s', self.name, trial=last_result.trial)
+    benchmark = last_result.benchmark
+    self.inspect_tool = ProjectContainerTool(benchmark, name='inspect')
+    self.inspect_tool.compile(extra_commands=' && rm -rf /out/* > /dev/null')
+    cur_round = 1
+    build_result = BuildResult(benchmark=benchmark,
+                               trial=last_result.trial,
+                               work_dirs=last_result.work_dirs,
+                               author=self,
+                               chat_history={self.name: ''})
+    self._discover_build_configurations()
+    prompt = self._initial_prompt(result_history)
+    try:
+      client = self.llm.get_chat_client(model=self.llm.get_model())
+      while prompt and cur_round < self.max_round:
+        response = self.chat_llm(cur_round,
+                                 client=client,
+                                 prompt=prompt,
+                                 trial=last_result.trial)
+        prompt = self._container_tool_reaction(cur_round, response,
+                                               build_result)
+        cur_round += 1
+    finally:
+      logger.info('Stopping and removing the inspect container %s',
+                  self.inspect_tool.container_id,
+                  trial=last_result.trial)
+      self.inspect_tool.terminate()
+
+    return build_result

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 import logger
 from agent.base_agent import BaseAgent
-from experimental.build_generator import templates, file_utils
+from experimental.build_generator import file_utils, templates
 from llm_toolkit.models import LLM
 from llm_toolkit.prompts import Prompt
 from results import BuildResult, Result
@@ -241,7 +241,7 @@ class BuildSystemBuildScriptAgent(BuildScriptAgent):
     self.target_path = target_path
     return len(self.build_files) > 0
 
-  def _initial_prompt(self, results: list[Result]) -> Prompt:
+  def _initial_prompt(self, results: list[Result]) -> Prompt:  # pylint: disable=unused-argument
     """Constructs initial prompt of the agent."""
     prompt = self.llm.prompt_type()(None)
 

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -14,72 +14,46 @@
 """LLM Build Script Agent"""
 
 import argparse
-import copy
 import os
 import re
+import shutil
 import subprocess
 from typing import Optional
 
 import logger
 from agent.base_agent import BaseAgent
-from experimental.build_generator import templates
+from experimental.build_generator import templates, file_utils
 from llm_toolkit.models import LLM
 from llm_toolkit.prompts import Prompt
 from results import BuildResult, Result
 from tool.base_tool import BaseTool
 from tool.container_tool import ProjectContainerTool
 
-MAX_PROMPT_LENGTH = 25000
+MAX_PROMPT_LENGTH = 20000
 
 
 class BuildScriptAgent(BaseAgent):
-  """Generate a working Dockerfile and build script from scratch."""
+  """Base class for buidl script agent."""
 
   def __init__(self,
                trial: int,
                llm: LLM,
                args: argparse.Namespace,
                github_url: str,
+               language: str,
                tools: Optional[list[BaseTool]] = None,
                name: str = ''):
     super().__init__(trial, llm, args, tools, name)
     self.github_url = github_url
+    self.language = language
     self.build_files = {}
+    self.last_status = False
     self.last_result = ''
-    self.target_files = {
-        'Makefile': [],
-        'configure.ac': [],
-        'Makefile.am': [],
-        'autogen.sh': [],
-        'bootstrap.sh': [],
-        'CMakeLists.txt': [],
-        'Config.in': [],
-    }
+    self.target_files = {}
 
-  def _discover_build_configurations(self) -> None:
-    """Helper to discover the build configuartions of a repository."""
-    # Clone targert repository
-    target_source_path = os.path.join(os.getcwd(), self.args.work_dirs,
-                                      self.github_url.split('/')[-1])
-    dst_folder = os.path.join(self.args.work_dirs,
-                              self.github_url.split('/')[-1])
-    if not os.path.isdir(target_source_path):
-      subprocess.check_call(
-          f'git clone --recurse-submodules {self.github_url} {dst_folder}',
-          shell=True)
-
-    # Locate common build configuration files
-    for root_dir, _, files in os.walk(target_source_path):
-      for file in files:
-        if file in self.target_files:
-          full_path = os.path.join(root_dir, file)
-          self.target_files[file].append(full_path)
-
-    # Extract content of build files
-    for files in self.target_files.values():
-      for file in files:
-        with open(file, 'r') as f:
-          self.build_files[file] = f.read()
+    # Get sample fuzzing harness
+    _, _, self.harness_path, self.harness_code = (
+        file_utils.get_language_defaults(self.language))
 
   def _parse_tag(self, response: str, tag: str) -> str:
     """Parses the tag from LLM response."""
@@ -105,44 +79,25 @@ class BuildScriptAgent(BaseAgent):
 
     return found_matches
 
-  def _initial_prompt(self, results: list[Result]) -> Prompt:
-    """Constructs initial prompt of the agent."""
-    self.prompt = self.llm.prompt_type()(None)
-
-    # Extract build configuration files content
-    build_files_str = []
-    for file, content in self.build_files.items():
-      target_str = templates.LLM_BUILD_FILE_TEMPLATE.replace('{PATH}', file)
-      target_str = target_str.replace('{CONTENT}', content)
-      build_files_str.append(target_str)
-
-    # Extract template Dockerfile content
-    dockerfile_str = templates.CLEAN_OSS_FUZZ_DOCKER
-    dockerfile_str = dockerfile_str.replace('{additional_packages}', '')
-    dockerfile_str = dockerfile_str.replace('{repo_url}', self.github_url)
-    dockerfile_str = dockerfile_str.replace('{project_repo_dir}',
-                                            self.github_url.split('/')[-1])
-
-    # Prepare prompt problem string
-    problem = templates.LLM_PROBLEM.replace('{BUILD_FILES}',
-                                            '\n'.join(build_files_str))
-    problem = problem.replace('{DOCKERFILE}', dockerfile_str)
-
-    self.prompt.add_priming(templates.LLM_PRIMING)
-    self.prompt.add_problem(problem)
-
-    return self.prompt
-
   def _container_handle_bash_commands(self, response: str, tool: BaseTool,
                                       prompt: Prompt) -> Prompt:
     """Handles the command from LLM with container |tool|."""
+    # Update fuzzing harness
+    harness = self._parse_tag(response, 'fuzzer')
+    if harness:
+      self.harness_code = harness
+    if isinstance(tool, ProjectContainerTool):
+      tool.write_to_file(self.harness_code, self.harness_path)
+
+    # Try execute the generated build script
     prompt_text = ''
     success = True
     for command in self._parse_tags(response, 'bash'):
       result = tool.execute(command)
       success = success and (result.returncode == 0)
-      prompt_text += self._format_bash_execution_result(
-          result, previous_prompt=prompt) + '\n'
+      format_result = self._format_bash_execution_result(result,
+                                                         previous_prompt=prompt)
+      prompt_text += self._parse_tag(format_result, 'stderr') + '\n'
 
     self.last_status = success
     self.last_result = prompt_text
@@ -173,15 +128,18 @@ class BuildScriptAgent(BaseAgent):
 
     # Execution success
     build_result.compiles = True
-    build_result.build_script_source = '\n'.join(
-        self._parse_tags(response, 'bash'))
+    build_result.fuzz_target_source = self.harness_code
+    build_script_source = '\n'.join(self._parse_tags(response, 'bash'))
+    if not build_script_source.startswith('#!'):
+      build_script_source = templates.EMPTY_OSS_FUZZ_BUILD + build_script_source
+    build_result.build_script_source = build_script_source
 
     return None
 
   def _container_tool_reaction(self, cur_round: int, response: str,
                                build_result: BuildResult) -> Optional[Prompt]:
     """Validates LLM conclusion or executes its command."""
-    prompt = copy.deepcopy(self.prompt)
+    prompt = self.llm.prompt_type()(None)
 
     if response:
       prompt = self._container_handle_bash_commands(response, self.inspect_tool,
@@ -213,7 +171,7 @@ class BuildScriptAgent(BaseAgent):
                                work_dirs=last_result.work_dirs,
                                author=self,
                                chat_history={self.name: ''})
-    self._discover_build_configurations()
+
     prompt = self._initial_prompt(result_history)
     try:
       client = self.llm.get_chat_client(model=self.llm.get_model())
@@ -232,3 +190,102 @@ class BuildScriptAgent(BaseAgent):
       self.inspect_tool.terminate()
 
     return build_result
+
+
+class BuildSystemBuildScriptAgent(BuildScriptAgent):
+  """Generate a working Dockerfile and build script from scratch
+  with build system."""
+
+  def __init__(self,
+               trial: int,
+               llm: LLM,
+               args: argparse.Namespace,
+               github_url: str,
+               language: str,
+               tools: Optional[list[BaseTool]] = None,
+               name: str = ''):
+    super().__init__(trial, llm, args, github_url, language, tools, name)
+    self.target_files = {
+        'Makefile': [],
+        'configure.ac': [],
+        'Makefile.am': [],
+        'autogen.sh': [],
+        'bootstrap.sh': [],
+        'CMakeLists.txt': [],
+        'Config.in': [],
+    }
+
+  def _discover_build_configurations(self) -> bool:
+    """Helper to discover the build configuartions of a repository."""
+    # Clone targert repository
+    target_path = os.path.join(self.args.work_dirs,
+                               self.github_url.split('/')[-1])
+    if not os.path.isdir(target_path):
+      subprocess.check_call(
+          f'git clone --recurse-submodules {self.github_url} {target_path}',
+          shell=True)
+
+    # Locate common build configuration files
+    for root_dir, _, files in os.walk(target_path):
+      for file in files:
+        if file in self.target_files:
+          full_path = os.path.join(root_dir, file)
+          self.target_files[file].append(full_path)
+
+    # Extract content of build files
+    for files in self.target_files.values():
+      for file in files:
+        with open(file, 'r') as f:
+          self.build_files[file.replace(target_path, '')] = f.read()
+
+    self.target_path = target_path
+    return len(self.build_files) > 0
+
+  def _initial_prompt(self, results: list[Result]) -> Prompt:
+    """Constructs initial prompt of the agent."""
+    prompt = self.llm.prompt_type()(None)
+
+    # Extract build configuration files content
+    build_files_str = []
+    for file, content in self.build_files.items():
+      target_str = templates.LLM_BUILD_FILE_TEMPLATE.replace('{PATH}', file)
+      target_str = target_str.replace('{CONTENT}', content)
+      build_files_str.append(target_str)
+
+    # Extract template Dockerfile content
+    dockerfile_str = templates.CLEAN_OSS_FUZZ_DOCKER
+    dockerfile_str = dockerfile_str.replace('{additional_packages}', '')
+    dockerfile_str = dockerfile_str.replace('{repo_url}', self.github_url)
+    dockerfile_str = dockerfile_str.replace('{project_repo_dir}',
+                                            self.github_url.split('/')[-1])
+
+    # Prepare prompt problem string
+    problem = templates.LLM_PROBLEM.replace('{BUILD_FILES}',
+                                            '\n'.join(build_files_str))
+    problem = problem.replace('{DOCKERFILE}', dockerfile_str)
+    problem = problem.replace('{FUZZER}', self.harness_code)
+    problem = problem.replace('{FUZZING_FILE}',
+                              self.harness_path.split('/')[-1])
+
+    prompt.add_priming(templates.LLM_PRIMING)
+    prompt.add_problem(problem)
+
+    return prompt
+
+  def execute(self, result_history: list[Result]) -> BuildResult:
+    """Executes the agent based on previous result."""
+    if not self._discover_build_configurations():
+      logger.info('No known build configuration.',
+                  self.name,
+                  trial=result_history[-1].trial)
+      return BuildResult(benchmark=result_history[-1].benchmark,
+                         trial=result_history[-1].trial,
+                         work_dirs=result_history[-1].work_dirs,
+                         author=self,
+                         chat_history={self.name: ''})
+
+    # Clean up directory
+    if os.path.isdir(self.target_path):
+      shutil.rmtree(self.target_path)
+
+    return super().execute(result_history)

--- a/experimental/build_generator/manager.py
+++ b/experimental/build_generator/manager.py
@@ -558,7 +558,7 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
   all_build_scripts: List[Tuple[
       str, str, build_script_generator.
       AutoBuildContainer]] = build_script_generator.extract_build_suggestions(
-          target_source_path, 'test-fuzz-build-')
+          target_source_path, 'test-fuzz-build-', LLM_MODEL)
 
   # Check each of the build scripts.
   logger.info('[+] Testing build suggestions')

--- a/experimental/build_generator/manager.py
+++ b/experimental/build_generator/manager.py
@@ -20,7 +20,7 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import build_script_generator
 import templates
@@ -137,7 +137,7 @@ def get_all_introspector_files(target_dir):
   return introspection_files_found
 
 
-def build_empty_fuzzers(build_workers, language):
+def build_empty_fuzzers(build_workers, language, from_agent=False) -> None:
   """Run build scripts against an empty fuzzer harness."""
   # Stage 2: perform program analysis to extract data to be used for
   # harness generation.
@@ -150,7 +150,8 @@ def build_empty_fuzzers(build_workers, language):
     logger.info('Test dir: %s :: %s', test_dir,
                 str(build_worker.executable_files_build['refined-static-libs']))
 
-    if not build_worker.executable_files_build['refined-static-libs']:
+    if not build_worker.executable_files_build[
+        'refined-static-libs'] and not from_agent:
       continue
 
     logger.info('Trying to link in an empty fuzzer')
@@ -209,7 +210,7 @@ def get_language_defaults(language: str):
 
 
 def run_introspector_on_dir(build_worker, test_dir,
-                            language) -> Tuple[bool, List[str]]:
+                            language) -> Tuple[bool, List[str], str, str]:
   """Runs Fuzz Introspector on a target directory with the ability
     to analyse code without having fuzzers (FUZZ_INTROSPECTOR_AUTO_FUZZ=1).
 
@@ -257,22 +258,26 @@ def run_introspector_on_dir(build_worker, test_dir,
 
   # Disable FI light because we want to make sure we can compile as well.
   modified_env['FI_DISABLE_LIGHT'] = "1"
-
+  stdout_str = ''
+  stderr_str = ''
   try:
-    subprocess.check_call('compile',
-                          shell=True,
-                          env=modified_env,
-                          stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL)
+    subprocess.run('compile',
+                   shell=True,
+                   env=modified_env,
+                   capture_output=True,
+                   text=True,
+                   check=True)
     build_returned_error = False
-  except subprocess.CalledProcessError:
+  except subprocess.CalledProcessError as e:
     build_returned_error = True
+    stdout_str = e.stdout
+    stderr_str = e.stderr
 
   if not os.path.isfile('/src/compiled_binary'):
     build_returned_error = True
 
   logger.info('Introspector build: %s', str(build_returned_error))
-  return build_returned_error, fuzzer_build_cmd
+  return build_returned_error, fuzzer_build_cmd, stdout_str, stderr_str
 
 
 def create_clean_oss_fuzz_from_empty(github_repo: str, build_worker,
@@ -538,7 +543,10 @@ def load_introspector_report():
   return summary_report
 
 
-def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
+def auto_generate(github_url,
+                  disable_testing_build_scripts=False,
+                  outdir='',
+                  use_agent=False):
   """Generates build script and fuzzer harnesses for a GitHub repository."""
   target_source_path = os.path.join(os.getcwd(), github_url.split('/')[-1])
   dst_folder = github_url.split('/')[-1]
@@ -548,27 +556,22 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
     subprocess.check_call(
         f'git clone --recurse-submodules {github_url} {dst_folder}', shell=True)
 
-  # Stage 1: Build script generation
   language = determine_project_language(target_source_path)
   logger.info('Target language: %s', language)
   append_to_report(outdir, f'Target language: {language}')
 
-  # record the path
-  logger.info('[+] Extracting build scripts statically')
-  all_build_scripts: List[Tuple[
-      str, str, build_script_generator.
-      AutoBuildContainer]] = build_script_generator.extract_build_suggestions(
-          target_source_path, 'test-fuzz-build-', LLM_MODEL)
-
-  # Check each of the build scripts.
-  logger.info('[+] Testing build suggestions')
-  build_results = build_script_generator.raw_build_evaluation(all_build_scripts)
-  logger.info('Checking results of %d build generators', len(build_results))
+  build_results = {}
+  if use_agent:
+    build_results = auto_generate_agent(target_source_path, language,
+                                        disable_testing_build_scripts)
+  else:
+    build_results = auto_generate_static(target_source_path)
 
   if disable_testing_build_scripts:
     logger.info('disabling testing build scripts')
     return
 
+  # Log raw result
   for test_dir, build_worker in build_results.items():
     build_heuristic = build_worker.build_suggestion.heuristic_id
     static_libs = build_worker.executable_files_build['static-libs']
@@ -582,11 +585,11 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
   # static libraries resulting from the build.
   refine_static_libs(build_results)
 
-  # Stage 2: perform program analysis to extract data to be used for
+  # Stage 3: perform program analysis to extract data to be used for
   # harness generation.
   build_empty_fuzzers(build_results, language)
 
-  # Stage 3: Harness generation and harness testing.
+  # Harness generation and harness testing.
   # We now know for which versions we can generate a base fuzzer.
   # Continue by runnig an introspector build using the auto-generated
   # build scripts but fuzz introspector as the sanitier. The introspector
@@ -601,7 +604,6 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
   # this to check if there are differences in build output.
   logger.info('Going through %d build results to generate fuzzers',
               len(build_results))
-
   for test_dir, build_worker in build_results.items():
     logger.info('Checking build heuristic: %s',
                 build_worker.build_suggestion.heuristic_id)
@@ -616,8 +618,8 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
     if os.path.isdir(INTROSPECTOR_OSS_FUZZ_DIR):
       shutil.rmtree(INTROSPECTOR_OSS_FUZZ_DIR)
 
-    build_returned_error, _ = run_introspector_on_dir(build_worker, test_dir,
-                                                      language)
+    build_returned_error, _, _, _ = run_introspector_on_dir(
+        build_worker, test_dir, language)
 
     if os.path.isdir(INTROSPECTOR_OSS_FUZZ_DIR):
       logger.info('Introspector build success')
@@ -647,6 +649,42 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
                                      test_dir)
 
 
+def auto_generate_agent(
+    target_dir, language, disable_testing_build_scripts
+) -> Dict[str, 'build_script_generator.BuildWorker']:
+  """Generate build script and fuzzer harnesses using llm agent approach."""
+  # Stage 1: Extract auto build llm agent
+  logger.info('[+] Extracting auto build llm agent')
+  llm_agents = build_script_generator.extract_llm_agents(LLM_MODEL, target_dir)
+
+  # Stage 2: Perform build script generation and fail retry
+  logger.info('[+] Perform build script generation and fail retry.')
+  build_results = {}
+  for agent in llm_agents:
+    build_results = build_results | agent.execute(
+        target_dir, language, disable_testing_build_scripts)
+
+  return build_results
+
+
+def auto_generate_static(
+    target_source_path) -> Dict[str, 'build_script_generator.BuildWorker']:
+  """Generate build script and fuzzer harnesses using static approach."""
+  # Stage 1: Build script generation
+  logger.info('[+] Extracting build scripts statically')
+  all_build_scripts: List[Tuple[
+      str, str, build_script_generator.
+      AutoBuildContainer]] = build_script_generator.extract_build_suggestions(
+          target_source_path, 'test-fuzz-build-')
+
+  # Stage 2: Check each of the build scripts.
+  logger.info('[+] Testing build suggestions')
+  build_results = build_script_generator.raw_build_evaluation(all_build_scripts)
+  logger.info('Checking results of %d build generators', len(build_results))
+
+  return build_results
+
+
 def parse_commandline():
   """Commandline parser."""
   parser = argparse.ArgumentParser()
@@ -659,6 +697,10 @@ def parse_commandline():
                       '-m',
                       help='Model to use for auto generation',
                       type=str)
+  parser.add_argument('--agent',
+                      '-a',
+                      help='Use LLM Agent Builder or not.',
+                      action='store_true')
   return parser
 
 
@@ -675,7 +717,7 @@ def main():
 
   append_to_report(args.out, f'Analysing: {args.repo}')
 
-  auto_generate(args.repo, args.disable_build_test, args.out)
+  auto_generate(args.repo, args.disable_build_test, args.out, args.agent)
 
 
 if __name__ == '__main__':

--- a/experimental/build_generator/manager.py
+++ b/experimental/build_generator/manager.py
@@ -20,9 +20,10 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import build_script_generator
+import file_utils as utils
 import templates
 import yaml
 
@@ -58,45 +59,6 @@ class Test:
     self.test_content = test_content
 
 
-def get_all_files_in_path(base_path: str,
-                          path_to_subtract: Optional[str] = None) -> List[str]:
-  """Gets all files in a tree and returns as a list of strings."""
-  all_files = []
-  if path_to_subtract is None:
-    path_to_subtract = os.getcwd()
-  for root, _, files in os.walk(base_path):
-    for fi in files:
-      path = os.path.join(root, fi)
-      if path.startswith(path_to_subtract):
-        path = path[len(path_to_subtract):]
-      if len(path) > 0 and path[0] == '/':
-        path = path[1:]
-      all_files.append(path)
-  return all_files
-
-
-def determine_project_language(path: str) -> str:
-  """Returns the likely language of a project by looking at file suffixes."""
-  all_files = get_all_files_in_path(path, path)
-
-  language_dict = {'c': 0, 'c++': 0}
-  for source_file in all_files:
-    if source_file.endswith('.c'):
-      language_dict['c'] = language_dict['c'] + 1
-    elif source_file.endswith('.cpp'):
-      language_dict['c++'] = language_dict['c++'] + 1
-    elif source_file.endswith('.cc'):
-      language_dict['c++'] = language_dict['c++'] + 1
-
-  target_language = 'c++'
-  max_count = 0
-  for language, count in language_dict.items():
-    if count > max_count:
-      target_language = language
-      max_count = count
-  return target_language
-
-
 def get_all_functions_in_project(introspection_files_found):
   all_functions_in_project = []
   for fi_yaml_file in introspection_files_found:
@@ -126,7 +88,7 @@ def get_all_header_files(all_files: List[str]) -> List[str]:
 
 
 def get_all_introspector_files(target_dir):
-  all_files = get_all_files_in_path(target_dir)
+  all_files = utils.get_all_files_in_path(target_dir)
   introspection_files_found = []
   for yaml_file in all_files:
     if 'allFunctionsWithMain' in yaml_file:
@@ -144,8 +106,8 @@ def build_empty_fuzzers(build_workers, language) -> None:
 
   # For each of the auto generated build scripts try to link
   # the resulting static libraries against an empty fuzzer.
-  fuzz_compiler, _, empty_fuzzer_file, fuzz_template = get_language_defaults(
-      language)
+  fuzz_compiler, _, empty_fuzzer_file, fuzz_template = (
+      utils.get_language_defaults(language))
   for test_dir, build_worker in build_workers.items():
     logger.info('Test dir: %s :: %s', test_dir,
                 str(build_worker.executable_files_build['refined-static-libs']))
@@ -199,15 +161,6 @@ def refine_static_libs(build_results) -> None:
         'refined-static-libs'] = refined_static_list
 
 
-def get_language_defaults(language: str):
-  compilers_and_flags = {
-      'c': ('$CC', '$CFLAGS', '/src/empty-fuzzer.c', templates.C_BASE_TEMPLATE),
-      'c++': ('$CXX', '$CXXFLAGS', '/src/empty-fuzzer.cpp',
-              templates.CPP_BASE_TEMPLATE),
-  }
-  return compilers_and_flags[language]
-
-
 def run_introspector_on_dir(build_worker, test_dir,
                             language) -> Tuple[bool, List[str]]:
   """Runs Fuzz Introspector on a target directory with the ability
@@ -222,7 +175,7 @@ def run_introspector_on_dir(build_worker, test_dir,
     """
   introspector_vanilla_build_script = build_worker.build_script
   (fuzz_compiler, fuzz_flags, empty_fuzzer_file,
-   fuzz_template) = get_language_defaults(language)
+   fuzz_template) = utils.get_language_defaults(language)
 
   with open(empty_fuzzer_file, 'w') as f:
     f.write(fuzz_template)
@@ -290,7 +243,7 @@ def create_clean_oss_fuzz_from_empty(github_repo: str, build_worker,
 
   introspector_vanilla_build_script = build_worker.build_script
   (fuzz_compiler, fuzz_flags, empty_fuzzer_file,
-   fuzz_template) = get_language_defaults(language)
+   fuzz_template) = utils.get_language_defaults(language)
 
   # Write empty fuzzer
   with open(os.path.join(oss_fuzz_folder, os.path.basename(empty_fuzzer_file)),
@@ -310,7 +263,7 @@ def create_clean_oss_fuzz_from_empty(github_repo: str, build_worker,
 
   # Add inclusion of header file paths. This is anticipating any harnesses
   # will make an effort to include relevant header files.
-  all_header_files = get_all_header_files(get_all_files_in_path(test_dir))
+  all_header_files = get_all_header_files(utils.get_all_files_in_path(test_dir))
   paths_to_include = set()
   for header_file in all_header_files:
     if not header_file.startswith('/src/'):
@@ -381,7 +334,7 @@ def create_clean_oss_fuzz_from_success(github_repo: str, out_dir: str,
     yaml.dump(project_yaml, project_out)
 
   # Copy fuzzer
-  _, _, fuzzer_target_file, _ = get_language_defaults(language)
+  _, _, fuzzer_target_file, _ = utils.get_language_defaults(language)
   shutil.copy(
       os.path.join(out_dir, os.path.basename(fuzzer_target_file)),
       os.path.join(oss_fuzz_folder,
@@ -422,7 +375,7 @@ def create_clean_clusterfuzz_lite_from_success(github_repo: str, out_dir: str,
     yaml.dump(project_yaml, project_out)
 
   # Copy fuzzer
-  _, _, fuzzer_target_file, _ = get_language_defaults(language)
+  _, _, fuzzer_target_file, _ = utils.get_language_defaults(language)
   shutil.copy(
       os.path.join(out_dir, os.path.basename(fuzzer_target_file)),
       os.path.join(cflite_folder,
@@ -549,7 +502,7 @@ def auto_generate(github_url, disable_testing_build_scripts=False, outdir=''):
         f'git clone --recurse-submodules {github_url} {dst_folder}', shell=True)
 
   # Stage 1: Build script generation
-  language = determine_project_language(target_source_path)
+  language = utils.determine_project_language(target_source_path)
   logger.info('Target language: %s', language)
   append_to_report(outdir, f'Target language: {language}')
 

--- a/experimental/build_generator/templates.py
+++ b/experimental/build_generator/templates.py
@@ -178,3 +178,17 @@ LLM_BUILD_FILE_TEMPLATE = '''
 <file_path>{PATH}</file_path>
 <file_content>{CONTENT}</file_content>
 '''
+
+LLM_RETRY = '''
+I failed to build the project with the above provided build script.
+Here is a dump of the stdout and stderr while executing the provided build
+script. Please analyse the result and generate a new build script with the
+same assumption above. You must only returns the content of the build script
+and nothing else more as always.
+
+Last 100 lines from the stdout for the execution:
+{STDOUT}
+
+Last 100 lines from the stderr for the execution:
+{STDERR}
+'''


### PR DESCRIPTION
This PR initialis the LLM approach for automatic build script generation of C/C++ projects. This is done by adding a separate path for the new LLM agent. Adding an extra flag --agent could trigger the new LLM agent flow for automatic build script generation.