### PR TITLE
Add chat history logging to Prototyper

### DIFF
--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -438,10 +438,16 @@ class Prototyper(BaseAgent):
     try:
       client = self.llm.get_chat_client(model=self.llm.get_model())
       while prompt and cur_round < self.max_round:
+
+        build_result.chat_history[self.name] += f'Step #{cur_round} - "agent-step": <CHAT PROMPT:ROUND {cur_round:02d}>{prompt.get()}</CHAT PROMPT:ROUND {cur_round:02d}>\n'
+        
         response = self.chat_llm(cur_round,
                                  client=client,
                                  prompt=prompt,
                                  trial=last_result.trial)
+        
+        build_result.chat_history[self.name] += f'Step #{cur_round} - "agent-step": <CHAT RESPONSE:ROUND {cur_round:02d}>{response}</CHAT RESPONSE:ROUND {cur_round:02d}>\n'
+        
         prompt = self._container_tool_reaction(cur_round, response,
                                                build_result)
         cur_round += 1

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -439,15 +439,19 @@ class Prototyper(BaseAgent):
       client = self.llm.get_chat_client(model=self.llm.get_model())
       while prompt and cur_round < self.max_round:
 
-        build_result.chat_history[self.name] += f'Step #{cur_round} - "agent-step": <CHAT PROMPT:ROUND {cur_round:02d}>{prompt.get()}</CHAT PROMPT:ROUND {cur_round:02d}>\n'
-        
+        build_result.chat_history[
+            self.
+            name] += f'Step #{cur_round} - "agent-step": <CHAT PROMPT:ROUND {cur_round:02d}>{prompt.get()}</CHAT PROMPT:ROUND {cur_round:02d}>\n'
+
         response = self.chat_llm(cur_round,
                                  client=client,
                                  prompt=prompt,
                                  trial=last_result.trial)
-        
-        build_result.chat_history[self.name] += f'Step #{cur_round} - "agent-step": <CHAT RESPONSE:ROUND {cur_round:02d}>{response}</CHAT RESPONSE:ROUND {cur_round:02d}>\n'
-        
+
+        build_result.chat_history[
+            self.
+            name] += f'Step #{cur_round} - "agent-step": <CHAT RESPONSE:ROUND {cur_round:02d}>{response}</CHAT RESPONSE:ROUND {cur_round:02d}>\n'
+
         prompt = self._container_tool_reaction(cur_round, response,
                                                build_result)
         cur_round += 1


### PR DESCRIPTION
Related issue #969 

This PR adds chat history logging to the Prototyper agent (and Enhancer as well, since Enhancers inherit from Prototypers). 
