### PR TITLE
Dockerfile enhancement: multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@
 # * Install python3-venv for the built-in Python3 venv module (not installed by default).
 # * Install gcloud CLI from Google Cloud's apt repository.
 
-FROM debian:12
+# Stage 1: Build
+FROM debian:12 AS build
 # Install packages used by the Experiment. Python and Git are required for the experiment.
 # Curl, certs, and gnupg are required to install gcloud.
 RUN apt-get update && \
@@ -32,15 +33,13 @@ RUN apt-get update && \
     wget2 \
     clang-format && \
     python3 -m venv /venv
+
 # Install gcloud cli.
 RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update -y && \
     apt-get install google-cloud-cli -y
-# Set timezone to Australia/Sydney.
-ENV TZ='Australia/Sydney'
-
-
+    
 # Install Docker for OSS-Fuzz.
 # Add Docker's official GPG key:
 RUN apt-get install ca-certificates curl gnupg && \
@@ -48,11 +47,13 @@ RUN apt-get install ca-certificates curl gnupg && \
     curl -fsSL https://download.docker.com/linux/debian/gpg \
     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     chmod a+r /etc/apt/keyrings/docker.gpg
+
 # Add the repository to Apt sources:
 RUN echo \
     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
     tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 RUN apt-get update && \
     apt-get install -y \
     docker-ce \
@@ -61,8 +62,17 @@ RUN apt-get update && \
     docker-buildx-plugin \
     docker-compose-plugin
 
-
 COPY . /experiment
 WORKDIR /experiment
-RUN /venv/bin/pip install --disable-pip-version-check -r requirements.txt
+RUN /venv/bin/pip install --disable-pip-version-check --default-timeout=100 -r requirements.txt
+
+# Stage 2: Runtime
+FROM debian:12
+# Set timezone to Australia/Sydney.
+ENV TZ='Australia/Sydney'
+
+COPY --from=build /venv /venv
+COPY --from=build /experiment /experiment
+WORKDIR /experiment
+
 ENTRYPOINT ["/venv/bin/python3", "./report/docker_run.py"]


### PR DESCRIPTION
This issue aims to refactor the current Dockerfile to use a multistage build approach. The motivation for this change is to:

1. Reduce final image size by excluding unnecessary build-time dependencies (e.g., gcc, libpython3-dev, etc.)
2. Enhance maintainability by clearly separating build and runtime concerns
```
Size of the current docker image: 3.82GB
Size of the docker image after multi-stage build: 1.06GB

```

Closes #990 
