### PR TITLE
Measure line coverage per project in report

### DIFF
--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -198,8 +198,12 @@ td .signature {
       <td>{{ accumulated_results.build_rate |percent }}%</td>
     </tr>
     <tr>
-      <td>Average coverage</td>
+      <td>Average benchmark coverage</td>
       <td>{{ accumulated_results.average_coverage |percent }}%</td>
+    </tr>
+    <tr>
+      <td>Average project coverage</td>
+      <td>{{ accumulated_results.average_project_coverage |percent }}%</td>
     </tr>
     <tr>
       <td>Average line coverage diff</td>


### PR DESCRIPTION
The current report summary only reports average line coverage per benchmark, this PR adds the number per project.
![image](https://github.com/user-attachments/assets/5aeb357b-3446-4e16-be55-456011f995a1)
