### PR TITLE
one-prompt: fix bug for missing coverage agent

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -314,15 +314,17 @@ class DefaultTemplateBuilder(PromptBuilder):
                          instruction: str = '') -> prompts.Prompt:
     """Prepares the code-fixing prompt."""
     priming, priming_weight = self._format_fixer_priming(benchmark)
+
     if error_desc and errors:
-      problem = self._format_fixer_problem(raw_code, error_desc, errors,
-                                           priming_weight, context, instruction)
+      pass
+    elif coverage_result:
+      error_desc = coverage_result.insight
+      errors = coverage_result.suggestions.splitlines()
     else:
-      assert coverage_result
-      problem = self._format_fixer_problem(
-          raw_code, coverage_result.insight,
-          coverage_result.suggestions.splitlines(), priming_weight, context,
-          instruction)
+      error_desc = ''
+      errors = []
+    problem = self._format_fixer_problem(raw_code, error_desc, errors,
+                                           priming_weight, context, instruction)
 
     self._prepare_prompt(priming, problem)
     return self._prompt
@@ -739,15 +741,17 @@ class EnhancerTemplateBuilder(PrototyperTemplateBuilder):
     priming_weight = self._model.estimate_token_num(priming)
     # TODO(dongge): Refine this logic.
     if self.error_desc and self.errors:
-
-      problem = self._format_fixer_problem(self.build_result.fuzz_target_source,
-                                           self.error_desc, self.errors,
-                                           priming_weight, '', '')
+      error_desc = self.error_desc
+      errors = self.errors
+    elif self.coverage_result:
+      error_desc = self.coverage_result.insight
+      errors = self.coverage_result.suggestions.splitlines()
     else:
-      assert self.coverage_result
-      problem = self._format_fixer_problem(
-          self.build_result.fuzz_target_source, self.coverage_result.insight,
-          self.coverage_result.suggestions.splitlines(), priming_weight, '', '')
+      error_desc = ''
+      errors = []
+    problem = self._format_fixer_problem(self.build_result.fuzz_target_source,
+                                           error_desc, errors,
+                                           priming_weight, '', '')
 
     self._prepare_prompt(priming, problem)
     return self._prompt

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -324,7 +324,7 @@ class DefaultTemplateBuilder(PromptBuilder):
       error_desc = ''
       errors = []
     problem = self._format_fixer_problem(raw_code, error_desc, errors,
-                                           priming_weight, context, instruction)
+                                         priming_weight, context, instruction)
 
     self._prepare_prompt(priming, problem)
     return self._prompt
@@ -750,8 +750,8 @@ class EnhancerTemplateBuilder(PrototyperTemplateBuilder):
       error_desc = ''
       errors = []
     problem = self._format_fixer_problem(self.build_result.fuzz_target_source,
-                                           error_desc, errors,
-                                           priming_weight, '', '')
+                                         error_desc, errors, priming_weight, '',
+                                         '')
 
     self._prepare_prompt(priming, problem)
     return self._prompt

--- a/stage/analysis_stage.py
+++ b/stage/analysis_stage.py
@@ -35,7 +35,10 @@ class AnalysisStage(BaseStage):
     if last_result.crashes:
       agent = self.get_agent(agent_name='SemanticAnalyzer')
     else:
-      agent = self.get_agent(agent_name='CoverageAnalyzer')
+      try:
+        agent = self.get_agent(agent_name='CoverageAnalyzer')
+      except RuntimeError:
+        agent = self.get_agent(agent_name='SemanticAnalyzer')
     analysis_result = self._execute_agent(agent, result_history)
 
     # TODO(dongge): Save logs and more info into workdir.


### PR DESCRIPTION
Following https://github.com/google/oss-fuzz-gen/pull/928 the analysis stage tries to get a a coverage agent https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/stage/analysis_stage.py#L38 and throws a RuntimeError if it does not exist: https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/stage/base_stage.py#L55
But only the agent approach has a CoverageAnalyzer: https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/run_one_experiment.py#L256

This fixes it by enabling so an error is not thrown if there's no coverage analyzer agent in the analysis stage. Ultimately I assume one of the aims of the architecture around the pipeline/modularised agent is to support plug-and-play style (many agents, pick those you like), so we should allow different pipelines to use different agents. Arguably we should enable CoverageAnalyzer for the one-prompt pipeline as well, but will do that a bit further down the line after finishing running some experiments focused on other things.
