### PR TITLE
results: add success field to base class

### DIFF
--- a/results.py
+++ b/results.py
@@ -39,7 +39,8 @@ class Result:
                fuzz_target_source: str = '',
                build_script_source: str = '',
                author: Any = None,
-               chat_history: Optional[dict] = None) -> None:
+               chat_history: Optional[dict] = None,
+               default_success: bool = False) -> None:
     self.benchmark = benchmark
     self.trial = trial
     self.work_dirs = work_dirs
@@ -47,6 +48,7 @@ class Result:
     self.build_script_source = build_script_source
     self.author = author
     self.chat_history = chat_history or {}
+    self.default_success = default_success
 
   def __repr__(self) -> str:
     attributes = [
@@ -54,6 +56,10 @@ class Result:
         if k not in self._repr_exclude
     ]
     return f'{self.__class__.__name__}({", ".join(attributes)})'
+
+  @property
+  def success(self):
+    return self.default_success
 
   def to_dict(self) -> dict:
     return {


### PR DESCRIPTION
We're running into issues in the cloud build when dill deserialization fails, because https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/common/cloud_builder.py#L422 may return a Result object, which gets called from https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/stage/base_stage.py#L62-L63 which get's called from https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/stage/analysis_stage.py#L39 and the pipeline uses the success field: https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/pipeline.py#L123-L127 but the base Result class does not have a success field: https://github.com/google/oss-fuzz-gen/blob/d12ae0e2a9a51dcbc1e2655288b059954a25dc48/results.py#L24-L70

This fixes it by introducing a default (failed) success property.