### PR TITLE
Aggregated Metrics -average coverage, number of crashes, and execution time.

### DIFF
--- a/report/common.py
+++ b/report/common.py
@@ -74,6 +74,8 @@ class Benchmark:
   project: str = ''
   function: str = ''
   language: str = ''
+  accumulated_results: AccumulatedResult = dataclasses.field(default_factory=AccumulatedResult)
+  execution_time: float = 0.0
 
 
 @dataclasses.dataclass

--- a/report/templates/index.json
+++ b/report/templates/index.json
@@ -12,6 +12,13 @@
         {% if benchmark.result.max_coverage_diff_report %}
         ,"max_line_coverage_diff_report": "{{ benchmark.result.max_coverage_diff_report }}"
         {%- endif %}
+        ,"accumulated_results": {
+                     "total_runs":       {{ benchmark.accumulated_results.total_runs }},
+                    "total_coverage":   {{ benchmark.accumulated_results.total_coverage }},
+                     "crashes":          {{ benchmark.accumulated_results.crashes }},
+                     "crash_cases":      {{ benchmark.accumulated_results.crash_cases }}
+                  }
+                  ,"execution_time": {{ benchmark.execution_time }}
     }{% if not loop.last %},{% endif %}
 {% endfor %}
     ]

--- a/report/trends_report_web/index.html
+++ b/report/trends_report_web/index.html
@@ -68,6 +68,7 @@ limitations under the License.
       <h2>Overview</h2>
       <div id="overview-chart" class="chart"></div>
       <div id="overview-table"></div>
+      <div id="aggregated-metrics" class="aggregated-metrics"></div>
       <h2>Projects</h2>
       <div id="overview-coverage-chart" class="chart"></div>
       <div id="projects" class="projects"></div>

--- a/report/trends_report_web/style.css
+++ b/report/trends_report_web/style.css
@@ -114,6 +114,26 @@ button {
 }
 
 /*
+ *aggregated metrics
+ */
+
+#aggregated-metrics {
+  margin: 1rem 0;
+}
+#aggregated-metrics table {
+  width: auto;
+  border-collapse: collapse;
+}
+#aggregated-metrics th,
+#aggregated-metrics td {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+}
+#aggregated-metrics h3 {
+  margin-bottom: 0.5rem;
+}
+
+/*
  * Projects
  */
 .projects {

--- a/report/web.py
+++ b/report/web.py
@@ -199,7 +199,11 @@ class GenerateReport:
 
     self._write_index_html(benchmarks, accumulated_results, time_results,
                            projects, samples_with_bugs, coverage_language_gains)
-    self._write_index_json(benchmarks)
+    self._write_index_json(
+        benchmarks,
+        accumulated_results=accumulated_results,
+        time_results=time_results,
+        projects=projects)
 
   def _write(self, output_path: str, content: str):
     """Utility write to filesystem function."""
@@ -232,9 +236,18 @@ class GenerateReport:
         coverage_language_gains=coverage_language_gains)
     self._write('index.html', rendered)
 
-  def _write_index_json(self, benchmarks: List[Benchmark]):
+ def _write_index_json(self,
+                        benchmarks: List[Benchmark],
+                        accumulated_results: AccumulatedResult,
+                        time_results: dict[str, Any],
+                        projects: list[Project]):
     """Generate the report index.json and write to filesystem."""
-    rendered = self._jinja.render('index.json', benchmarks=benchmarks)
+    rendered = self._jinja.render(
+        'index.json',
+        benchmarks=benchmarks,
+        accumulated_results=accumulated_results,
+        time_results=time_results,
+        projects=projects)
     self._write('index.json', rendered)
 
   def _write_benchmark_index(self, benchmark: Benchmark, samples: List[Sample],


### PR DESCRIPTION
### Aggregated Metrics 

**This will allow users to quickly compare the performance of different fuzzing strategies.**

now should include accumulated_results , execution_time in json file .

should show average of coverage across the experiements, total no of crashes and execution time plus total no of crash cases 
![Screenshot 2025-04-21 131352](https://github.com/user-attachments/assets/ff3b7551-91cd-4917-8ca7-c71777d3e045)
 
@DonggeLiu  could you please take look, thank you !