### PR TITLE
build-generator: re-enable e2e after installation

### DIFF
--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -94,7 +94,7 @@ def setup_worker_project(oss_fuzz_base: str,
   # Copy over the generator
   files_to_copy = {
       'build_script_generator.py', 'manager.py', 'templates.py', 'constants.py',
-      'file_utils.py', '../../requirements.txt'
+      'file_utils.py'
   }
   for target_file in files_to_copy:
     shutil.copyfile(

--- a/experimental/build_generator/templates.py
+++ b/experimental/build_generator/templates.py
@@ -126,8 +126,8 @@ RUN mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 # TODO(David): enable this and make sure performance is too
 # exhaustive (100+ min for some projects)
 ENV FI_DISABLE_LIGHT=1
-COPY *.py *.json requirements.txt $SRC/
-RUN pip install -r requirements.txt
+COPY *.py *.json $SRC/
+RUN python3 -m pip install pyyaml
 WORKDIR $SRC
 COPY build.sh $SRC/
 '''


### PR DESCRIPTION
https://github.com/google/oss-fuzz-gen/pull/979 caused issues when using `oss-fuzz-generator` from the installed package, because `requirements.txt` is not found in the package. Fixing this by avoiding to copy it in, and just install the library we need.