### PR TITLE
build_generation: Fix false positive result

### DIFF
--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -17,6 +17,7 @@ import argparse
 import os
 import re
 import subprocess
+import time
 from typing import Optional
 
 import logger
@@ -92,11 +93,18 @@ class BuildScriptAgent(BaseAgent):
     prompt_text = ''
     success = True
     for command in self._parse_tags(response, 'bash'):
+      # Add set -e to ensure docker image failing is reflected.
+      command = command.replace('#!/bin/bash', '')
+      command = f'set -e\n{command}'
+
+      # Test command in docker
       result = tool.execute(command)
-      success = success and (result.returncode == 0)
       format_result = self._format_bash_execution_result(result,
                                                          previous_prompt=prompt)
       prompt_text += self._parse_tag(format_result, 'stderr') + '\n'
+      if result.returncode != 0:
+        success = False
+        break
 
     self.last_status = success
     self.last_result = prompt_text
@@ -157,6 +165,30 @@ class BuildScriptAgent(BaseAgent):
 
     return prompt
 
+  def _prepare_repository(self) -> str:
+    """Helper to prepare the repository for analysis."""
+    target_path = os.path.join(self.args.work_dirs,
+                               self.github_url.split('/')[-1])
+    if not os.path.isdir(target_path):
+      subprocess.check_call(
+          f'git clone --recurse-submodules {self.github_url} {target_path}',
+          shell=True)
+
+    return target_path
+
+  def _discover_headers(self) -> list[str]:
+    """Helper to discover all header file directories for inclusion."""
+    # Prepare targert repository
+    target_path = self._prepare_repository()
+
+    headers = set()
+    for root, _, files in os.walk(target_path):
+      for file in files:
+        if file.endswith((".h", ".hpp")):
+          headers.add(root.replace(target_path, ''))
+
+    return list(headers)
+
   def execute(self, result_history: list[Result]) -> BuildResult:
     """Executes the agent based on previous result."""
     last_result = result_history[-1]
@@ -175,6 +207,9 @@ class BuildScriptAgent(BaseAgent):
     try:
       client = self.llm.get_chat_client(model=self.llm.get_model())
       while prompt and cur_round < self.max_round:
+        # Sleep for a minute to avoid over RPM
+        time.sleep(60)
+
         response = self.chat_llm(cur_round,
                                  client=client,
                                  prompt=prompt,
@@ -216,13 +251,8 @@ class BuildSystemBuildScriptAgent(BuildScriptAgent):
 
   def _discover_build_configurations(self) -> bool:
     """Helper to discover the build configuartions of a repository."""
-    # Clone targert repository
-    target_path = os.path.join(self.args.work_dirs,
-                               self.github_url.split('/')[-1])
-    if not os.path.isdir(target_path):
-      subprocess.check_call(
-          f'git clone --recurse-submodules {self.github_url} {target_path}',
-          shell=True)
+    # Prepare targert repository
+    target_path = self._prepare_repository()
 
     # Locate common build configuration files
     for root_dir, _, files in os.walk(target_path):
@@ -264,6 +294,9 @@ class BuildSystemBuildScriptAgent(BuildScriptAgent):
     problem = problem.replace('{FUZZER}', self.harness_code)
     problem = problem.replace('{FUZZING_FILE}',
                               self.harness_path.split('/')[-1])
+
+    headers = self._discover_headers()
+    problem = problem.replace('{HEADERS}', ','.join(headers))
 
     prompt.add_priming(templates.LLM_PRIMING)
     prompt.add_problem(problem)

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -32,6 +32,7 @@ from tool.container_tool import ProjectContainerTool
 MAX_PROMPT_LENGTH = 20000
 SAMPLE_HEADERS_COUNT = 30
 
+
 class BuildScriptAgent(BaseAgent):
   """Base class for buidl script agent."""
 

--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -391,6 +391,7 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
     for llm_agent_ctr in llm_agents:
       build_script = ''
       harness = ''
+      build_success = False
       for trial in range(args.max_round):
         logger.info('Agent: %s. Round %d', llm_agent_ctr.__name__, trial)
         agent = llm_agent_ctr(trial=trial,
@@ -410,6 +411,7 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
           break
 
         if build_result.compiles:
+          build_success = True
           build_script = build_result.build_script_source
           harness = build_result.fuzz_target_source
           break
@@ -417,7 +419,7 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
         logger.info('Round %d build script generation failed for project %s',
                     trial, target_repository)
 
-      if build_script:
+      if build_success:
         logger.info('Build script generation success for project %s',
                     target_repository)
 
@@ -479,7 +481,7 @@ def parse_commandline():
                       '-mr',
                       help='Max round of trial for the llm build script agent.',
                       type=int,
-                      default=5)
+                      default=10)
   parser.add_argument('--work-dirs',
                       '-w',
                       help='Working directory path.',

--- a/experimental/build_generator/templates.py
+++ b/experimental/build_generator/templates.py
@@ -214,7 +214,7 @@ Below is the template fuzzing harness, which you must follow and modify:
 
 </fuzzer>
 
-Lastly, here is a list of all comma-separated directories that contain header files that you may need to include.
+Lastly, here is a list of all comma-separated header files, please choose some to include.
 <headers>
 {HEADERS}
 </headers>

--- a/experimental/build_generator/templates.py
+++ b/experimental/build_generator/templates.py
@@ -184,9 +184,13 @@ Please also modify the provided fuzzing harness (stored as `$SRC/{FUZZING_FILE}`
 Generate the most suitable Bash build script for compiling the project, assuming the build is performed on Ubuntu 24.04.
 Assume the build script, stored as `$SRC/build.sh`  will be executed with root privileges – therefore, do not use `sudo`.
 
-Include any necessary flags and environment variables. Please avoid modifying existing environemnt variable flag.
+`$CC` and `$CXX` is already exist, use them to compile source code.
 
-Avoid running tests or installation steps – the goal is to compile the project into a static library. If the original build system does not produce a static library, attempt to use `llvm-ar` to archive object files instead.
+Include any other necessary flags and environment variables. Please use if statement (`if [ -z "${FLAG:-}" ]`) to check if the variable exist or not, if it is existed, append to the original variables, otherwise, create it.
+
+Avoid running tests or installation steps – the goal is to compile the project into a static library if possible. But do not modify any build configuration files (e.g., using `sed` or similar tools).
+
+If the original build system does not produce a static library, attempt to use `llvm-ar` to archive object files instead.
 
 Do not modify any build configuration files (e.g., using `sed` or similar tools).
 
@@ -207,7 +211,13 @@ Here is the Dockerfile that will be used for the build. Assume the build script 
 Below is the template fuzzing harness, which you must follow and modify:
 <fuzzer>
 {FUZZER}
+
 </fuzzer>
+
+Lastly, here is a list of all comma-separated directories that contain header files that you may need to include.
+<headers>
+{HEADERS}
+</headers>
 '''
 
 LLM_BUILD_FILE_TEMPLATE = '''


### PR DESCRIPTION
Following #979, it was observed that the container tools execute the generated build script within the Docker image using a single command. If the **final** command in that script succeeds, the Docker execution will return an exit code of `0`—even if earlier commands have failed. This leads to false positives in interpreting the build result.

This PR addresses the issue by prepending `set -e` to the command sequence passed to the container tool. This ensures the script exits immediately upon any command failure, preserving the non-zero exit code to correctly indicate build script failures.

Additionally, this PR improves parts of the prompt templates and refines the retry-wait logic, resulting in more reliable LLM-driven build script generation.