### PR TITLE
build-generator: support linking against multiple libs

### DIFF
--- a/experimental/build_generator/build_script_generator.py
+++ b/experimental/build_generator/build_script_generator.py
@@ -315,6 +315,7 @@ class PureMakefileScannerWithSubstitutions(AutoBuildBase):
         'sed -i \'s/CC=/#CC=/g\' ./Makefile',
         'sed -i \'s/CXX=/#CXX=/g\' ./Makefile',
         'sed -i \'s/CC =/#CC=/g\' ./Makefile',
+        'sed -i \'s/gcc/clang/g\' Make.Rules || true',
         'sed -i \'s/CXX =/#CXX=/g\' ./Makefile', 'make V=1 || true'
     ]
     build_container.heuristic_id = self.name + '1'


### PR DESCRIPTION
Sometimes we don't want to link all static libs produced. We shuold test combinations of each.

Also add further makefile adjustments and adds `--no-whole-archive` after linking in the relevant found libraries. This is to avoid linking in whole std libraries, which can cause issues and is bad practice.