### PR TITLE
build_generation: Fix invalid response handling and llm model handling

### DIFF
--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -369,21 +369,10 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
   # Prepare environment
   worker_project_name = get_next_worker_project(oss_fuzz_base)
 
-  # Prepare LLM model
-  llm = models.LLM.setup(
-      ai_binary=os.getenv('AI_BINARY', ''),
-      name=args.model,
-      max_tokens=4096,
-      num_samples=1,
-      temperature=0.4,
-      temperature_list=[],
-  )
-  llm.MAX_INPUT_TOKEN = llm_agent.MAX_PROMPT_LENGTH
-
   # All agents
   llm_agents = [
+      llm_agent.AutoDiscoveryBuildScriptAgent,
       llm_agent.BuildSystemBuildScriptAgent,
-      llm_agent.AutoDiscoveryBuildScriptAgent
   ]
 
   for target_repository in target_repositories:
@@ -399,6 +388,17 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
       harness = ''
       build_success = False
       for trial in range(args.max_round):
+        # Prepare new LLM model
+        llm = models.LLM.setup(
+            ai_binary=os.getenv('AI_BINARY', ''),
+            name=args.model,
+            max_tokens=4096,
+            num_samples=1,
+            temperature=0.4,
+            temperature_list=[],
+        )
+        llm.MAX_INPUT_TOKEN = llm_agent.MAX_PROMPT_LENGTH
+
         logger.info('Agent: %s. Round %d', llm_agent_ctr.__name__, trial)
         agent = llm_agent_ctr(trial=trial,
                               llm=llm,


### PR DESCRIPTION
This PR addresses two issues that impact the success rate of the Auto Discovery Build Generation Agent:

1. Occasionally, the LLM returns invalid results with incorrect tags for parsing. This PR introduces a new prompt to explain the situation to the LLM and instruct it to correct the response.  
2. The LLM model was previously instantiated only once for all projects and trials, resulting in a bug where chat history from previous projects was incorrectly preserved and influenced subsequent LLM processes. This PR resolves the issue by reinitialising the LLM model for each project trial.