### PR TITLE
build-generator: make sure we only parse a single build script

### DIFF
--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -93,7 +93,7 @@ class BuildScriptAgent(BaseAgent):
 
     # Retrieve data from response
     harness = self._parse_tag(response, 'fuzzer')
-    build_script = '\n'.join(self._parse_tags(response, 'bash'))
+    build_script = self._parse_tag(response, 'bash')
     commands = '; '.join(self._parse_tags(response, 'command'))
 
     if build_script:
@@ -174,7 +174,7 @@ class BuildScriptAgent(BaseAgent):
     # Execution success
     build_result.compiles = True
     build_result.fuzz_target_source = self.harness_code
-    build_script_source = '\n'.join(self._parse_tags(response, 'bash'))
+    build_script_source = self._parse_tag(response, 'bash')
     if not build_script_source.startswith('#!'):
       build_script_source = templates.EMPTY_OSS_FUZZ_BUILD + build_script_source
     build_result.build_script_source = build_script_source


### PR DESCRIPTION
I observed several cases where a response from the LLMs are in the format:

```
The `Makefile` provides several targets, primarily for testing and examples. There are no explicit targets for building a static library or object files, but we can compile `jsmn.c` directly to create the necessary object files or a static library for linking with our fuzzer.

Here's the plan:

1. Compile `jsmn.c` to an object file.
2. Archive the object file into a static library.
3. Compile the fuzzing harness with the static library.

Let's proceed with generating the build script and updating the fuzzing harness.

### Build Script

```bash
<bash>
# Set up compilation flags
if [ -z "${CFLAGS:-}" ]; then
  CFLAGS="-I$SRC/jsmn"
else
  CFLAGS="$CFLAGS -I$SRC/jsmn"
fi

# Compile jsmn.c into an object file
$CC $CFLAGS -c $SRC/jsmn/jsmn.c -o jsmn.o

# Archive the object file into a static library
llvm-ar rcs libjsmn.a jsmn.o

# Compile the fuzzing harness with the static library
$CC $CFLAGS $SRC/empty-fuzzer.c -o fuzzer -Wl,--whole-archive libjsmn.a -Wl,--no-whole-archive
</bash>
`` ` (added a space for GitHub)

### Updated Fuzzing Harness

```fuzzer
<fuzzer>
#include <stdint.h>
#include <stdlib.h>
#include <stdio.h>
#include "jsmn.h"

int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
{
    printf("Hello world\n");
    // Insert fuzzer contents here
    // input string contains fuzz input.

    // end of fuzzer contents

    return 0;
}
</fuzzer>
```

The problem is that "```bash" is in the response, and also "<bash>".

The current logic will parse both tags and then contruct a double-build script that looks like:
```
# Set up compilation flags
if [ -z "${CFLAGS:-}" ]; then
  CFLAGS="-I$SRC/jsmn"
else
  CFLAGS="$CFLAGS -I$SRC/jsmn"
fi

# Compile jsmn.c into an object file
$CC $CFLAGS -c $SRC/jsmn/jsmn.c -o jsmn.o

# Archive the object file into a static library
llvm-ar rcs libjsmn.a jsmn.o

# Compile the fuzzing harness with the static library
$CC $CFLAGS $SRC/empty-fuzzer.c -o fuzzer -Wl,--whole-archive libjsmn.a -Wl,--no-whole-archive
<bash>
# Set up compilation flags
if [ -z "${CFLAGS:-}" ]; then
  CFLAGS="-I$SRC/jsmn"
else
  CFLAGS="$CFLAGS -I$SRC/jsmn"
fi

# Compile jsmn.c into an object file
$CC $CFLAGS -c $SRC/jsmn/jsmn.c -o jsmn.o

# Archive the object file into a static library
llvm-ar rcs libjsmn.a jsmn.o

# Compile the fuzzing harness with the static library
$CC $CFLAGS $SRC/empty-fuzzer.c -o fuzzer -Wl,--whole-archive libjsmn.a -Wl,--no-whole-archive
</bash>
```

This commit makes sure we only handle the XML tags.
