### PR TITLE
base_agent: use gettext when logging

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -65,7 +65,7 @@ class BaseAgent(ABC):
     """Chat with LLM."""
     logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %02d>',
                 cur_round,
-                prompt.get(),
+                prompt.gettext(),
                 cur_round,
                 trial=trial)
     response = self.llm.chat_llm(client=client, prompt=prompt)
@@ -80,7 +80,7 @@ class BaseAgent(ABC):
     """Chat with LLM."""
     logger.info('<CHAT PROMPT:ROUND %02d>%s</CHAT PROMPT:ROUND %02d>',
                 cur_round,
-                prompt.get(),
+                prompt.gettext(),
                 cur_round,
                 trial=trial)
     response = self.llm.ask_llm(prompt=prompt)


### PR DESCRIPTION
get() provides json formatted output for OpenAI prompts, which is tricky to read in the logs. Formatting with gettext makes following the logs much more intuitive.

This is similar in nature to https://github.com/google/oss-fuzz-gen/pull/976