### PR TITLE
build_generator: llm_agent: reduce sleep time

### DIFF
--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -247,8 +247,8 @@ class BuildScriptAgent(BaseAgent):
     try:
       client = self.llm.get_chat_client(model=self.llm.get_model())
       while prompt:
-        # Sleep for a minute to avoid over RPM
-        time.sleep(60)
+        # Sleep shortly to avoid RPM
+        time.sleep(6)
 
         response = self.chat_llm(cur_round,
                                  client=client,


### PR DESCRIPTION
I found 60 seconds to be quite excessive and makes experimentation really slow. I did not find any problems with a reduced sleep time.