### PR TITLE
Automate PR experiments 

### DIFF
--- a/.github/workflows/pr-experiment.yml
+++ b/.github/workflows/pr-experiment.yml
@@ -1,0 +1,58 @@
+name: PR Experiment
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+
+env:
+  GCP_PROJECT: oss-fuzz
+  IMAGE_REPO: us-central1-docker.pkg.dev/oss-fuzz-base/oss-fuzz-gen/ci
+
+jobs:
+  request-pr-experiment:
+    name: "Trigger GKE experiment for PR"
+    # only run when a PR is created/updated by maintainers,
+    # or when a PR review is submitted/approved by a maintainer
+    if: >-
+      (
+        github.event_name == 'pull_request' &&
+        contains(fromJson('["DavidKorczynski","DonggeLiu"]'), github.event.pull_request.user.login)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved' &&
+        contains(fromJson('["DavidKorczynski","DonggeLiu"]'), github.event.review.user.login)
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCLOUD_CREDENTIAL }}
+
+      - name: Configure gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT }}
+
+      - name: Build & push CI Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ci/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_REPO }}:pr-${{ github.event.pull_request.number }}
+
+      - name: Run CI trial build container
+        run: |
+          docker run \
+            -e PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }} \
+            -e BRANCH=${{ github.head_ref }} \
+            -e REPO=${{ github.repositoryUrl }} \
+            ${{ env.IMAGE_REPO }}:pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
This pr is indeed for Automatically running tests experiment on PRs which are created or approved by maintainers .

Currently, here is how we do it manually:

1.  Wait for the `Build Docker image for PR / build (pull_request)` CI to finish.
    * This CI uploads/updates an image (tagged with PR ID) to our artifact registry.
2.  Auth to gcloud locally.
    * E.g., `gcloud auth login && gcloud auth application-default login && gcloud auth application-default set-quota-project oss-fuzz`.
3.  Request a GKE experiment with `request_pr_exp.py`.
    * E.g., `python -m report.request_pr_exp -p <PR-ID> -n <YOUR-NAME>`.
4.  Copy and Paste the links printed by the script to the PR so that others can see it and track improvements / regressions.
5. (Optional) Repeat 1-3 if the experiment failed. Add `-f` in step 3 so that the old GKE job and bucket dir will be removed to give place to the new one.
     * E.g., `python -m report.request_pr_exp -p <PR-ID> -n <YOUR-NAME> -f`

cc : @DavidKorczynski / @DonggeLiu  i added both of you as maintainers , please let me know that it works or we have to adjust that , a Big Thanks to both of you !
