### PR TITLE
experimental: build_generator: set OSS_FUZZ_DIR in agent workflow

### DIFF
--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -26,6 +26,7 @@ from typing import List
 import git
 from openai import OpenAIError
 
+from experiment import oss_fuzz_checkout
 from experiment.benchmark import Benchmark
 from experiment.workdir import WorkDirs
 from experimental.build_generator import (constants, file_utils, llm_agent,
@@ -364,6 +365,11 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
   llm agent approach."""
   # Process default arguments
   oss_fuzz_base = os.path.abspath(args.oss_fuzz)
+
+  # Set OSS_FUZZ_DIR in oss_fuzz_checkout as the agent will use this module
+  # for dealing with the generated project.
+
+  oss_fuzz_checkout.OSS_FUZZ_DIR = oss_fuzz_base
   work_dirs = WorkDirs(args.work_dirs, keep=True)
 
   # Prepare environment


### PR DESCRIPTION
Otherwise, oss_fuzz_checkout will default to oss-fuzz as the relevant dir, which does not match the oss_fuzz_base if set:

https://github.com/google/oss-fuzz-gen/blob/165fdc1334b6e37b55576763d3dc427f854dfefe/experiment/oss_fuzz_checkout.py#L426-L434

This is called by the container tool used by the agent.

This PR fixes so oss_fuzz_checkout uses the appropriate folder.