### PR TITLE
build_generation: Fix template and add validation

### DIFF
--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -392,46 +392,39 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
     for llm_agent_ctr in llm_agents:
       build_script = ''
       harness = ''
-      build_success = False
-      for trial in range(args.max_round):
-        # Prepare new LLM model
-        llm = models.LLM.setup(
-            ai_binary=os.getenv('AI_BINARY', ''),
-            name=args.model,
-            max_tokens=4096,
-            num_samples=1,
-            temperature=0.4,
-            temperature_list=[],
-        )
-        llm.MAX_INPUT_TOKEN = llm_agent.MAX_PROMPT_LENGTH
 
-        logger.info('Agent: %s. Round %d', llm_agent_ctr.__name__, trial)
-        agent = llm_agent_ctr(trial=trial,
-                              llm=llm,
-                              args=args,
-                              github_url=target_repository,
-                              language=language)
-        result_history = [
-            Result(benchmark=benchmark, trial=trial, work_dirs=work_dirs)
-        ]
+      # Prepare new LLM model
+      llm = models.LLM.setup(
+          ai_binary=os.getenv('AI_BINARY', ''),
+          name=args.model,
+          max_tokens=4096,
+          num_samples=1,
+          temperature=0.4,
+          temperature_list=[],
+      )
+      llm.MAX_INPUT_TOKEN = llm_agent.MAX_PROMPT_LENGTH
 
-        try:
-          build_result = agent.execute(result_history)
-        except OpenAIError:
-          logger.info(('Round %d build script generation failed for project %s'
-                       ' with openai errors'), trial, target_repository)
-          break
+      logger.info('Agent: %s.', llm_agent_ctr.__name__)
+      agent = llm_agent_ctr(trial=1,
+                            llm=llm,
+                            args=args,
+                            github_url=target_repository,
+                            language=language)
+      result_history = [
+          Result(benchmark=benchmark, trial=1, work_dirs=work_dirs)
+      ]
 
-        if build_result.compiles:
-          build_success = True
-          build_script = build_result.build_script_source
-          harness = build_result.fuzz_target_source
-          break
+      try:
+        build_result = agent.execute(result_history)
+      except OpenAIError:
+        logger.info(('Round 1 build script generation failed for project %s'
+                     ' with openai errors'), target_repository)
+        break
 
-        logger.info('Round %d build script generation failed for project %s',
-                    trial, target_repository)
+      if build_result.compiles:
+        build_script = build_result.build_script_source
+        harness = build_result.fuzz_target_source
 
-      if build_success:
         logger.info('Build script generation success for project %s',
                     target_repository)
 

--- a/experimental/build_generator/templates.py
+++ b/experimental/build_generator/templates.py
@@ -183,6 +183,7 @@ Your response **must only contain two XML tags**:
 - The build script will be executed as root on **Ubuntu 24.04**, so **do not use `sudo`**.
 - `$CC` and `$CXX` are set and must be used for compilation.
 - `$CFLAGS` and `$CXXFLAGS` must be used for compilation of source files. This is important because we need the flags to be used in the environment.
+- The fuzzing harness binary must be placed as `$OUT/{FUZZER_NAME}`. Make sure to use `-o $OUT/{FUZZER_NAME}` in the link stage of the fuzzing harness
 - If additional packages are needed, include a single `apt install` command at the top.
 - Use the provided build system files to compile the target project.
 - If a static library is not produced, collect the object files and archive them using `llvm-ar`.
@@ -207,32 +208,24 @@ Your response **must only contain two XML tags**:
 
 ### Provided Resources
 - **Build system configuration files:**
-  ```xml
   <build_files>
   {BUILD_FILES}
   </build_files>
-  ```
 
 - **Dockerfile for build environment:**
-  ```xml
   <dockerfile>
   {DOCKERFILE}
   </dockerfile>
-  ```
 
 - **Template fuzzing harness:**
-  ```xml
   <fuzzer>
   {FUZZER}
   </fuzzer>
-  ```
 
 - **Available header files:**
-  ```xml
   <headers>
   {HEADERS}
   </headers>
-  ```
 '''
 
 LLM_BUILD_FILE_TEMPLATE = '''
@@ -273,18 +266,14 @@ The generated build script will be executed in a **fresh session for testing**. 
 ### Provided Resources
 
 - Dockerfile:
-  ```xml
   <dockerfile>
   {DOCKERFILE}
   </dockerfile>
-  ```
 
 - **Template fuzzing harness:**
-  ```xml
   <fuzzer>
   {FUZZER}
   </fuzzer>
-  ```
 
 
 ### Interaction Protocol
@@ -308,7 +297,7 @@ You may include multiple shell commands in:
 - Use `$CC` and `$CXX` for all compile and link steps.
 - `$CFLAGS` and `$CXXFLAGS` must be used for compilation of source files. This is important because we need the flags to be used in the environment.
 - When you link the empty fuzzing harness, you must use `$LIB_FUZZING_ENGINE` which holds `-fsanitize=fuzzer` to make sure we link in libFuzzer's logic.
-- The fuzzing harness binary must be placed in the `$OUT` folder. Make sure to use `-o $OUT/...` in the link stage of the fuzzing harness.
+- The fuzzing harness binary must be placed as `$OUT/{FUZZER_NAME}`. Make sure to use `-o $OUT/{FUZZER_NAME}` in the link stage of the fuzzing harness.
 - When linking the fuzzing harness against the code compiled in the target, make sure to link in the whole code of the target by using <code>-Wl,--whole-archive libtarget.a -Wl,--no-whole-archive</code> for each static library. This includes for libraries that have been assembled of object files.
 - When compiling and linking the fuzzing harness, the build script must be ready for building and linking multiple fuzzing harnesses. Each fuzzing harness is prefixed with "empty-fuzzer-*" and the source file suffix.
   You must make sure to build/link the fuzzing harnesses in a loop, so that the build script can handle an arbitrary number of fuzzing harnesses.
@@ -381,4 +370,12 @@ To be valid, the response must meet the following requirements regarding XML tag
 - The <fuzzer></fuzzer> tag is **required only if** the fuzzing harness has been modified. If included, it must contain the **entire source code** of the updated fuzzing harness, not just a diff or partial snippet.
 
 Do not include any content outside these XML tags. Revisit your output and regenerate it with these rules strictly followed.
+'''
+
+LLM_MISSING_BINARY = '''
+The compiled binary was not found at `$OUT/{FUZZER_NAME}`. Please ensure that you use `-o $OUT/{FUZZER_NAME}` during the linking stage of the fuzzing harness.
+
+Below is the output from executing the previously generated build script for reference:
+
+{RESULT}
 '''


### PR DESCRIPTION
This PR addresses several issues related to LLM templates and enhances the validation of generated build results to ensure they are correct and reliable.

The following changes have been made:
1. Removed the XML code wrapper from templates to prevent confusion for the LLM.
2. Added a test to verify that the compiled fuzzing harness binary is correctly placed in the `$OUT` directory after a successful compilation.
3. Integrated a Fuzz-Introspector check for successfully built projects.
4. Removed a redundant trial in runner.py, which unnecessarily retried the entire process, despite retry logic already being handled within the LLM agents; this change helps to speed up the overall process.
5. Fixed a bug in bash command processing where commands from the LLM were incorrectly treated as a complete build script during the discovery phase.