### PR TITLE
build_generator: Remove unnecessary truncation

### DIFF
--- a/experimental/build_generator/constants.py
+++ b/experimental/build_generator/constants.py
@@ -22,6 +22,8 @@ MODEL_GPT_4 = 'gpt-4'
 MODEL_VERTEX = 'vertex'
 MODELS = [MODEL_GPT_35_TURBO, MODEL_VERTEX]
 
+MAX_PROMPT_LENGTH = 25000
+
 # Common -l<lib> to required package mapping for Dockerfile installation
 LIBRARY_PACKAGE_MAP = {
     "z": "zlib1g-dev",

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -207,10 +207,7 @@ class BuildScriptAgent(BaseAgent):
         retry = retry.replace('{FUZZER_NAME}', self.harness_name)
       else:
         retry = templates.LLM_RETRY.replace('{BASH_RESULT}', self.last_result)
-
-      # Refine prompt text to max prompt count and add to prompt
-      length = min(len(retry), (MAX_PROMPT_LENGTH - len(prompt.gettext())))
-      prompt.add_problem(retry[-length:])
+      prompt.add_problem(retry)
 
       # Store build result
       build_result.compiles = False

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -29,7 +29,6 @@ from results import BuildResult, Result
 from tool.base_tool import BaseTool
 from tool.container_tool import ProjectContainerTool
 
-MAX_PROMPT_LENGTH = 20000
 SAMPLE_HEADERS_COUNT = 30
 MAX_DISCOVERY_ROUND = 100
 INTROSPECTOR_OSS_FUZZ_DIR = '/src/inspector'

--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -425,7 +425,7 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
           temperature=0.4,
           temperature_list=[],
       )
-      llm.MAX_INPUT_TOKEN = llm_agent.MAX_PROMPT_LENGTH
+      llm.MAX_INPUT_TOKEN = constants.MAX_PROMPT_LENGTH
 
       logger.info('Agent: %s.', llm_agent_ctr.__name__)
       agent = llm_agent_ctr(trial=1,


### PR DESCRIPTION
As of #1017, the prompt truncation process has been implemented directly in the OpenAI LLM models. This makes the additional truncation in the build_generator LLM agent unnecessary and potentially confusing. This PR removes the redundant second truncation from the LLM agent.