### PR TITLE
build_generation: Fix prompts and constants

### DIFF
--- a/experimental/build_generator/constants.py
+++ b/experimental/build_generator/constants.py
@@ -24,6 +24,9 @@ MODELS = [MODEL_GPT_35_TURBO, MODEL_VERTEX]
 
 MAX_PROMPT_LENGTH = 25000
 
+INTROSPECTOR_OSS_FUZZ_DIR = '/src/inspector'
+INTROSPECTOR_ALL_FUNCTIONS_FILE = 'all-fuzz-introspector-functions.json'
+
 # Common -l<lib> to required package mapping for Dockerfile installation
 LIBRARY_PACKAGE_MAP = {
     "z": "zlib1g-dev",

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 import logger
 from agent.base_agent import BaseAgent
-from experimental.build_generator import file_utils, templates
+from experimental.build_generator import constants, file_utils, templates
 from llm_toolkit.models import LLM
 from llm_toolkit.prompts import Prompt
 from results import BuildResult, Result
@@ -31,7 +31,6 @@ from tool.container_tool import ProjectContainerTool
 
 SAMPLE_HEADERS_COUNT = 30
 MAX_DISCOVERY_ROUND = 100
-INTROSPECTOR_OSS_FUZZ_DIR = '/src/inspector'
 
 
 class BuildScriptAgent(BaseAgent):
@@ -163,7 +162,7 @@ class BuildScriptAgent(BaseAgent):
             success = True
             # Test introspector build
             introspector_build_result = self._test_introspector_build(tool)
-            command = f'test -d {INTROSPECTOR_OSS_FUZZ_DIR}'
+            command = f'test -d {constants.INTROSPECTOR_OSS_FUZZ_DIR}'
             introspector_dir_check_result = tool.execute(command)
             if introspector_dir_check_result.returncode == 0:
               logger.info('Introspector build success', trial=-1)
@@ -402,9 +401,7 @@ class BuildSystemBuildScriptAgent(BuildScriptAgent):
   def execute(self, result_history: list[Result]) -> BuildResult:
     """Executes the agent based on previous result."""
     if not self._discover_build_configurations():
-      logger.info('No known build configuration.',
-                  self.name,
-                  trial=result_history[-1].trial)
+      logger.info('No known build configuration.', trial=self.trial)
       return BuildResult(benchmark=result_history[-1].benchmark,
                          trial=result_history[-1].trial,
                          work_dirs=result_history[-1].work_dirs,

--- a/experimental/build_generator/manager.py
+++ b/experimental/build_generator/manager.py
@@ -23,13 +23,13 @@ import subprocess
 from typing import List, Tuple
 
 import build_script_generator
+import constants
 import file_utils as utils
 import templates
 import yaml
 
-INTROSPECTOR_OSS_FUZZ_DIR = '/src/inspector'
-
-INTROSPECTOR_ALL_FUNCTIONS_FILE = 'all-fuzz-introspector-functions.json'
+INTROSPECTOR_OSS_FUZZ_DIR = constants.INTROSPECTOR_OSS_FUZZ_DIR
+INTROSPECTOR_ALL_FUNCTIONS_FILE = constants.INTROSPECTOR_OSS_FUZZ_DIR
 
 LLM_MODEL = ''
 

--- a/experimental/build_generator/templates.py
+++ b/experimental/build_generator/templates.py
@@ -246,11 +246,9 @@ Here is a dump of the bash execution result.
 '''
 
 LLM_AUTO_DISCOVERY = '''
-You are tasked with generating a **build script** to compile and link a target project, and updating a **template fuzzing harness** by adding appropriate header includes from the project. The harness itself should not be modified beyond these includes.
+You are tasked with generating a **build script** to compile and statically link a target project, and updating a **template fuzzing harness** by including relevant project headers. Do **not** modify the harness logic, only add `#include` statements.
 
-The project source code is located at `$SRC/{PROJECT_NAME}` inside a Docker container running **Ubuntu 24.04**.
-
-The fuzzing harness template is provided at `$SRC/{FUZZING_FILE}` and the content is shown below, which you must modified from the given template.
+The source code is located at `$SRC/{PROJECT_NAME}` inside a Docker container running **Ubuntu 24.04**. The fuzzing harness template is at `$SRC/{FUZZING_FILE}` and is provided below.
 
 The generated build script will be executed in a **fresh session for testing**. Do **not** include any `|| true` or similar constructs to suppress errors.
 
@@ -261,7 +259,8 @@ The generated build script will be executed in a **fresh session for testing**. 
 - `$CFLAGS` and `$CXXFLAGS` must be used for compilation of source files. This is important because we need the flags to be used in the environment.
 - Project source: `$SRC/{PROJECT_NAME}`
 - Fuzzing harness template: `$SRC/{FUZZING_FILE}`
-- Container environment: Defined by the provided `Dockerfile`
+- Linking: Use `$LIB_FUZZING_ENGINE` and link fuzzers statically
+- Output fuzzers to: `$OUT/{FUZZER_NAME}`
 
 ### Provided Resources
 
@@ -270,11 +269,10 @@ The generated build script will be executed in a **fresh session for testing**. 
   {DOCKERFILE}
   </dockerfile>
 
-- **Template fuzzing harness:**
+- Template fuzzing harness:
   <fuzzer>
   {FUZZER}
   </fuzzer>
-
 
 ### Interaction Protocol
 
@@ -282,41 +280,37 @@ This is an **interactive process**. You do not initially know the project layout
 
 You are limited to **{MAX_DISCOVERY_ROUND} discovery rounds**, so plan efficiently.
 
-Use the following XML tags for communication:
-
-- `<command></command>` – Use to request shell commands that will be executed in the container.
+Your result must only contains these XML tags. **NOTHING MORE**.
+- `<command></command>` – Use to request shell commands that will be executed in the container. You may include multiple semicolon-separated commands per tag, or use multiple tags.
 - `<bash></bash>` – Use only when ready to output the **final build script**.
 - `<fuzzer></fuzzer>` – wraps the complete, modified fuzzing harness, which includes and links the binaries compiled from the target project. The result **MUST** contain the **entire source code** of the updated fuzzing harness, not just a diff or partial snippet.
 
-You may include multiple shell commands in:
-- A single `<command>` tag, separated by semicolons (`;`), or
-- Separate `<command>` tags, executed in sequence.
+Your goal is to compile the project into a static library (`libtarget.a`) that can be linked into the fuzzing harnesses.
 
-### Build Script Guidelines
+### Supported Build Systems
 
-- Use `$CC` and `$CXX` for all compile and link steps.
-- `$CFLAGS` and `$CXXFLAGS` must be used for compilation of source files. This is important because we need the flags to be used in the environment.
-- When you link the empty fuzzing harness, you must use `$LIB_FUZZING_ENGINE` which holds `-fsanitize=fuzzer` to make sure we link in libFuzzer's logic.
-- The fuzzing harness binary must be placed as `$OUT/{FUZZER_NAME}`. Make sure to use `-o $OUT/{FUZZER_NAME}` in the link stage of the fuzzing harness.
-- When linking the fuzzing harness against the code compiled in the target, make sure to link in the whole code of the target by using <code>-Wl,--whole-archive libtarget.a -Wl,--no-whole-archive</code> for each static library. This includes for libraries that have been assembled of object files.
-- When compiling and linking the fuzzing harness, the build script must be ready for building and linking multiple fuzzing harnesses. Each fuzzing harness is prefixed with "empty-fuzzer-*" and the source file suffix.
-  You must make sure to build/link the fuzzing harnesses in a loop, so that the build script can handle an arbitrary number of fuzzing harnesses.
-  As as an example, the following is incorrect:
-<code>$CC $CFLAGS -I$SRC/jsmn $SRC/empty-fuzzer.c -o $OUT/jsmn_fuzzer -L. -Wl,--whole-archive libjsmn.a -Wl,--no-whole-archive $LIB_FUZZING_ENGINE</code>
-  and the following is correct:
-<code>
-for fuzzer in $(find $SRC -maxdepth 1 -name 'empty-fuzzer.*'); do
-  fuzzer_basename=$(basename $fuzzer)
-  $CC $CFLAGS -I$SRC/.../.../ ${fuzzer} -o $OUT/${fuzzer_basename} -L. -Wl,--whole-archive .../.a -Wl,--no-whole-archive $LIB_FUZZING_ENGINE
-done
-</code>
-- Do **not** use `sudo` (script runs as root).
-- Do **not** use `|| true` to suppress errors.
-- If a supported build system exists (e.g., CMake, Autotools, Make), use it for compiling the project.
-- For **fuzzer compilation**, always use manual compilation with `$CC` or `$CXX`, regardless of the project’s build system.
-- Do not modify existing build configuration files.
-- Skip tests, installation, or unrelated build targets.
-- Safely extend environment variables (e.g., CFLAGS):
+- If the project uses **Android.bp** (Soong), assume it **cannot be invoked directly**. Instead:
+  - Identify source files manually using tools like `find`.
+  - Compile them individually using `$CC`/`$CXX`.
+  - Archive the resulting object files into a static library using `llvm-ar`.
+
+- If the project uses **BUILD.gn**, avoid running `gn gen` or `ninja` unless **GN/Ninja tools are explicitly installed** in the provided Dockerfile.
+  - Instead, locate and compile relevant `.c` or `.cc` source files manually with `$CC`/`$CXX`.
+
+- If the project includes standard build files such as `Makefile`, `configure`, or other commonly known build files, use the corresponding build system as intended.
+
+- If **no recognizable build system** or configuration files are found, attempt to compile all source files directly using `$CC`/`$CXX`, and package them into a static library using `llvm-ar`.
+
+- Whenever possible, include `$CFLAGS` and `$CXXFLAGS` during the compile process.
+
+- If additional packages are needed, you **MUST** also install them with `apt-get` command.
+
+Do **not** modify or patch existing build configuration files under any circumstances.
+
+### Build Script Requirements
+
+- Use `$CC` and `$CXX` for all compilation and linking tasks.
+- Always apply `$CFLAGS` and `$CXXFLAGS` when compiling source files, both for the project and the fuzzing harness. Safely extend these variables as needed:
   ```bash
   if [ -z "${CFLAGS:-}" ]; then
     CFLAGS="-I/some/include"
@@ -324,32 +318,51 @@ done
     CFLAGS="$CFLAGS -I/some/include"
   fi
   ```
-- If the build does not produce a static library, collect `.o` files and archive them using:
+
+- The script **must not**:
+  - Use `sudo` (the container runs as root),
+  - Suppress errors (e.g., via `|| true`),
+  - Run tests or installation targets.
+
+- If the build does not automatically generate a static library, collect all `.o` files and manually archive them:
   ```bash
   llvm-ar rcs libtarget.a *.o
   ```
-- Link the resulting static library into the fuzzer using:
+
+- When linking the fuzzing harness, always use:
   ```bash
   -Wl,--whole-archive libtarget.a -Wl,--no-whole-archive
   ```
 
+- Ensure the script builds **all fuzzing harnesses** matching the `empty-fuzzer.*` pattern using a loop, like so:
+  ```bash
+  for fuzzer in $(find $SRC -maxdepth 1 -name 'empty-fuzzer.*'); do
+    fuzzer_basename=$(basename $fuzzer)
+    $CC $CFLAGS -I$SRC/... $fuzzer -o $OUT/${fuzzer_basename} -L. -Wl,--whole-archive libtarget.a -Wl,--no-whole-archive $LIB_FUZZING_ENGINE
+  done
+  ```
+
+- If you are not using a build system (e.g., Make/CMake), and some source files fail to compile, you may **skip those individual files** to allow the build process to complete successfully. Focus on compiling as many valid source files as possible to produce a usable static library.
+
 ### Fuzzing Harness Requirements
 
-- Only modify the provided harness by including headers from the target project as necessary.
-- Do **not** add any logic, templates, function calls, or placeholders.
-- The harness must remain syntactically valid and must compile and link cleanly with the generated static library.
-- The result **MUST** contain the **entire source code** of the updated fuzzing harness, not just a diff or partial snippet.
+- Only modify the harness by adding necessary `#include` statements for project headers. Try to keep it as minimum as possible.
+- Do not alter or add logic, boilerplate, or functions.
+- The result MUST be **a complete, valid C/C++ file** that compiles and links cleanly.
 
 ### Getting Started
 
-Begin by issuing discovery commands to explore the project layout and identify its build system and header locations. Suggested starting commands include:
+Begin with discovery commands to examine project structure and identify build system and headers.
 
-- `ls -la $SRC/{PROJECT_NAME}`
-- `find $SRC/{PROJECT_NAME} -name CMakeLists.txt -o -name configure -o -name Makefile`
-- `find $SRC/{PROJECT_NAME} -type d -name include`
+Useful starting points:
+```bash
+ls -la $SRC/{PROJECT_NAME}
+find $SRC/{PROJECT_NAME} -name Android.bp -o -name BUILD.gn -o -name Makefile -o -name CMakeLists.txt
+find $SRC/{PROJECT_NAME} -type f \( -name '*.h' -o -name '*.hpp' \)
+```
 
-Your first reply should be a `<command>` block to start the investigation.
-And your last reply should returns the full generated build script and modified harness with the `<bash>` and `<fuzzer>` tag.
+Your **first reply** must be a `<command>` block to begin project exploration.
+Your **final reply** must include the `<bash>` block and, if the harness was modified, the `<fuzzer>` block.
 '''
 
 LLM_DOCKER_FEEDBACK = '''


### PR DESCRIPTION
This PR improves the build generation agent with several prompt and configuration updates:
1. Moved Fuzz-Introspector configuration to `constants.py`.  
2. Updated the agent prompt with the following improvements:
   - **Android.bp**: Instructed the LLM to ignore Soong and compile sources manually.
   - **BUILD.gn**: Instructed the LLM to avoid using `gn gen` unless GN/Ninja are clearly available.
   - **Fallback strategy**: If no build system is found, compile sources manually and archive them with `llvm-ar`.
   - **Build system usage**: Clarified that Makefile/configure/CMake should be used if available, and must not be modified.
   - **Tag enforcement**: Enforced correct use of tags—`<bash>` for the final script, `<fuzzer>` only if the harness is modified, and `<command>` for discovery. Tags must contain only their respective content with no extra output.