### PR TITLE
build_generator: Fix bug for working directory preperation

### DIFF
--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -395,9 +395,6 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
   oss_fuzz_checkout.OSS_FUZZ_DIR = oss_fuzz_base
   work_dirs = WorkDirs(args.work_dirs, keep=True)
 
-  # Prepare environment
-  worker_project_name = get_next_worker_project(oss_fuzz_base)
-
   # All agents
   llm_agents = [
       llm_agent.AutoDiscoveryBuildScriptAgent,
@@ -406,6 +403,8 @@ def run_agent(target_repositories: List[str], args: argparse.Namespace):
 
   for target_repository in target_repositories:
     logger.info('Target repository: %s', target_repository)
+    # Prepare environment
+    worker_project_name = get_next_worker_project(oss_fuzz_base)
     language = setup_worker_project(oss_fuzz_base, worker_project_name,
                                     args.model, target_repository, True,
                                     os.path.abspath(args.work_dirs))


### PR DESCRIPTION
This PR fixes a bug where only one working environment was being used for all projects, causing files from previous projects to be copied incorrectly. For example, if the last project was a C project and the current one is a C++ project, an old file (empty-fuzzer.c) was copied over. This file wasn’t overwritten and caused build errors since it wasn't compatible with the new project. The fix ensures a fresh working environment is created for each project, preventing this issue.