### PR TITLE
build_generation: Refine the guideline for build script generation

### DIFF
--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -92,6 +92,7 @@ class BuildScriptAgent(BaseAgent):
         'PROJECT_NAME': 'auto-fuzz-proj',
         'FI_DISABLE_LIGHT': '1',
         'FUZZING_LANGUAGE': self.language,
+        'FUZZINTRO_OUTDIR': args.work_dir,
     }
     env_str = ' '.join(f"{key}='{value}'" for key, value in envs.items())
 
@@ -115,6 +116,8 @@ class BuildScriptAgent(BaseAgent):
     commands = '; '.join(self._parse_tags(response, 'command'))
 
     if commands:
+      self.discovery_stage = True
+
       # Execute the command directly, then return the formatted result
       result = tool.execute(commands)
       prompt_text = self._format_bash_execution_result(result,

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -92,7 +92,7 @@ class BuildScriptAgent(BaseAgent):
         'PROJECT_NAME': 'auto-fuzz-proj',
         'FI_DISABLE_LIGHT': '1',
         'FUZZING_LANGUAGE': self.language,
-        'FUZZINTRO_OUTDIR': args.work_dir,
+        'FUZZINTRO_OUTDIR': self.args.work_dirs,
     }
     env_str = ' '.join(f"{key}='{value}'" for key, value in envs.items())
 


### PR DESCRIPTION
This PR includes the following changes:
1. Added missing Fuzz-Introspector environment variable to reduce redundant output in the final results.
2. Change the agent flow to allow LLM returns to the interaction process if needed.
3. Updated the build prompt with several fixes:
   - Added strict constraints to avoid guessing and encourage returning to the interaction process.
   - Clarified build system detection and emphasized that listed examples are not exhaustive.
   - Tightened rules on compiler flag use and header inclusion.
   - Prohibited use of macros and type defines unless absolutely necessary.
   - Added a "Common Mistakes to Avoid" section to summarise key restrictions.