### PR TITLE
e2e: harden repository recognition and add default out

### DIFF
--- a/experimental/build_generator/runner.py
+++ b/experimental/build_generator/runner.py
@@ -527,8 +527,16 @@ def extract_target_repositories(target_input) -> list[str]:
     target_repositories = read_targets_file(target_input)
   else:
     target_repositories = [target_input]
-  logger.info(target_repositories)
-  return target_repositories
+
+  refined_targets = []
+  for repo in target_repositories:
+    # Remove trailing /
+    while repo.endswith('/'):
+      repo = repo[:-1]
+    refined_targets.append(repo)
+  logger.info(refined_targets)
+
+  return refined_targets
 
 
 def main():

--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -494,7 +494,10 @@ def parse_commandline():
   """Parse the commandline."""
   parser = argparse.ArgumentParser()
   parser.add_argument('--input', '-i', help='Input to analyze')
-  parser.add_argument('--out', '-o', help='Directory to store output.')
+  parser.add_argument('--out',
+                      '-o',
+                      help='Directory to store output.',
+                      default='oss-fuzz-generated')
   parser.add_argument('--silent',
                       '-s',
                       help='Disable logging in subprocess.',


### PR DESCRIPTION
Previously issues would happen if repositories ended with '/'. This fixes it so we dont run into issues by removing trailing '/'.