### PR TITLE
xref_context: Add test xref in project context

### DIFF
--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -174,9 +174,23 @@ class ContextRetriever:
           'function_signature: %s', project, func_sig)
     return xrefs
 
+  def _get_test_xrefs_to_function(self) -> list[str]:
+    """Queries FI for test source calling the function being fuzzed."""
+    project = self._benchmark.project
+    func_name = self._benchmark.function_name
+    xrefs = introspector.query_introspector_for_tests_xref(project, [func_name])
+
+    if not xrefs:
+      logging.warning(
+          'Could not retrieve tests xrefs for project: %s '
+          'function_signature: %s', project, func_name)
+
+    return xrefs
+
   def get_context_info(self) -> dict:
     """Retrieves contextual information and stores them in a dictionary."""
     xrefs = self._get_xrefs_to_function()
+    test_xrefs = self._get_test_xrefs_to_function()
     func_source = self._get_function_implementation()
     files = self._get_files_to_include()
     decl = self._get_embeddable_declaration()
@@ -188,6 +202,7 @@ class ContextRetriever:
         'files': files,
         'decl': decl,
         'header': header,
+        'test_xrefs': test_xrefs,
     }
 
     logging.info('Context: %s', context_info)

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -204,6 +204,7 @@ class DefaultTemplateBuilder(PromptBuilder):
         func_source=context_info['func_source'],
         xrefs='\n'.join(context_info['xrefs']),
         include_statement=context_info['header'],
+        tests_xrefs='\n'.join(context_info['tests_xrefs']),
     )
 
   def _select_examples(self, examples: list[list],

--- a/prompts/template_xml/context.txt
+++ b/prompts/template_xml/context.txt
@@ -24,4 +24,9 @@ Here is the source code for functions which reference the function being tested:
 <code>
 {{ xrefs }}
 </code>
+
+Here is the source code for the tests/examples that reference the function being tested:
+<code>
+{{ tests_xrefs }}
+</code>
 {% endif %}


### PR DESCRIPTION
This PR adds a new item to the project context and query introspector to retrieve the test or example sources that call the target function. This new context item provides information for the LLM to reference existing test or example sources when generating a fuzzing harness for the target functions.