### PR TITLE
Fix error in true/false positive crash designation on the experiment result page

### DIFF
--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -172,7 +172,7 @@ td .signature {
             <td class="table-index">{{ loop.index }}</td>
             <td data-sort-value="{{bug_sample.benchmark.project}}">{{bug_sample.benchmark.project}}</td>
             <td data-sort-value="{{bug_sample.benchmark.id}}"><a href="sample/{{ bug_sample.benchmark.id|urlencode }}/{{ bug_sample.sample.id }}.html">{{bug_sample.benchmark.id}}-{{ bug_sample.sample.id }} </a> </td>
-            <td style="color: {{ 'red' if bug_sample.sample.result.crashes and not bug_sample.sample.result.is_semantic_error else 'green' }}" data-sort-value="{{'True positive' if bug_sample.sample.result.is_semantic_error else 'False positive'}}">{{'True positive' if bug_sample.sample.result.is_semantic_error else 'False positive'}}</td>
+            <td style="color: {{ 'red' if bug_sample.sample.result.crashes and bug_sample.sample.result.is_semantic_error else 'green' }}" data-sort-value="{{'True positive' if not bug_sample.sample.result.is_semantic_error else 'False positive'}}">{{'True positive' if not bug_sample.sample.result.is_semantic_error else 'False positive'}}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/report/templates/index.html
+++ b/report/templates/index.html
@@ -172,7 +172,7 @@ td .signature {
             <td class="table-index">{{ loop.index }}</td>
             <td data-sort-value="{{bug_sample.benchmark.project}}">{{bug_sample.benchmark.project}}</td>
             <td data-sort-value="{{bug_sample.benchmark.id}}"><a href="sample/{{ bug_sample.benchmark.id|urlencode }}/{{ bug_sample.sample.id }}.html">{{bug_sample.benchmark.id}}-{{ bug_sample.sample.id }} </a> </td>
-            <td style="color: {{ 'red' if bug_sample.sample.result.crashes and bug_sample.sample.result.is_semantic_error else 'green' }}" data-sort-value="{{'True positive' if not bug_sample.sample.result.is_semantic_error else 'False positive'}}">{{'True positive' if not bug_sample.sample.result.is_semantic_error else 'False positive'}}</td>
+            <td style="color: {{ 'red' if bug_sample.sample.result.crashes and not bug_sample.sample.result.is_semantic_error else 'green' }}" data-sort-value="{{'False positive' if bug_sample.sample.result.is_semantic_error else 'True positive'}}">{{'False positive' if bug_sample.sample.result.is_semantic_error else 'True positive'}}</td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
This PR fixes an error in the oss-fuzz-gen's experiment result page where true positive crashes are classified as false positives, and vice versa.

In report/templates/benchmark.html, crashes are designated as True vulnerabilities if `sample.result.crashes and **not** sample.result.is_semantic_error`.

However, in report/templates/index.html, the reverse occurs. Crashes were previously designated as True positives if `bug_sample.sample.result.is_semantic_error`. This PR fixes this discrepancy.