### PR TITLE
introspector: avoid discarding unreached targets

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -84,7 +84,7 @@ def get_oracle_dict() -> Dict[str, Any]:
   """Returns the oracles available to identify targets."""
   # Do this in a function to allow for forward-declaration of functions below.
   oracle_dict = {
-      'far-reach-low-coverage': get_unreached_functions,
+      'far-reach-low-coverage': query_introspector_for_far_reach_low_cov,
       'low-cov-with-fuzz-keyword': query_introspector_for_keyword_targets,
       'easy-params-far-reach': query_introspector_for_easy_param_targets,
       'optimal-targets': query_introspector_for_optimal_targets,
@@ -498,9 +498,8 @@ def query_introspector_addr_type_info(project: str, addr: str) -> str:
   return _get_data(resp, 'dwarf-map', '')
 
 
-def get_unreached_functions(project):
+def query_introspector_for_far_reach_low_cov(project):
   functions = query_introspector_oracle(project, INTROSPECTOR_ORACLE_FAR_REACH)
-  functions = [f for f in functions if not f['reached_by_fuzzers']]
   return functions
 
 


### PR DESCRIPTION
We shuold let the FI API make the decision here. This is to enable benchmark generation for some cases where it was unintuitive why there were no targets.