### PR TITLE
base-tool: make accessing .txt files independent of cwd

### DIFF
--- a/tool/base_tool.py
+++ b/tool/base_tool.py
@@ -19,7 +19,8 @@ from typing import Any
 
 from experiment.benchmark import Benchmark
 
-TOOL_TUTORIAL_DIR = os.path.join('prompts', 'tool')
+TOOL_TUTORIAL_DIR = os.path.join(os.path.dirname(__file__), '../prompts',
+                                 'tool')
 
 
 class BaseTool(ABC):


### PR DESCRIPTION
This is needed when running `oss-fuzz-generator` in locations not in OFG root.