### PR TITLE
end-to-end: enable targeting specific function

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -838,13 +838,14 @@ def generate_benchmark_for_targeted_function(project: str, function_name: str):
   project_lang = oss_fuzz_checkout.get_project_language(project)
 
   harness, target_name, _ = _get_harness_intrinsics(project, [], project_lang)
-
+  if not harness:
+    return ''
   target_benchmarks = [
       benchmarklib.Benchmark(
           benchmark_id='cli',
           project=project,
           language=project_lang,
-          function_signature=function_dict.get('function_signature'),
+          function_signature=function_dict.get('function_signature', ''),
           function_name=get_raw_function_name(function_dict, project),
           return_type=_get_clean_return_type(function_dict, project),
           params=_group_function_params(

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -40,6 +40,10 @@ T = TypeVar('T', str, list, dict, int)  # Generic type.
 TIMEOUT = 45
 MAX_RETRY = 5
 
+BENCHMARK_ROOT: str = './benchmark-sets'
+BENCHMARK_DIR: str = f'{BENCHMARK_ROOT}/comparison'
+GENERATED_BENCHMARK: str = 'generated-benchmark-'
+
 USE_FI_TO_GET_TARGETS = bool(int(os.getenv('OSS_FI_TO_GET_TARGETS', '1')))
 
 # By default exclude static functions when identifying fuzz target candidates
@@ -71,6 +75,7 @@ INTROSPECTOR_ALL_FUNC_TYPES = ''
 INTROSPECTOR_TEST_SOURCE = ''
 INTROSPECTOR_HARNESS_SOURCE_AND_EXEC = ''
 INTROSPECTOR_LANGUAGE_STATS = ''
+INTROSPECTOR_GET_TARGET_FUNCTION = ''
 
 INTROSPECTOR_HEADERS_FOR_FUNC = ''
 INTROSPECTOR_SAMPLE_XREFS = ''
@@ -108,7 +113,8 @@ def set_introspector_endpoints(endpoint):
       INTROSPECTOR_FUNCTION_WITH_MATCHING_RETURN_TYPE, \
       INTROSPECTOR_ORACLE_ALL_TESTS, INTROSPECTOR_JVM_PROPERTIES, \
       INTROSPECTOR_TEST_SOURCE, INTROSPECTOR_HARNESS_SOURCE_AND_EXEC, \
-      INTROSPECTOR_JVM_PUBLIC_CLASSES, INTROSPECTOR_LANGUAGE_STATS
+      INTROSPECTOR_JVM_PUBLIC_CLASSES, INTROSPECTOR_LANGUAGE_STATS, \
+      INTROSPECTOR_GET_TARGET_FUNCTION
 
   INTROSPECTOR_ENDPOINT = endpoint
 
@@ -148,6 +154,8 @@ def set_introspector_endpoints(endpoint):
       f'{INTROSPECTOR_ENDPOINT}/all-public-classes')
   INTROSPECTOR_LANGUAGE_STATS = (
       f'{INTROSPECTOR_ENDPOINT}/database-language-stats')
+  INTROSPECTOR_GET_TARGET_FUNCTION = (
+      f'{INTROSPECTOR_ENDPOINT}/get-target-function')
 
 
 def _construct_url(api: str, params: dict) -> str:
@@ -498,6 +506,33 @@ def query_introspector_addr_type_info(project: str, addr: str) -> str:
   return _get_data(resp, 'dwarf-map', '')
 
 
+def get_next_generated_benchmarks_dir() -> str:
+  """Retuns the next folder to be used for generated benchmarks."""
+  max_idx = -1
+  # When generating benchmarks dynamically sometimes we may not have a
+  # benchmark folder, as the command will be run from an arbitrary directory.
+  # Create the benchmark folder if this is the case.
+  if not os.path.isdir(BENCHMARK_ROOT):
+    os.makedirs(BENCHMARK_ROOT)
+  for benchmark_folder in os.listdir(BENCHMARK_ROOT):
+    try:
+      max_idx = max(max_idx,
+                    int(benchmark_folder.replace(GENERATED_BENCHMARK, '')))
+    except (ValueError, TypeError) as _:
+      pass
+  max_idx += 1
+  return os.path.join(BENCHMARK_ROOT, f'{GENERATED_BENCHMARK}{max_idx}')
+
+
+def query_introspector_target_function(project: str, function: str) -> dict:
+  resp = _query_introspector(INTROSPECTOR_GET_TARGET_FUNCTION, {
+      'project': project,
+      'function': function
+  })
+
+  return _get_data(resp, 'function', {})
+
+
 def query_introspector_for_far_reach_low_cov(project):
   functions = query_introspector_oracle(project, INTROSPECTOR_ORACLE_FAR_REACH)
   return functions
@@ -795,6 +830,36 @@ def populate_benchmarks_using_test_migration(
                                preferred_target_name=target_name,
                                test_file_path=test_file))
   return potential_benchmarks[:limit]
+
+
+def generate_benchmark_for_targeted_function(project: str, function_name: str):
+  """generates a benchmark for a single function."""
+  function_dict = query_introspector_target_function(project, function_name)
+  project_lang = oss_fuzz_checkout.get_project_language(project)
+
+  harness, target_name, _ = _get_harness_intrinsics(project, [], project_lang)
+
+  target_benchmarks = [
+      benchmarklib.Benchmark(
+          benchmark_id='cli',
+          project=project,
+          language=project_lang,
+          function_signature=function_dict.get('function_signature'),
+          function_name=get_raw_function_name(function_dict, project),
+          return_type=_get_clean_return_type(function_dict, project),
+          params=_group_function_params(
+              _get_clean_arg_types(function_dict, project),
+              _get_arg_names(function_dict, project, project_lang),
+              project_lang),
+          target_path=harness,
+          preferred_target_name=target_name,
+          function_dict=function_dict)
+  ]
+
+  benchmark_dir = get_next_generated_benchmarks_dir()
+  os.makedirs(benchmark_dir)
+  benchmarklib.Benchmark.to_yaml(target_benchmarks, outdir=benchmark_dir)
+  return benchmark_dir
 
 
 def populate_benchmarks_using_introspector(project: str, language: str,

--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -458,6 +458,9 @@ def run_harness_generation(workdir,
     introspector.set_introspector_endpoints('http://127.0.0.1:8080/api')
     benchmark_dir = introspector.generate_benchmark_for_targeted_function(
         target_project, target_function)
+    if not benchmark_dir:
+      logger.info('Failed to generated benchmarks.')
+      sys.exit(1)
   else:
     logger.info('Generating a broad set of benchmarks')
     benchmark_dir = ''

--- a/experimental/end_to_end/cli.py
+++ b/experimental/end_to_end/cli.py
@@ -28,6 +28,7 @@ import time
 import requests
 import yaml
 
+from data_prep import introspector
 from experimental.build_generator import runner
 from llm_toolkit import models
 
@@ -195,7 +196,7 @@ def wait_until_fi_webapp_is_launched():
   sys.exit(0)
 
 
-def run_ofg_generation(projects_to_run, workdir, args):
+def run_ofg_generation(projects_to_run, workdir, args, target_benchmarks=''):
   """Runs harness generation"""
   logger.info('Running OFG experiment: %s', os.getcwd())
   oss_fuzz_dir = os.path.join(workdir, 'oss-fuzz')
@@ -203,12 +204,17 @@ def run_ofg_generation(projects_to_run, workdir, args):
   cmd = ['python3', os.path.join(OFG_BASE_DIR, 'run_all_experiments.py')]
   cmd.append('--model')
   cmd.append(args.model)
-  cmd.append('-g')
-  cmd.append(args.benchmark_oracles)
-  cmd.append('-gp')
-  cmd.append(','.join(projects_to_run))
-  cmd.append('-gm')
-  cmd.append(str(args.generate_benchmarks_max))
+
+  if not target_benchmarks:
+    cmd.append('-g')
+    cmd.append(args.benchmark_oracles)
+    cmd.append('-gp')
+    cmd.append(','.join(projects_to_run))
+    cmd.append('-gm')
+    cmd.append(str(args.generate_benchmarks_max))
+  else:
+    cmd.append('-b')
+    cmd.append(target_benchmarks)
   cmd.append('--context')
   cmd.append('-of')
   cmd.append(oss_fuzz_dir)
@@ -416,7 +422,10 @@ def prepare_fuzz_introspector_db(out_gen, workdir, parallel_introspector_jobs):
   create_fi_db(workdir)
 
 
-def run_harness_generation(workdir, args):
+def run_harness_generation(workdir,
+                           args,
+                           target_project='',
+                           target_function=''):
   """Runs harness generation based on the projects in `out_gen`"""
 
   # Read the json file from FI to get all current projects.
@@ -428,10 +437,13 @@ def run_harness_generation(workdir, args):
     set()
 
   projects_to_run = []
-  with open(fi_project_json, 'r') as f:
-    json_content = json.load(f)
-  for elem in json_content:
-    projects_to_run.append(elem['project_name'])
+  if target_project:
+    projects_to_run = [target_project]
+  else:
+    with open(fi_project_json, 'r') as f:
+      json_content = json.load(f)
+    for elem in json_content:
+      projects_to_run.append(elem['project_name'])
 
   # Launch the fuzz introspector webapp so it's ready for OFG core
   shutdown_fi_webapp()
@@ -440,8 +452,18 @@ def run_harness_generation(workdir, args):
   dst_data_dir = _create_data_dir(workdir)
   logger.info('Wrote data directory for OFG experiments in %s', dst_data_dir)
 
+  # Generate benchmarks if asked to
+  if target_project and target_function:
+    logger.info('Generating benchmark for specific function')
+    introspector.set_introspector_endpoints('http://127.0.0.1:8080/api')
+    benchmark_dir = introspector.generate_benchmark_for_targeted_function(
+        target_project, target_function)
+  else:
+    logger.info('Generating a broad set of benchmarks')
+    benchmark_dir = ''
+
   # Run OFG core using local OSS-Fuzz and local Fuzz Introspector.
-  run_ofg_generation(projects_to_run, workdir, args)
+  run_ofg_generation(projects_to_run, workdir, args, benchmark_dir)
 
   create_merged_oss_fuzz_projects(projects_to_run, workdir)
   return projects_to_run
@@ -524,7 +546,8 @@ def run_cmd_harness_generation(args):
   abs_workdir = os.path.abspath(args.workdir)
 
   # Run harness generation.
-  projects_run = run_harness_generation(abs_workdir, args)
+  projects_run = run_harness_generation(abs_workdir, args, args.project,
+                                        args.function_name)
 
   # Log results.
   logger.info('Finished analysis')
@@ -665,6 +688,11 @@ def parse_commandline():
       default=
       'far-reach-low-coverage,low-cov-with-fuzz-keyword,easy-params-far-reach,test-migration'
   )
+  run_harness_generation_parser.add_argument(
+      '--project', default='', help='Limit analysis to specified project.')
+  run_harness_generation_parser.add_argument('--function-name',
+                                             default='',
+                                             help='Target function')
 
   # Run a full end to end generation.
   run_full_parser = subparsers.add_parser(

--- a/run_all_experiments.py
+++ b/run_all_experiments.py
@@ -49,10 +49,7 @@ NUM_SAMPLES: int = run_one_experiment.NUM_SAMPLES
 RUN_TIMEOUT: int = run_one_experiment.RUN_TIMEOUT
 TEMPERATURE: float = run_one_experiment.TEMPERATURE
 
-BENCHMARK_ROOT: str = './benchmark-sets'
-BENCHMARK_DIR: str = f'{BENCHMARK_ROOT}/comparison'
 RESULTS_DIR: str = run_one_experiment.RESULTS_DIR
-GENERATED_BENCHMARK: str = 'generated-benchmark-'
 JSON_REPORT = 'report.json'
 TIME_STAMP_FMT = '%Y-%m-%d %H:%M:%S'
 
@@ -72,28 +69,10 @@ class Result:
     self.result = result
 
 
-def get_next_generated_benchmarks_dir() -> str:
-  """Retuns the next folder to be used for generated benchmarks."""
-  max_idx = -1
-  # When generating benchmarks dynamically sometimes we may not have a
-  # benchmark folder, as the command will be run from an arbitrary directory.
-  # Create the benchmark folder if this is the case.
-  if not os.path.isdir(BENCHMARK_ROOT):
-    os.makedirs(BENCHMARK_ROOT)
-  for benchmark_folder in os.listdir(BENCHMARK_ROOT):
-    try:
-      max_idx = max(max_idx,
-                    int(benchmark_folder.replace(GENERATED_BENCHMARK, '')))
-    except (ValueError, TypeError) as _:
-      pass
-  max_idx += 1
-  return os.path.join(BENCHMARK_ROOT, f'{GENERATED_BENCHMARK}{max_idx}')
-
-
 def generate_benchmarks(args: argparse.Namespace) -> None:
   """Generates benchmarks, write to filesystem and set args benchmark dir."""
   logger.info('Generating benchmarks.')
-  benchmark_dir = get_next_generated_benchmarks_dir()
+  benchmark_dir = introspector.get_next_generated_benchmarks_dir()
   logger.info('Setting benchmark directory to %s.', benchmark_dir)
   os.makedirs(benchmark_dir)
   args.benchmarks_directory = benchmark_dir


### PR DESCRIPTION
This is a useful feature for both doing targeted harness generation as it allows us to bypass oracles and go for a function we, for some reason, find interesting. This is also very useful for development purposes.