### PR TITLE
Get and log the source code of the fuzz target and build script.

### DIFF
--- a/experiment/evaluator.py
+++ b/experiment/evaluator.py
@@ -280,7 +280,8 @@ class Evaluator:
               f'{self.benchmark.target_path}\n')
 
     if not build_script_path or os.path.getsize(build_script_path) == 0:
-      return name
+      # Return the generated project path to the caller.
+      return generated_project_path
 
     # Copy generated build script to generated_project_path
     shutil.copyfile(
@@ -294,7 +295,8 @@ class Evaluator:
     with open(os.path.join(generated_project_path, 'Dockerfile'), 'a') as f:
       f.write('\nCOPY agent-build.sh /src/build.sh\n')
 
-    return name
+    # Return the generated project path to the caller.
+    return generated_project_path
 
   def _fix_generated_fuzz_target(self, ai_binary: str,
                                  generated_oss_fuzz_project: str,


### PR DESCRIPTION
This commit also modifies the create_ossfuzz_project to return the path of the generated oss-fuzz project so it can read the files from the project. Finally, this commit adds the retrieved sources to the report log.