### PR TITLE
Handle empty error description and errors in DefaultTemplateBuilder

### DIFF
--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -321,8 +321,8 @@ class DefaultTemplateBuilder(PromptBuilder):
       error_desc = coverage_result.insight
       errors = coverage_result.suggestions.splitlines()
     else:
-      error_desc = ''
-      errors = []
+      error_desc = error_desc or ''
+      errors = errors or []
     problem = self._format_fixer_problem(raw_code, error_desc, errors,
                                          priming_weight, context, instruction)
 


### PR DESCRIPTION
This PR fixes #1052 by ensuring that detailed build error messages are retained when generating fixer prompts.

Changes:
- Prevent errors from being cleared if error_desc is empty but errors has content.
- Default error_desc to an empty string if None.
- Default errors to an empty list if None.

This avoids the “Unexpected empty error message” warning.