### PR TITLE
build-fixer: break without changing exit condition on max rounds

### DIFF
--- a/experimental/build_fixer/build_fix.py
+++ b/experimental/build_fixer/build_fix.py
@@ -356,7 +356,7 @@ class BuildFixAgent(BaseAgent):
           logger.info('Max discovery rounds reached (%s).',
                       self.args.max_round,
                       trial=self.trial)
-          self.exit_condition_met = True
+          break
 
       # Post LLM communication and function execution loop.
       # Log details on success.


### PR DESCRIPTION
otherwise we end up declaring everything a success erroneously.