### PR TITLE
context: Add macro wrapped

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -478,7 +478,7 @@ def query_introspector_macro_block(project: str,
           'source': source_path,
           'start': line_start,
           'end': line_end
-  })
+      })
   result = _get_data(resp, 'project', {})
   return result.get('macro_block_info', [])
 

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -72,10 +72,12 @@ INTROSPECTOR_FUNC_SIG = ''
 INTROSPECTOR_ADDR_TYPE = ''
 INTROSPECTOR_ALL_HEADER_FILES = ''
 INTROSPECTOR_ALL_FUNC_TYPES = ''
+INTROSPECTOR_ALL_TYPE_DEFINITION = ''
 INTROSPECTOR_TEST_SOURCE = ''
 INTROSPECTOR_HARNESS_SOURCE_AND_EXEC = ''
 INTROSPECTOR_LANGUAGE_STATS = ''
 INTROSPECTOR_GET_TARGET_FUNCTION = ''
+INTROSPECTOR_CHECK_MACRO = ''
 
 INTROSPECTOR_HEADERS_FOR_FUNC = ''
 INTROSPECTOR_SAMPLE_XREFS = ''
@@ -114,7 +116,8 @@ def set_introspector_endpoints(endpoint):
       INTROSPECTOR_ORACLE_ALL_TESTS, INTROSPECTOR_JVM_PROPERTIES, \
       INTROSPECTOR_TEST_SOURCE, INTROSPECTOR_HARNESS_SOURCE_AND_EXEC, \
       INTROSPECTOR_JVM_PUBLIC_CLASSES, INTROSPECTOR_LANGUAGE_STATS, \
-      INTROSPECTOR_GET_TARGET_FUNCTION
+      INTROSPECTOR_GET_TARGET_FUNCTION, INTROSPECTOR_ALL_TYPE_DEFINITION, \
+      INTROSPECTOR_CHECK_MACRO
 
   INTROSPECTOR_ENDPOINT = endpoint
 
@@ -138,6 +141,8 @@ def set_introspector_endpoints(endpoint):
       f'{INTROSPECTOR_ENDPOINT}/addr-to-recursive-dwarf-info')
   INTROSPECTOR_ALL_HEADER_FILES = f'{INTROSPECTOR_ENDPOINT}/all-header-files'
   INTROSPECTOR_ALL_FUNC_TYPES = f'{INTROSPECTOR_ENDPOINT}/func-debug-types'
+  INTROSPECTOR_ALL_TYPE_DEFINITION = (
+      f'{INTROSPECTOR_ENDPOINT}/full-type-definition')
   INTROSPECTOR_HEADERS_FOR_FUNC = (
       f'{INTROSPECTOR_ENDPOINT}/get-header-files-needed-for-function')
   INTROSPECTOR_SAMPLE_XREFS = (
@@ -156,6 +161,7 @@ def set_introspector_endpoints(endpoint):
       f'{INTROSPECTOR_ENDPOINT}/database-language-stats')
   INTROSPECTOR_GET_TARGET_FUNCTION = (
       f'{INTROSPECTOR_ENDPOINT}/get-target-function')
+  INTROSPECTOR_CHECK_MACRO = f'{INTROSPECTOR_ENDPOINT}/check_macro'
 
 
 def _construct_url(api: str, params: dict) -> str:
@@ -448,6 +454,32 @@ def query_introspector_function_debug_arg_types(project: str,
   })
   arg_types = _get_data(resp, 'arg-types', [])
   return arg_types
+
+
+def query_introspector_type_definition(project: str) -> List[dict]:
+  """Queries FuzzIntrospector for a full list of custom type definition
+  including, union, struct, typedef, enum and macro definition."""
+  resp = _query_introspector(INTROSPECTOR_ALL_TYPE_DEFINITION, {
+      'project': project,
+  })
+  project = _get_data(resp, 'project', {})
+  return project.get('typedef_list', [])
+
+
+def query_introspector_macro_block(project: str,
+                                   source_path: str,
+                                   line_start: int = 0,
+                                   line_end: int = 99999) -> List[dict]:
+  """Queries FuzzIntrospector for a full list of custom type definition
+  including, union, struct, typedef, enum and macro definition."""
+  resp = _query_introspector(INTROSPECTOR_CHECK_MACRO, {
+      'project': project,
+      'source': source_path,
+      'start': line_start,
+      'end': line_end
+  })
+  project = _get_data(resp, 'project', {})
+  return project.get('macro_block_info', [])
 
 
 def query_introspector_cross_references(project: str,

--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -462,8 +462,8 @@ def query_introspector_type_definition(project: str) -> List[dict]:
   resp = _query_introspector(INTROSPECTOR_ALL_TYPE_DEFINITION, {
       'project': project,
   })
-  project = _get_data(resp, 'project', {})
-  return project.get('typedef_list', [])
+  result = _get_data(resp, 'project', {})
+  return result.get('typedef_list', [])
 
 
 def query_introspector_macro_block(project: str,
@@ -472,14 +472,15 @@ def query_introspector_macro_block(project: str,
                                    line_end: int = 99999) -> List[dict]:
   """Queries FuzzIntrospector for a full list of custom type definition
   including, union, struct, typedef, enum and macro definition."""
-  resp = _query_introspector(INTROSPECTOR_CHECK_MACRO, {
-      'project': project,
-      'source': source_path,
-      'start': line_start,
-      'end': line_end
+  resp = _query_introspector(
+      INTROSPECTOR_CHECK_MACRO, {
+          'project': project,
+          'source': source_path,
+          'start': line_start,
+          'end': line_end
   })
-  project = _get_data(resp, 'project', {})
-  return project.get('macro_block_info', [])
+  result = _get_data(resp, 'project', {})
+  return result.get('macro_block_info', [])
 
 
 def query_introspector_cross_references(project: str,

--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -162,6 +162,28 @@ class ContextRetriever:
 
     return function_source
 
+  def _get_macro_block(self) -> list[str]:
+    """Queries FI to check macro block around this function."""
+    project = self._benchmark.project
+    source = self._benchmark.function_dict.get('function_filename', '')
+    start = self._benchmark.function_dict.get('source_line_begin', 0)
+    end = self._benchmark.function_dict.get('source_end_begin', 99999)
+    macro_block = introspector.query_introspector_macro_block(
+        project, source, start, end)
+
+    results = set()
+    for macro in macro_block:
+      conditions = macro.get('conditions', [])
+      for condition in conditions:
+        cond_type = condition.get('type')
+        cond_detail = condition.get('condition')
+        if not cond_type or not cond_detail:
+          continue
+
+        results.add(f'#{cond_type} {cond_detail}')
+
+    return list(results)
+
   def _get_xrefs_to_function(self) -> list[str]:
     """Queries FI for function being fuzzed."""
     project = self._benchmark.project
@@ -177,6 +199,7 @@ class ContextRetriever:
   def get_context_info(self) -> dict:
     """Retrieves contextual information and stores them in a dictionary."""
     xrefs = self._get_xrefs_to_function()
+    macro = self._get_macro_block()
     func_source = self._get_function_implementation()
     files = self._get_files_to_include()
     decl = self._get_embeddable_declaration()
@@ -184,6 +207,7 @@ class ContextRetriever:
 
     context_info = {
         'xrefs': xrefs,
+        'macro_block': macro,
         'func_source': func_source,
         'files': files,
         'decl': decl,

--- a/llm_toolkit/prompt_builder.py
+++ b/llm_toolkit/prompt_builder.py
@@ -203,6 +203,7 @@ class DefaultTemplateBuilder(PromptBuilder):
         must_insert=context_info['decl'],
         func_source=context_info['func_source'],
         xrefs='\n'.join(context_info['xrefs']),
+        macro='\n'.join(context_info['macro']),
         include_statement=context_info['header'],
     )
 

--- a/prompts/template_xml/context.txt
+++ b/prompts/template_xml/context.txt
@@ -20,6 +20,11 @@ Here is the source code of the function being tested:
 {% endif %}
 {% if xrefs %}
 
+Here are all the macro conditions wrapped around or present in the target functions:
+<code>
+{{ macro }}
+</code>
+
 Here is the source code for functions which reference the function being tested:
 <code>
 {{ xrefs }}


### PR DESCRIPTION
This PR follows https://github.com/google/oss-fuzz-gen/pull/1087 to add a new function context with information on all macro conditions wrapped or exists in the target functions with the new macro block checking FI query.

**This PR needs rebase after https://github.com/google/oss-fuzz-gen/pull/1087 is merged.**