### PR TITLE
build-fix: disable caching

### DIFF
--- a/experimental/build_fixer/build_fix.py
+++ b/experimental/build_fixer/build_fix.py
@@ -673,6 +673,10 @@ def fix_build(args, oss_fuzz_base, use_tools: bool = True):
 
   project_name = args.project
   oss_fuzz_checkout.OSS_FUZZ_DIR = oss_fuzz_base
+
+  # Disabling caching
+  oss_fuzz_checkout.ENABLE_CACHING = False
+
   work_dirs = WorkDirs(args.work_dirs, keep=True)
 
   # Prepare LLM model


### PR DESCRIPTION
The prompt looks strange with a cached image, it also does not make sense to use caching since we want to test from base each time.