### PR TITLE
one_prompt_prototyper: Fix error extraction

### DIFF
--- a/agent/one_prompt_prototyper.py
+++ b/agent/one_prompt_prototyper.py
@@ -133,10 +133,21 @@ class OnePromptPrototyper(BaseAgent):
                                    num_samples=1,
                                    temperature=self.args.temperature)
 
+    # Extract error message from stdout and stderr
     errors = code_fixer.extract_error_from_lines(
         build_result.compile_log.split('\n'),
         os.path.basename(build_result.benchmark.target_path),
         build_result.benchmark.language)
+
+    # Also process stderr separately to avoid truncation in compile_log
+    errors.extend(code_fixer.extract_error_from_lines(
+        build_result.compile_error.split('\n'),
+        os.path.basename(build_result.benchmark.target_path),
+        build_result.benchmark.language))
+
+    # Deduplicate error messages
+    errors = list(set(errors))
+
     build_result.compile_error = '\n'.join(errors)
     if build_result.benchmark.language == 'jvm':
       builder = prompt_builder.JvmFixingBuilder(

--- a/agent/one_prompt_prototyper.py
+++ b/agent/one_prompt_prototyper.py
@@ -140,10 +140,11 @@ class OnePromptPrototyper(BaseAgent):
         build_result.benchmark.language)
 
     # Also process stderr separately to avoid truncation in compile_log
-    errors.extend(code_fixer.extract_error_from_lines(
-        build_result.compile_error.split('\n'),
-        os.path.basename(build_result.benchmark.target_path),
-        build_result.benchmark.language))
+    errors.extend(
+        code_fixer.extract_error_from_lines(
+            build_result.compile_error.split('\n'),
+            os.path.basename(build_result.benchmark.target_path),
+            build_result.benchmark.language))
 
     # Deduplicate error messages
     errors = list(set(errors))


### PR DESCRIPTION
Sometimes the compile_log data in build_result is truncated due to excessive stdout and stderr output from the test build. This can result in missing error messages and cause the error extraction logic to fail, preventing any error messages from being passed to the LLM for code fixing.
This PR resolves the issue by also using the full stderr stored in build_result.compile_error to extract error messages, and introduces deduplication logic to avoid sending repeated messages to the LLM.