### PR TITLE
logger: adjust levels

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -127,7 +127,7 @@ def debug(msg: object,
           trial: int,
           exc_info=None,
           stack_info: bool = False,
-          stacklevel: int = 1,
+          stacklevel: int = 2,
           extra: Mapping[str, object] | None = None,
           **kwargs: object) -> None:
   return get_trial_logger(trial=trial).debug(msg,
@@ -144,7 +144,7 @@ def info(msg: object,
          trial: int,
          exc_info=None,
          stack_info: bool = False,
-         stacklevel: int = 1,
+         stacklevel: int = 2,
          extra: Mapping[str, object] | None = None,
          **kwargs: object) -> None:
   return get_trial_logger(trial=trial).info(msg,
@@ -161,7 +161,7 @@ def warning(msg: object,
             trial: int,
             exc_info=None,
             stack_info: bool = False,
-            stacklevel: int = 1,
+            stacklevel: int = 2,
             extra: Mapping[str, object] | None = None,
             **kwargs: object) -> None:
   return get_trial_logger(trial=trial).warning(msg,
@@ -178,7 +178,7 @@ def error(msg: object,
           trial: int,
           exc_info=None,
           stack_info: bool = False,
-          stacklevel: int = 1,
+          stacklevel: int = 2,
           extra: Mapping[str, object] | None = None,
           **kwargs: object) -> None:
   return get_trial_logger(trial=trial).error(msg,
@@ -198,7 +198,7 @@ def get_trial_logger(name: str = __name__,
   if not logger.handlers:
     formatter = logging.Formatter(
         fmt=('%(asctime)s [Trial ID: %(trial)02d] %(levelname)s '
-             '[%(module)s.%(funcName)s]: %(message)s'),
+             '[%(module)s.%(funcName)s:%(lineno)s]: %(message)s'),
         datefmt='%Y-%m-%d %H:%M:%S')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)


### PR DESCRIPTION
Currently we log the `logger.logger.info`, `...warning` functions in the log, instead of the actual locations calling `..info(` in the code. This makes it difficult to trace source code flow by way of logging and means a lot of grepping is needed for identifying where certain logs come from. This commit switches stack level so we now have the actual location of the code that calls into `..info` e.g.:

```
2025-06-16 14:38:26 [Trial ID: 02] INFO
[function_based_prototyper.execute:416]
```