### PR TITLE
disable function analyzer for non-compliant models

### DIFF
--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -266,16 +266,21 @@ def _fuzzing_pipeline(benchmark: Benchmark, model: models.LLM,
                               CrashAnalyzer(trial=trial, llm=model, args=args),
                           ])
   elif args.agent:
+
+    writer_agents = []
+    if 'gemini' in args.model or 'vertex' in args.model:
+      writer_agents.append(
+          FunctionAnalyzer(trial=trial,
+                           llm=model,
+                           args=args,
+                           benchmark=benchmark))
+    writer_agents += [
+        Prototyper(trial=trial, llm=model, args=args),
+        Enhancer(trial=trial, llm=model, args=args)
+    ]
     p = pipeline.Pipeline(args=args,
                           trial=trial,
-                          writing_stage_agents=[
-                              FunctionAnalyzer(trial=trial,
-                                               llm=model,
-                                               args=args,
-                                               benchmark=benchmark),
-                              Prototyper(trial=trial, llm=model, args=args),
-                              Enhancer(trial=trial, llm=model, args=args),
-                          ],
+                          writing_stage_agents=writer_agents,
                           analysis_stage_agents=[
                               SemanticAnalyzer(trial=trial,
                                                llm=model,
@@ -286,20 +291,21 @@ def _fuzzing_pipeline(benchmark: Benchmark, model: models.LLM,
                               CrashAnalyzer(trial=trial, llm=model, args=args),
                           ])
   else:
+    writer_agents = []
+    if 'gemini' in args.model or 'vertex' in args.model:
+      writer_agents.append(
+          FunctionAnalyzer(trial=trial,
+                           llm=model,
+                           args=args,
+                           benchmark=benchmark))
+    writer_agents += [
+        OnePromptPrototyper(trial=trial, llm=model, args=args),
+        OnePromptEnhancer(trial=trial, llm=model, args=args)
+    ]
+
     p = pipeline.Pipeline(args=args,
                           trial=trial,
-                          writing_stage_agents=[
-                              FunctionAnalyzer(trial=trial,
-                                               llm=model,
-                                               args=args,
-                                               benchmark=benchmark),
-                              OnePromptPrototyper(trial=trial,
-                                                  llm=model,
-                                                  args=args),
-                              OnePromptEnhancer(trial=trial,
-                                                llm=model,
-                                                args=args),
-                          ],
+                          writing_stage_agents=writer_agents,
                           analysis_stage_agents=[
                               SemanticAnalyzer(trial=trial,
                                                llm=model,

--- a/stage/writing_stage.py
+++ b/stage/writing_stage.py
@@ -50,13 +50,16 @@ class WritingStage(BaseStage):
       # Execute the Enhancer agent
       agent = self.get_agent(index=2)
     else:
-      # First, execute the FunctionAnalyzer agent
       agent = self.get_agent(index=0)
-      agent_result = self._execute_agent(agent, result_history)
-      result_history.append(agent_result)
+      if agent.name == 'FunctionAnalyzer':
+        # If the first agent is FunctionAnalyzer, we execute it first
+        # to generate a new fuzz target and build script.
+        agent_result = self._write_new_fuzz_target(result_history)
+        result_history.append(agent_result)
 
-      # Then, execute the Prototyper agent
-      agent = self.get_agent(index=1)
+        # Then, execute the Prototyper agent to refine the fuzz target.
+        agent = self.get_agent(index=1)
+
     agent_result = self._execute_agent(agent, result_history)
     build_result = cast(BuildResult, agent_result)
 


### PR DESCRIPTION
https://github.com/google/oss-fuzz-gen/pull/1092 caused some regressions for non-vertex models in the main pipelines. Adjusting so this is disabled during those pipelines as it means we cant run the analysis not using vertex models.