### PR TITLE
stage: execution: handle binary data

### DIFF
--- a/stage/execution_stage.py
+++ b/stage/execution_stage.py
@@ -166,7 +166,6 @@ class ExecutionStage(BaseStage):
           raw_run_log_lines = f.readlines()
           run_log_lines = []
           for line in raw_run_log_lines:
-            # Decode bytes to string and strip whitespace.
             decoded_line = line.decode('utf-8', errors='ignore')
             if decoded_line:
               run_log_lines.append(decoded_line)


### PR DESCRIPTION
The run logs can contain binary that can't be decoded. This is likely only a tiny bit of the logs, though, so we shouldn't fail hard on unicode decoding errors as such. This fixes it by doing a softer decoding and making sure we don't break because of unicode decode errors.