### PR TITLE
pipeline: avoid crash analyser in custom pipeline

### DIFF
--- a/run_one_experiment.py
+++ b/run_one_experiment.py
@@ -263,7 +263,6 @@ def _fuzzing_pipeline(benchmark: Benchmark, model: models.LLM,
                               CoverageAnalyzer(trial=trial,
                                                llm=model,
                                                args=args),
-                              CrashAnalyzer(trial=trial, llm=model, args=args),
                           ])
   elif args.agent:
 

--- a/stage/analysis_stage.py
+++ b/stage/analysis_stage.py
@@ -35,7 +35,10 @@ class AnalysisStage(BaseStage):
     assert isinstance(last_result, RunResult)
 
     if last_result.crashes:
-      agent = self.get_agent(agent_name='CrashAnalyzer')
+      try:
+        agent = self.get_agent(agent_name='CrashAnalyzer')
+      except RuntimeError:
+        agent = self.get_agent(agent_name='SemanticAnalyzer')
     else:
       try:
         agent = self.get_agent(agent_name='CoverageAnalyzer')


### PR DESCRIPTION
This is easier for testing purposes when the focus is elsewhere.