### PR TITLE
context: Fix xref api calls

### DIFF
--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -187,10 +187,26 @@ class ContextRetriever:
 
     if not xrefs:
       logging.warning(
-          'Could not retrieve tests xrefs for project: %s '
-          'function_signature: %s', project, func_name)
+          'Could not retrieve xrefs for project: %s '
+          'function_signature: %s', project, func_sig)
 
-    return [xref for xref in xrefs if xref.strip()]
+    source_list = xrefs.get('source')
+    detail_list = xrefs.get('details')
+
+    if source_list:
+      source_list.insert(0, '<code>')
+      source_list.append('</code>')
+      return [src for src in source_list if src.strip()]
+
+    result = ['<codeblock>']
+
+    for detail in detail_list:
+      result.append('<code>')
+      result.extend(detail)
+      result.append('</code>')
+
+    result.append('</codeblock>')
+    return result
 
   def _get_param_typedef(self) -> list[str]:
     """Querties FI for param type definitions with type name."""

--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -187,8 +187,8 @@ class ContextRetriever:
 
     if not xrefs:
       logging.warning(
-          'Could not retrieve xrefs for project: %s '
-          'function_signature: %s', project, func_sig)
+          'Could not retrieve tests xrefs for project: %s '
+          'function_signature: %s', project, func_name)
 
     source_list = xrefs.get('source')
     detail_list = xrefs.get('details')

--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -193,13 +193,13 @@ class ContextRetriever:
     source_list = xrefs.get('source')
     detail_list = xrefs.get('details')
 
-    if not source_list and not detail_list:
-        return []
-
     if source_list:
       source_list.insert(0, '<code>')
       source_list.append('</code>')
       return [src for src in source_list if src.strip()]
+
+    if not detail_list:
+      return []
 
     result = ['<codeblock>']
 
@@ -209,6 +209,7 @@ class ContextRetriever:
       result.append('</code>')
 
     result.append('</codeblock>')
+
     return result
 
   def _get_param_typedef(self) -> list[str]:

--- a/data_prep/project_context/context_introspector.py
+++ b/data_prep/project_context/context_introspector.py
@@ -193,6 +193,9 @@ class ContextRetriever:
     source_list = xrefs.get('source')
     detail_list = xrefs.get('details')
 
+    if not source_list and not detail_list:
+        return []
+
     if source_list:
       source_list.insert(0, '<code>')
       source_list.append('</code>')

--- a/prompts/template_xml/context.txt
+++ b/prompts/template_xml/context.txt
@@ -34,7 +34,5 @@ Here is the source code for functions which reference the function being tested:
 {% if tests_xrefs %}
 
 Here is the source code snippet for the tests/examples that reference the function being tested:
-<code>
 {{ tests_xrefs }}
-</code>
 {% endif %}


### PR DESCRIPTION
This PR refines the xrefs test context to more precisely include the line of the target function call, along with the lines where its parameters are defined and initialised, to provide more accurate and minimal information for prompt creation.