### PR TITLE
Update CrashAnalyzer to Handle Invalid LLM Responses

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -167,7 +167,8 @@ class BaseAgent(ABC):
       prompt.append(prompt_text)
     return prompt
 
-  def _container_handle_invalid_tool_usage(self, tool: BaseTool, cur_round: int,
+  def _container_handle_invalid_tool_usage(self, tools: list[BaseTool],
+                                           cur_round: int,
                                            response: str,
                                            prompt: Prompt) -> Prompt:
     """Formats a prompt to re-teach LLM how to use the |tool|."""
@@ -175,8 +176,10 @@ class BaseAgent(ABC):
                    cur_round,
                    response,
                    trial=self.trial)
-    prompt_text = (f'No valid instruction received, Please follow the '
-                   f'interaction protocols:\n{tool.tutorial()}')
+    prompt_text = ('No valid instruction received, Please follow the'
+                  'interaction protocols for available tools:\n\n')
+    for tool in tools:
+      prompt_text += f'{tool.tutorial()}\n\n'
     prompt.append(prompt_text)
     return prompt
 

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -168,8 +168,7 @@ class BaseAgent(ABC):
     return prompt
 
   def _container_handle_invalid_tool_usage(self, tools: list[BaseTool],
-                                           cur_round: int,
-                                           response: str,
+                                           cur_round: int, response: str,
                                            prompt: Prompt) -> Prompt:
     """Formats a prompt to re-teach LLM how to use the |tool|."""
     logger.warning('ROUND %02d Invalid response from LLM: %s',
@@ -177,7 +176,7 @@ class BaseAgent(ABC):
                    response,
                    trial=self.trial)
     prompt_text = ('No valid instruction received, Please follow the'
-                  'interaction protocols for available tools:\n\n')
+                   'interaction protocols for available tools:\n\n')
     for tool in tools:
       prompt_text += f'{tool.tutorial()}\n\n'
     prompt.append(prompt_text)

--- a/agent/coverage_analyzer.py
+++ b/agent/coverage_analyzer.py
@@ -93,7 +93,7 @@ class CoverageAnalyzer(BaseAgent):
     # Finally check invalid responses.
     if not response or not prompt.get():
       prompt = self._container_handle_invalid_tool_usage(
-          self.inspect_tool, cur_round, response, prompt)
+          [self.inspect_tool], cur_round, response, prompt)
       with open(INVALID_PRMOT_PATH, 'r') as prompt_file:
         prompt.append(prompt_file.read())
 

--- a/agent/coverage_analyzer.py
+++ b/agent/coverage_analyzer.py
@@ -92,8 +92,9 @@ class CoverageAnalyzer(BaseAgent):
 
     # Finally check invalid responses.
     if not response or not prompt.get():
-      prompt = self._container_handle_invalid_tool_usage(
-          [self.inspect_tool], cur_round, response, prompt)
+      prompt = self._container_handle_invalid_tool_usage([self.inspect_tool],
+                                                         cur_round, response,
+                                                         prompt)
       with open(INVALID_PRMOT_PATH, 'r') as prompt_file:
         prompt.append(prompt_file.read())
 

--- a/agent/crash_analyzer.py
+++ b/agent/crash_analyzer.py
@@ -140,7 +140,9 @@ class CrashAnalyzer(BaseAgent):
     if self._parse_tag(response, 'bash'):
       return self._container_handle_bash_command(response, self.bash_tool,
                                                  prompt)
-    return None
+    # Finally handle invalid responses.
+    return self._container_handle_invalid_tool_usage(
+        [self.gdb_tool, self.bash_tool], cur_round, response, prompt)
 
   def execute(self, result_history: list[Result]) -> AnalysisResult:
     """Executes the agent based on previous run result."""

--- a/agent/function_analyzer.py
+++ b/agent/function_analyzer.py
@@ -154,8 +154,8 @@ class FunctionAnalyzer(base_agent.ADKBaseAgent):
 
     # Finally check invalid request.
     if not request or not prompt.get():
-      prompt = self._container_handle_invalid_tool_usage(
-          [self.inspect_tool], 0, request, prompt)
+      prompt = self._container_handle_invalid_tool_usage([self.inspect_tool], 0,
+                                                         request, prompt)
 
     tool_response = prompt.get()
 

--- a/agent/function_analyzer.py
+++ b/agent/function_analyzer.py
@@ -155,7 +155,7 @@ class FunctionAnalyzer(base_agent.ADKBaseAgent):
     # Finally check invalid request.
     if not request or not prompt.get():
       prompt = self._container_handle_invalid_tool_usage(
-          self.inspect_tool, 0, request, prompt)
+          [self.inspect_tool], 0, request, prompt)
 
     tool_response = prompt.get()
 

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -421,7 +421,7 @@ class Prototyper(BaseAgent):
     # Finally check invalid responses.
     if not response or not prompt.get():
       prompt = self._container_handle_invalid_tool_usage(
-          self.inspect_tool, cur_round, response, prompt)
+          [self.inspect_tool], cur_round, response, prompt)
 
     return prompt
 

--- a/agent/prototyper.py
+++ b/agent/prototyper.py
@@ -420,8 +420,9 @@ class Prototyper(BaseAgent):
 
     # Finally check invalid responses.
     if not response or not prompt.get():
-      prompt = self._container_handle_invalid_tool_usage(
-          [self.inspect_tool], cur_round, response, prompt)
+      prompt = self._container_handle_invalid_tool_usage([self.inspect_tool],
+                                                         cur_round, response,
+                                                         prompt)
 
     return prompt
 

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -244,7 +244,7 @@ class BuildScriptAgent(BaseAgent):
 
     if not response or not prompt or not prompt.get():
       prompt = self._container_handle_invalid_tool_usage(
-          self.inspect_tool, cur_round, response, prompt)
+          [self.inspect_tool], cur_round, response, prompt)
 
     return prompt
 
@@ -457,7 +457,7 @@ class AutoDiscoveryBuildScriptAgent(BuildScriptAgent):
 
     return prompt
 
-  def _container_handle_invalid_tool_usage(self, tool: BaseTool, cur_round: int,
+  def _container_handle_invalid_tool_usage(self, tools: list[BaseTool], cur_round: int,
                                            response: str,
                                            prompt: Prompt) -> Prompt:
     """Formats a prompt to re-teach LLM how to use the |tool|."""
@@ -495,7 +495,7 @@ class AutoDiscoveryBuildScriptAgent(BuildScriptAgent):
 
     if not response or not prompt.get() or self.invalid:
       prompt = self._container_handle_invalid_tool_usage(
-          self.inspect_tool, cur_round, response, prompt)
+          [self.inspect_tool], cur_round, response, prompt)
 
     return prompt
 

--- a/experimental/build_generator/llm_agent.py
+++ b/experimental/build_generator/llm_agent.py
@@ -243,8 +243,9 @@ class BuildScriptAgent(BaseAgent):
         return None
 
     if not response or not prompt or not prompt.get():
-      prompt = self._container_handle_invalid_tool_usage(
-          [self.inspect_tool], cur_round, response, prompt)
+      prompt = self._container_handle_invalid_tool_usage([self.inspect_tool],
+                                                         cur_round, response,
+                                                         prompt)
 
     return prompt
 
@@ -457,8 +458,8 @@ class AutoDiscoveryBuildScriptAgent(BuildScriptAgent):
 
     return prompt
 
-  def _container_handle_invalid_tool_usage(self, tools: list[BaseTool], cur_round: int,
-                                           response: str,
+  def _container_handle_invalid_tool_usage(self, tools: list[BaseTool],
+                                           cur_round: int, response: str,
                                            prompt: Prompt) -> Prompt:
     """Formats a prompt to re-teach LLM how to use the |tool|."""
     # pylint: disable=unused-argument
@@ -494,8 +495,9 @@ class AutoDiscoveryBuildScriptAgent(BuildScriptAgent):
           return None
 
     if not response or not prompt.get() or self.invalid:
-      prompt = self._container_handle_invalid_tool_usage(
-          [self.inspect_tool], cur_round, response, prompt)
+      prompt = self._container_handle_invalid_tool_usage([self.inspect_tool],
+                                                         cur_round, response,
+                                                         prompt)
 
     return prompt
 


### PR DESCRIPTION
This PR does the following:
- Fixes the bug where CrashAnalyzer returns prematurely after receiving an invalid LLM response.
- Modifies the function for handling invalid LLM Responses (_container_handle_invalid_tool_usage) so it can handle multiple tools. CrashAnalyzer requires this.
- Updates callers of _container_handle_invalid_tool_usage so they pass a list of tools, instead of a tool object.