### PR TITLE
Add CSV export for the report

### DIFF
--- a/report/docker_run.py
+++ b/report/docker_run.py
@@ -225,7 +225,7 @@ def run_on_data_from_scratch(cmd=None):
   report_process = subprocess.Popen([
       "bash", "report/upload_report.sh", local_results_dir, gcs_report_dir,
       args.benchmark_set, args.model
-  ])
+  ] + args.additional_args)
 
   # Launch run_all_experiments.py
   # some notes:
@@ -381,7 +381,7 @@ def run_standard(cmd=None):
   report_process = subprocess.Popen([
       "bash", "report/upload_report.sh", local_results_dir, gcs_report_dir,
       args.benchmark_set, args.model
-  ])
+  ] + args.additional_args)
 
   # Prepare the command to run experiments
   run_cmd = [

--- a/report/export.py
+++ b/report/export.py
@@ -20,14 +20,6 @@ from abc import abstractmethod
 from report.common import Results
 
 
-def determine_base_url(results_dir: str, port: int = 8012) -> str:
-  """Determine the base URL based on the environment."""
-  if 'gcb-experiment' in results_dir:
-    path = results_dir.removeprefix('gs://oss-fuzz-gcb-experiment-run-logs/')
-    return f'https://llm-exp.oss-fuzz.com/{path}'
-  return f'http://127.0.0.1:{port}'
-
-
 class BaseExporter:
   """Base class for exporters."""
 

--- a/report/export.py
+++ b/report/export.py
@@ -15,16 +15,27 @@
 import csv
 import logging
 import os
+from abc import abstractmethod
 
 from report.common import Results
 
-
-class CSVReport:
-  """Export a report to CSV."""
+class BaseExporter:
+  """Base class for exporters."""
 
   def __init__(self, results: Results, output_dir: str):
     self._results = results
     self._output_dir = output_dir
+
+  @abstractmethod
+  def generate(self):
+    """Generate a report."""
+    pass
+
+class CSVExporter(BaseExporter):
+  """Export a report to CSV."""
+
+  def __init__(self, results: Results, output_dir: str):
+    super().__init__(results, output_dir)
 
   def generate(self):
     """Generate a CSV file with the results."""
@@ -32,7 +43,7 @@ class CSVReport:
     os.makedirs(os.path.dirname(csv_path), exist_ok=True)
 
     with open(csv_path, 'w', newline='') as csvfile:
-      fieldnames = ["Benchmark", "Sample", "Status", "Compiles", "Crashes"]
+      fieldnames = ["Project", "Benchmark", "Sample", "Status", "Compiles", "Crashes"]
 
       writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
       writer.writeheader()
@@ -44,9 +55,11 @@ class CSVReport:
                                                   targets)
         benchmarks.append(benchmark)
         samples = self._results.get_samples(results, targets)
+        project = benchmark_id.split("-")[1]
 
         for sample in samples:
           writer.writerow({
+              "Project": project,
               "Benchmark": benchmark_id,
               "Sample": sample.id,
               "Status": sample.status,
@@ -62,12 +75,11 @@ class CSVReport:
     return os.path.join(self._output_dir, 'crashes.csv')
 
 
-class GoogleSheetsReporter:
+class GoogleSheetsExporter(BaseExporter):
   """Export a report to Google Sheets."""
 
   def __init__(self, results: Results, output_dir: str):
-    self._results = results
-    self._output_dir = output_dir
+    super().__init__(results, output_dir)
 
 
 #   def generate(self):

--- a/report/export.py
+++ b/report/export.py
@@ -19,23 +19,40 @@ from abc import abstractmethod
 
 from report.common import Results
 
+
+def determine_base_url(results_dir: str, port: int = 8012) -> str:
+  """Determine the base URL based on the environment."""
+  if 'gcb-experiment' in results_dir:
+    path = results_dir.removeprefix('gs://oss-fuzz-gcb-experiment-run-logs/')
+    return f'https://llm-exp.oss-fuzz.com/{path}'
+  return f'http://127.0.0.1:{port}'
+
+
 class BaseExporter:
   """Base class for exporters."""
 
-  def __init__(self, results: Results, output_dir: str):
+  def __init__(self, results: Results, output_dir: str, base_url: str = ''):
     self._results = results
     self._output_dir = output_dir
+    self._base_url = base_url.rstrip('/')
+    self._headers = [
+        "Project", "Function Signature", "Sample", "Crash Type", "Compiles",
+        "Crashes", "Coverage", "Line Coverage Diff", "Reproducer Path"
+    ]
 
   @abstractmethod
-  def generate(self):
+  def generate(self) -> str:
     """Generate a report."""
-    pass
+
+  def _get_full_url(self, relative_path: str) -> str:
+    """Convert relative path to full URL."""
+    if not self._base_url:
+      return relative_path
+    return f"{self._base_url}/{relative_path}"
+
 
 class CSVExporter(BaseExporter):
   """Export a report to CSV."""
-
-  def __init__(self, results: Results, output_dir: str):
-    super().__init__(results, output_dir)
 
   def generate(self):
     """Generate a CSV file with the results."""
@@ -43,9 +60,7 @@ class CSVExporter(BaseExporter):
     os.makedirs(os.path.dirname(csv_path), exist_ok=True)
 
     with open(csv_path, 'w', newline='') as csvfile:
-      fieldnames = ["Project", "Benchmark", "Sample", "Status", "Compiles", "Crashes"]
-
-      writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+      writer = csv.DictWriter(csvfile, fieldnames=self._headers)
       writer.writeheader()
 
       benchmarks = []
@@ -55,16 +70,32 @@ class CSVExporter(BaseExporter):
                                                   targets)
         benchmarks.append(benchmark)
         samples = self._results.get_samples(results, targets)
-        project = benchmark_id.split("-")[1]
+
+        project_name = benchmark_id.split("-")[1]
 
         for sample in samples:
+          report_url = self._get_full_url(
+              f"sample/{benchmark_id}/{sample.id}.html")
           writer.writerow({
-              "Project": project,
-              "Benchmark": benchmark_id,
-              "Sample": sample.id,
-              "Status": sample.status,
-              "Compiles": sample.result.compiles,
-              "Crashes": sample.result.crashes
+              "Project":
+                  project_name,
+              "Function Signature":
+                  benchmark.function,
+              "Sample":
+                  report_url,
+              "Crashes":
+                  sample.result.crashes,
+              "Crash Type":
+                  'False Positive'
+                  if sample.result.is_semantic_error else 'True Positive',
+              "Compiles":
+                  sample.result.compiles,
+              "Coverage":
+                  sample.result.coverage,
+              "Line Coverage Diff":
+                  sample.result.line_coverage_diff,
+              "Reproducer Path":
+                  sample.result.reproducer_path
           })
 
     logging.info("Created CSV file at %s", csv_path)
@@ -73,15 +104,3 @@ class CSVExporter(BaseExporter):
   def get_url_path(self):
     """Get the URL path to the CSV file."""
     return os.path.join(self._output_dir, 'crashes.csv')
-
-
-class GoogleSheetsExporter(BaseExporter):
-  """Export a report to Google Sheets."""
-
-  def __init__(self, results: Results, output_dir: str):
-    super().__init__(results, output_dir)
-
-
-#   def generate(self):
-#     """Generate a Google Sheets report."""
-#     pass

--- a/report/export.py
+++ b/report/export.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A module to export a report to CSV or Google Sheets."""
+import csv
+import logging
+import os
+
+from report.common import Results
+
+
+class CSVReport:
+  """Export a report to CSV."""
+
+  def __init__(self, results: Results, output_dir: str):
+    self._results = results
+    self._output_dir = output_dir
+
+  def generate(self):
+    """Generate a CSV file with the results."""
+    csv_path = os.path.join(self._output_dir, 'crashes.csv')
+    os.makedirs(os.path.dirname(csv_path), exist_ok=True)
+
+    with open(csv_path, 'w', newline='') as csvfile:
+      fieldnames = ["Benchmark", "Sample", "Status", "Compiles", "Crashes"]
+
+      writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+      writer.writeheader()
+
+      benchmarks = []
+      for benchmark_id in self._results.list_benchmark_ids():
+        results, targets = self._results.get_results(benchmark_id)
+        benchmark = self._results.match_benchmark(benchmark_id, results,
+                                                  targets)
+        benchmarks.append(benchmark)
+        samples = self._results.get_samples(results, targets)
+
+        for sample in samples:
+          writer.writerow({
+              "Benchmark": benchmark_id,
+              "Sample": sample.id,
+              "Status": sample.status,
+              "Compiles": sample.result.compiles,
+              "Crashes": sample.result.crashes
+          })
+
+    logging.info("Created CSV file at %s", csv_path)
+    return csv_path
+
+  def get_url_path(self):
+    """Get the URL path to the CSV file."""
+    return os.path.join(self._output_dir, 'crashes.csv')
+
+
+class GoogleSheetsReporter:
+  """Export a report to Google Sheets."""
+
+  def __init__(self, results: Results, output_dir: str):
+    self._results = results
+    self._output_dir = output_dir
+
+
+#   def generate(self):
+#     """Generate a Google Sheets report."""
+#     pass

--- a/report/templates/base.html
+++ b/report/templates/base.html
@@ -332,8 +332,8 @@ tbody tr:nth-child(odd) {
                 :class="darkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-800'"
             >
                 <div class="py-1" role="menu">
-                    <a href="#" class="block px-4 py-2 text-sm" role="menuitem">Export as PDF (.pdf)</a>
-                    <a href="#" class="block px-4 py-2 text-sm" role="menuitem">Export as CSV (.csv)</a>
+                    <a href="{{ json_url_path }}" class="block px-4 py-2 text-sm" role="menuitem">Export as JSON (.json)</a>
+                    <a href="{{ csv_url_path }}" class="block px-4 py-2 text-sm" role="menuitem">Export as CSV (.csv)</a>
                     <a href="#" class="block px-4 py-2 text-sm" role="menuitem">Export as Google Sheet</a>
                 </div>
             </div>

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -59,7 +59,12 @@ mkdir results-report
 
 update_report() {
   # Generate the report
-  $PYTHON -m report.web -r "${RESULTS_DIR:?}" -b "${BENCHMARK_SET:?}" -m "$MODEL" -o results-report $REPORT_ADDITIONAL_ARGS
+  if [[ $GCS_DIR != '' ]]; then
+    CLOUD_BASE_URL="https://llm-exp.oss-fuzz.com/Result-reports/${GCS_DIR}"
+    $PYTHON -m report.web -r "${RESULTS_DIR:?}" -b "${BENCHMARK_SET:?}" -m "$MODEL" -o results-report --base-url "$CLOUD_BASE_URL" $REPORT_ADDITIONAL_ARGS
+  else
+    $PYTHON -m report.web -r "${RESULTS_DIR:?}" -b "${BENCHMARK_SET:?}" -m "$MODEL" -o results-report $REPORT_ADDITIONAL_ARGS
+  fi
 
   cd results-report || exit 1
 

--- a/report/upload_report.sh
+++ b/report/upload_report.sh
@@ -20,6 +20,7 @@
 ##   results_dir is the local directory with the experiment results.
 ##   gcs_dir is the name of the directory for the report in gs://oss-fuzz-gcb-experiment-run-logs/Result-reports/.
 ##     Defaults to '$(whoami)-%YY-%MM-%DD'.
+##   additional_args are passed through to report.web (e.g., --with-csv)
 
 # TODO(dongge): Re-write this script in Python as it gets more complex.
 
@@ -27,6 +28,9 @@ RESULTS_DIR=$1
 GCS_DIR=$2
 BENCHMARK_SET=$3
 MODEL=$4
+# All remaining arguments are additional args for report.web
+shift 4
+REPORT_ADDITIONAL_ARGS="$@"
 DATE=$(date '+%Y-%m-%d')
 
 # Sleep 5 minutes for the experiment to start.
@@ -55,7 +59,7 @@ mkdir results-report
 
 update_report() {
   # Generate the report
-  $PYTHON -m report.web -r "${RESULTS_DIR:?}" -b "${BENCHMARK_SET:?}" -m "$MODEL" -o results-report
+  $PYTHON -m report.web -r "${RESULTS_DIR:?}" -b "${BENCHMARK_SET:?}" -m "$MODEL" -o results-report $REPORT_ADDITIONAL_ARGS
 
   cd results-report || exit 1
 

--- a/report/web.py
+++ b/report/web.py
@@ -31,7 +31,7 @@ import jinja2
 
 from report.common import (AccumulatedResult, Benchmark, FileSystem, Project,
                            Results, Sample, Target)
-from report.export import CSVReport
+from report.export import CSVExporter, determine_base_url
 from report.parse_run_log import RunLogsParser
 
 LOCAL_HOST = '127.0.0.1'
@@ -527,7 +527,10 @@ def generate_report(args: argparse.Namespace) -> None:
   }
   # WIP: writing to a CSV file
   if args.with_csv:
-    csv_reporter = CSVReport(results=results, output_dir=args.output_dir)
+    base_url = determine_base_url(args.results_dir, getattr(args, 'port', 8012))
+    csv_reporter = CSVExporter(results=results,
+                               output_dir=args.output_dir,
+                               base_url=base_url)
     csv_reporter.generate()
     # Temporarily commented out because locally this is just a relative path
     # template_globals['csv_url_path'] = csv_reporter.get_url_path()

--- a/report/web.py
+++ b/report/web.py
@@ -15,7 +15,6 @@
 """Report generation tool to create HTML reports for experiment result."""
 
 import argparse
-import dataclasses
 import json
 import logging
 import os
@@ -32,6 +31,7 @@ import jinja2
 
 from report.common import (AccumulatedResult, Benchmark, FileSystem, Project,
                            Results, Sample, Target)
+from report.export import CSVReport
 from report.parse_run_log import RunLogsParser
 
 LOCAL_HOST = '127.0.0.1'
@@ -433,8 +433,6 @@ class GenerateReport:
             "triager_prompt": ""
         }
 
-        logs = self._results.get_logs(benchmark.id, sample.id) or []
-
         sample_data = {
             "sample": sample.id,
             "status": sample.result.finished,
@@ -522,7 +520,24 @@ def generate_report(args: argparse.Namespace) -> None:
   logging.info('Generating web page files in %s', args.output_dir)
   results = Results(results_dir=args.results_dir,
                     benchmark_set=args.benchmark_set)
-  jinja_env = JinjaEnv(template_globals={'model': args.model})
+
+  template_globals = {
+      'model': args.model,
+      'json_url_path': 'unified_data.json',
+  }
+  # WIP: writing to a CSV file
+  if args.with_csv:
+    csv_reporter = CSVReport(results=results, output_dir=args.output_dir)
+    csv_reporter.generate()
+    # Temporarily commented out because locally this is just a relative path
+    # template_globals['csv_url_path'] = csv_reporter.get_url_path()
+    template_globals['csv_url_path'] = 'crashes.csv'
+
+  # WIP: writing to Google Sheets
+  if args.with_google_sheets:
+    pass
+
+  jinja_env = JinjaEnv(template_globals=template_globals)
   gr = GenerateReport(results=results,
                       jinja_env=jinja_env,
                       results_dir=args.results_dir,
@@ -571,6 +586,14 @@ def _parse_arguments() -> argparse.Namespace:
                       help='Port to launch webserver on.',
                       type=int,
                       default=8012)
+  parser.add_argument('--with-csv',
+                      '-csv',
+                      help='Will write a CSV file with the results.',
+                      action='store_true')
+  parser.add_argument('--with-google-sheets',
+                      '-gs',
+                      help='Will write to Google Sheets.',
+                      action='store_true')
 
   return parser.parse_args()
 

--- a/report/web.py
+++ b/report/web.py
@@ -31,7 +31,7 @@ import jinja2
 
 from report.common import (AccumulatedResult, Benchmark, FileSystem, Project,
                            Results, Sample, Target)
-from report.export import CSVExporter, determine_base_url
+from report.export import CSVExporter
 from report.parse_run_log import RunLogsParser
 
 LOCAL_HOST = '127.0.0.1'
@@ -527,7 +527,7 @@ def generate_report(args: argparse.Namespace) -> None:
   }
   # WIP: writing to a CSV file
   if args.with_csv:
-    base_url = determine_base_url(args.results_dir, getattr(args, 'port', 8012))
+    base_url = args.base_url if args.base_url else "http://127.0.0.1:8012"
     csv_reporter = CSVExporter(results=results,
                                output_dir=args.output_dir,
                                base_url=base_url)
@@ -597,6 +597,10 @@ def _parse_arguments() -> argparse.Namespace:
                       '-gs',
                       help='Will write to Google Sheets.',
                       action='store_true')
+  parser.add_argument(
+      '--base-url',
+      help='Base URL for the report (used in cloud environments).',
+      default='')
 
   return parser.parse_args()
 


### PR DESCRIPTION
This PR adds a basic CSV export functionality for the report. 

Each row in the CSV is a trial/sample. The headers are:
- `Project`: Human-readable project name
- `Function Signature`: Human-readable function signature
- `Sample`: Hyperlink to the trial/sample page in the report
- `Crash Type`: Whether the sample is a true or false positive crash
- `Compiles`
- `Crashes`
- `Coverage`
- `Line Coverage Diff`
- `Reproducer Path`

To trigger CSV export, run experiments with an added `-csv` or `--with-csv` flag. The generated CSV can then be accessed via the report itself (by clicking on the top-left 'Export' button), or found at the root of the results directory as `crashes.csv`.