### PR TITLE
Add support to self-hosted models via ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Current supported models are:
 - OpenAI GPT-3.5-turbo (Azure)
 - OpenAI GPT-4 (Azure)
 - OpenAI GPT-4o (Azure)
+- Self-hosted models via Ollama (experimental)
 
 Generated fuzz targets are evaluated with four metrics against the most up-to-date data from production environment:
 - Compilability

--- a/USAGE.md
+++ b/USAGE.md
@@ -78,6 +78,19 @@ export AZURE_OPENAI_API_VERSION='<your-azure-api-version>' # default is '2024-02
 > Tip: 
 To distinguish between the two ways of accessing OpenAI models, you need to add `-azure` to the model name **when using OpenAI on Azure**. For example, `gpt-3.5-turbo-azure` will use OpenAI on Azure, while `gpt-3.5-turbo` will use OpenAI on OpenAI.
 
+#### Ollama (experimental)
+
+[Ollama](https://ollama.com) exposes an OpenAI-compatible API for self-hosted models.
+
+Pull a model on Ollama and pass it with the `ollama/<tag>` syntax, where `<tag>` is the exact tag served by Ollama.
+For example, `ollama/gemma4:latest`.
+
+The default endpoint is `http://localhost:11434/v1`.
+If the Ollama instance is reachable at a different URL, set it as an ENV variable:
+```bash
+export OLLAMA_BASE_URL='<your-ollama-base-url>'
+```
+
 
 ## Running experiments
 To generate and evaluate the fuzz targets in a benchmark set via *local* experiments:
@@ -114,6 +127,7 @@ the model is supported by way of Vertex AI:
 14. `gpt-4o`
 15. `gpt-4o-azure`
 16. `gpt-4-azure`
+17. `ollama/<tag>`
 
 Experiments can also be run on Google Cloud using Google Cloud Build. You can
 do this by passing

--- a/llm_toolkit/models.py
+++ b/llm_toolkit/models.py
@@ -103,6 +103,13 @@ class LLM:
       return AIBinaryModel(name, ai_binary, max_tokens, num_samples,
                            temperature)
 
+    if name == 'ollama' or name == 'ollama/':
+      raise ValueError('Use --model ollama/<tag>')
+    if name.startswith('ollama/'):
+      instance = Ollama(ai_binary, max_tokens, num_samples, temperature, temperature_list)
+      instance.name = name
+      return instance
+
     for subcls in cls.all_llm_subclasses():
       if getattr(subcls, 'name', None) == name:
         return subcls(
@@ -238,7 +245,7 @@ class GPT(LLM):
 
   def get_model(self) -> Any:
     """Returns the underlying model instance."""
-    # Placeholder: No suitable implementation/usage yet.
+    return self.name
 
   def get_chat_client(self, model: Any) -> Any:
     """Returns a new chat session."""
@@ -330,7 +337,7 @@ class GPT(LLM):
 
     completion = self.with_retry_on_error(
         lambda: client.chat.completions.create(messages=self.messages,
-                                               model=self.name,
+                                               model=self.get_model(),
                                                n=self.num_samples,
                                                temperature=self.temperature),
         [openai.OpenAIError])
@@ -354,7 +361,7 @@ class GPT(LLM):
 
     result = self.with_retry_on_error(
         lambda: client.responses.create(
-            model=self.name, input=self.messages, tools=tools),
+            model=self.get_model(), input=self.messages, tools=tools),
         [openai.OpenAIError])
     return result
 
@@ -370,7 +377,7 @@ class GPT(LLM):
 
     completion = self.with_retry_on_error(
         lambda: client.chat.completions.create(messages=prompt.get(),
-                                               model=self.name,
+                                               model=self.get_model(),
                                                n=self.num_samples,
                                                temperature=self.temperature),
         [openai.OpenAIError])
@@ -389,7 +396,7 @@ class GPT(LLM):
 
     completion = self.with_retry_on_error(
         lambda: client.chat.completions.create(messages=prompt.get(),
-                                               model=self.name,
+                                               model=self.get_model(),
                                                n=self.num_samples,
                                                temperature=self.temperature),
         [openai.OpenAIError])
@@ -474,7 +481,7 @@ class ChatGPT(GPT):
     completion = self.with_retry_on_error(
         lambda: client.chat.completions.create(
             messages=self.conversation_history,
-            model=self.name,
+            model=self.get_model(),
             n=self.num_samples,
             temperature=self.temperature), [openai.OpenAIError])
 
@@ -541,6 +548,21 @@ class AzureGPT4o(AzureGPT):
   """Azure's GPTi-4 model."""
 
   name = 'gpt-4o-azure'
+
+
+class Ollama(GPT):
+  """Ollama via OpenAI-compatible endpoint. Use with --model ollama/<tag>."""
+
+  name = 'ollama' # Set at instance level in setup()
+
+  def get_model(self) -> str:
+    """Returns the model tag sent to the Ollama API (the part after `ollama/`)."""
+    return self.name.split('/', 1)[1]
+
+  def _get_client(self):
+    """Returns the Ollama client."""
+    return openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY', 'dummy key'), # dummy key
+                         base_url=os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434/v1')) # ollama default endpoint
 
 
 class Claude(LLM):


### PR DESCRIPTION
This PR adds experimental support for self-hosted models via [Ollama](https://ollama.com)'s OpenAI-compatible API.

Use it with `--model ollama/<tag>`, where `<tag>` is the model tag served by the Ollama instance.
The default endpoint is `http://localhost:11434/v1`, overridable with `OLLAMA_BASE_URL`.

Implemented as a `GPT` subclass that overrides `_get_client()` (same pattern as `AzureGPT`) and `get_model()` to strip the `ollama/` prefix before sending to the API.
`GPT.get_model()` is changed from a no-op placeholder to `return self.name`.

Tested end-to-end with `gemma4:e4b`.