### PR TITLE
ci: add input sanitization for PR comment arguments

### DIFF
--- a/ci/ci_trial_build.py
+++ b/ci/ci_trial_build.py
@@ -18,10 +18,32 @@ the last PR comment containing "/gcbrun" and pass it to request_pr_exp.py."""
 
 import logging
 import os
+import re
 import sys
 
 import github  # type: ignore
 import request_pr_exp
+
+# Allowlist pattern for arguments parsed from PR comments. Only permit
+# characters that are safe to embed in shell commands and Kubernetes YAML
+# templates.  Shell metacharacters (;, &, |, `, $, (, ), {, }, <, >, ", ')
+# are intentionally excluded to prevent command injection.
+_SAFE_ARG_PATTERN = re.compile(r'^[a-zA-Z0-9_\-\./,=:@]+$')
+
+
+def _sanitize_shell_arg(value: str) -> str:
+  """Returns |value| if it consists solely of safe characters.
+
+  Raises ValueError if |value| contains shell metacharacters or other
+  characters that could alter command interpretation when the value is
+  embedded in a shell string or a Kubernetes Job template.
+  """
+  if not _SAFE_ARG_PATTERN.match(value):
+    raise ValueError(
+        f'Argument contains disallowed characters: {value!r}. '
+        'Only alphanumeric characters and the following symbols are permitted: '
+        '- _ . / , = : @')
+  return value
 
 TRIGGER_COMMAND = '/gcbrun'
 TRIAL_BUILD_COMMAND_STR = f'{TRIGGER_COMMAND} exp '
@@ -43,7 +65,13 @@ def get_comments(pull_request_number):
 
 
 def get_latest_gcbrun_command(comments):
-  """Gets the last /gcbrun comment from comments."""
+  """Gets the last /gcbrun comment from comments.
+
+  Each argument parsed from the comment body is validated against an allowlist
+  before being returned. If any argument fails validation the entire command is
+  rejected and None is returned so that the CI job is not triggered with
+  untrusted input.
+  """
   for comment in reversed(comments):
     # This seems to get comments on code too.
     body = comment.body
@@ -53,7 +81,17 @@ def get_latest_gcbrun_command(comments):
       continue
     if len(body) == len(TRIAL_BUILD_COMMAND_STR):
       return None
-    return body[len(TRIAL_BUILD_COMMAND_STR):].strip().split(' ')
+    raw_args = [a for a in body[len(TRIAL_BUILD_COMMAND_STR):].strip().split(' ') if a]
+    sanitized_args = []
+    for arg in raw_args:
+      try:
+        sanitized_args.append(_sanitize_shell_arg(arg))
+      except ValueError:
+        logging.warning(
+            'Rejected /gcbrun command: argument contains disallowed '
+            'characters: %r. Command will not be executed.', arg)
+        return None
+    return sanitized_args if sanitized_args else None
   return None
 
 

--- a/ci/request_pr_exp.py
+++ b/ci/request_pr_exp.py
@@ -26,6 +26,7 @@ You can also pass arbitrary flags to experiments after -- separator:
 import argparse
 import logging
 import os
+import shlex
 import subprocess as sp
 import sys
 import time
@@ -386,8 +387,11 @@ def _fill_template(args: argparse.Namespace) -> str:
   exp_env_vars['GKE_REDIRECT_OUTS'] = f'{args.redirect_outs}'.lower()
   exp_env_vars['GKE_EXP_MAX_ROUND'] = args.max_round
 
-  # Add additional args as a space-separated string
-  exp_env_vars['GKE_EXP_ADDITIONAL_ARGS'] = ' '.join(args.additional_args)
+  # Each additional argument is shell-quoted before being joined so that
+  # special characters within individual arguments are treated as literals
+  # by the bash -c shell that executes the Kubernetes Job command string.
+  exp_env_vars['GKE_EXP_ADDITIONAL_ARGS'] = ' '.join(
+      shlex.quote(arg) for arg in args.additional_args)
 
   with open(args.gke_template, 'r') as file:
     yaml_template = file.read()


### PR DESCRIPTION
Validate and shell-quote arguments extracted from /gcbrun PR comments
before passing them to the GKE experiment pipeline.

In `ci/ci_trial_build.py`, each token from the PR comment body is now
checked against a character allowlist (`[a-zA-Z0-9_\-\.\/,=:@]`). Any
argument that contains characters outside this set causes the entire
command to be rejected and logged as a warning. This prevents unexpected
input from reaching the Kubernetes job template substitution step.

In `ci/request_pr_exp.py`, the `additional_args` list is now joined
using `shlex.quote()` so that special characters within individual
arguments are treated as literals by the `bash -c` interpreter that
runs the Kubernetes Job command string. This acts as a second layer of
defense covering both `ci/k8s/pr-exp.yaml` and `ci/k8s/large-pr-exp.yaml`.

Files changed:
- `ci/ci_trial_build.py`: Added `_SAFE_ARG_PATTERN` allowlist and
  `_sanitize_shell_arg()` validator; updated `get_latest_gcbrun_command()`
  to reject commands containing disallowed characters.
- `ci/request_pr_exp.py`: Added `shlex` import and shell-quoting for
  `additional_args` before template substitution.
